### PR TITLE
タイマー延長時に累計時間の続きから経過表示する

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -119,7 +119,7 @@ function PopoverView() {
 }
 
 export function TimerPage({ sessions }: { sessions: SessionsState }) {
-  const { isRunning, elapsedSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime } = useTimer()
+  const { isRunning, elapsedSeconds, baseSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime } = useTimer()
   const workday = useWorkday(sessions.today)
   const suggestions = useSuggestions(sessions.todaySessions)
   const [activeTimerName, setActiveTimerName] = useState('')
@@ -173,6 +173,7 @@ export function TimerPage({ sessions }: { sessions: SessionsState }) {
           <ActiveTimer
             name={activeTimerName}
             elapsedSeconds={elapsedSeconds}
+            baseSeconds={baseSeconds}
             color={activeColor}
             initialProjectCode={activeTimerProjectCode}
             initialWorkCategory={activeTimerWorkCategory}

--- a/src/renderer/src/components/Popover/ActiveTimer.test.tsx
+++ b/src/renderer/src/components/Popover/ActiveTimer.test.tsx
@@ -95,4 +95,31 @@ describe('ActiveTimer', () => {
     await userEvent.click(screen.getByText('会議'))
     expect(screen.getByLabelText('作業区分')).toHaveValue('会議')
   })
+
+  it('baseSecondsがあると累計込みの分数を表示する（25分 + 2分 = 27分）', () => {
+    render(
+      <ActiveTimer
+        name="テスト"
+        elapsedSeconds={120}
+        baseSeconds={1500}
+        color="#FF9500"
+        onStop={vi.fn()}
+      />
+    )
+    expect(screen.getByText('27分経過')).toBeInTheDocument()
+  })
+
+  it('baseSecondsはジュースの水位に影響しない（elapsed=0なら液面は最下部のまま）', () => {
+    const { container } = render(
+      <ActiveTimer
+        name="テスト"
+        elapsedSeconds={0}
+        baseSeconds={1500}
+        color="#FF9500"
+        onStop={vi.fn()}
+      />
+    )
+    const juiceLevel = container.querySelector('[data-testid="juice-level"]')
+    expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,120 /)
+  })
 })

--- a/src/renderer/src/components/Popover/ActiveTimer.tsx
+++ b/src/renderer/src/components/Popover/ActiveTimer.tsx
@@ -7,6 +7,8 @@ import { resolveJuiceColor } from '../../domain/colors'
 interface Props {
   name: string
   elapsedSeconds: number
+  /** 延長時に引き継ぐ累計秒。表示にのみ加算され、水位アニメーションには影響しない */
+  baseSeconds?: number
   color: string
   initialProjectCode?: string
   initialWorkCategory?: string
@@ -20,7 +22,7 @@ function juiceLevel(seconds: number): number {
   return Math.min((seconds / 900) * 100, 100)
 }
 
-export function ActiveTimer({ name, elapsedSeconds, color, initialProjectCode, initialWorkCategory, projectCodeSuggestions = [], workCategorySuggestions = [], onStop }: Props) {
+export function ActiveTimer({ name, elapsedSeconds, baseSeconds = 0, color, initialProjectCode, initialWorkCategory, projectCodeSuggestions = [], workCategorySuggestions = [], onStop }: Props) {
   const [projectCode, setProjectCode] = useState(initialProjectCode ?? '')
   const [workCategory, setWorkCategory] = useState(initialWorkCategory ?? '')
   const resolvedColor = resolveJuiceColor(color)
@@ -65,7 +67,7 @@ export function ActiveTimer({ name, elapsedSeconds, color, initialProjectCode, i
               </g>
             </svg>
             <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs font-bold leading-[1.2] text-[var(--text-primary)]">
-              {Math.floor(elapsedSeconds / 60)}分経過
+              {Math.floor((baseSeconds + elapsedSeconds) / 60)}分経過
             </span>
           </div>
         </div>

--- a/src/renderer/src/hooks/useTimer.test.ts
+++ b/src/renderer/src/hooks/useTimer.test.ts
@@ -190,4 +190,52 @@ describe('useTimer', () => {
     expect(mockSaveSession).not.toHaveBeenCalled()
     expect(mockUpdateSession).not.toHaveBeenCalled()
   })
+
+  describe('baseSeconds（延長時の累計引き継ぎ）', () => {
+    const existing: Session = {
+      id: 'id-1',
+      taskId: 'task-1',
+      name: '既存作業',
+      projectCode: 'P001',
+      workCategory: '設計',
+      times: [{ startTime: '2026-06-11T09:00:00', endTime: '2026-06-11T09:25:00' }],
+      date: '2026-06-11',
+      color: 'strawberry',
+      totalTime: 25,
+    }
+
+    it('初期状態は0', () => {
+      const { result } = renderHook(() => useTimer())
+      expect(result.current.baseSeconds).toBe(0)
+    })
+
+    it('startMoreで既存セッションのtotalTime×60になる', () => {
+      const { result } = renderHook(() => useTimer())
+      act(() => { result.current.startMore(existing) })
+      expect(result.current.baseSeconds).toBe(1500)
+      // elapsedSeconds（アニメーション用）は0から
+      expect(result.current.elapsedSeconds).toBe(0)
+    })
+
+    it('startでは0のまま', () => {
+      const { result } = renderHook(() => useTimer())
+      act(() => { result.current.start('新規作業') })
+      expect(result.current.baseSeconds).toBe(0)
+    })
+
+    it('startMore後にstopすると0に戻る', async () => {
+      const { result } = renderHook(() => useTimer())
+      act(() => { result.current.startMore(existing) })
+      act(() => { vi.advanceTimersByTime(60000) })
+      await act(async () => { await result.current.stop() })
+      expect(result.current.baseSeconds).toBe(0)
+    })
+
+    it('startMore後にcancelすると0に戻る', () => {
+      const { result } = renderHook(() => useTimer())
+      act(() => { result.current.startMore(existing) })
+      act(() => { result.current.cancel() })
+      expect(result.current.baseSeconds).toBe(0)
+    })
+  })
 })

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -8,6 +8,8 @@ import { sessionRepository } from '../repositories/sessionRepository'
 export interface TimerState {
   isRunning: boolean
   elapsedSeconds: number
+  /** 延長時に引き継ぐ累計秒（表示用オフセット）。新規タイマーでは0 */
+  baseSeconds: number
   activeColor: string
   activeSessionId: string | null
   start: (name: string, color?: string) => void
@@ -20,6 +22,7 @@ export interface TimerState {
 export function useTimer(): TimerState {
   const [isRunning, setIsRunning] = useState(false)
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const [baseSeconds, setBaseSeconds] = useState(0)
   const [activeColor, setActiveColor] = useState<string>(JUICE_COLOR_KEYS[0])
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
 
@@ -41,6 +44,7 @@ export function useTimer(): TimerState {
     activeColorRef.current = c
     isRunningRef.current = true
     setActiveColor(c)
+    setBaseSeconds(0)
     setElapsedSeconds(0)
     setIsRunning(true)
     setActiveSessionId(null)
@@ -61,6 +65,7 @@ export function useTimer(): TimerState {
     activeColorRef.current = existingSession.color
     isRunningRef.current = true
     setActiveColor(existingSession.color)
+    setBaseSeconds(existingSession.totalTime * 60)
     setElapsedSeconds(0)
     setIsRunning(true)
     setActiveSessionId(existingSession.id)
@@ -121,6 +126,7 @@ export function useTimer(): TimerState {
     isRunningRef.current = false
     timerRepository.stopped()
     setIsRunning(false)
+    setBaseSeconds(0)
     setElapsedSeconds(0)
     setActiveSessionId(null)
     return resultSession
@@ -139,6 +145,7 @@ export function useTimer(): TimerState {
     isRunningRef.current = false
     timerRepository.stopped()
     setIsRunning(false)
+    setBaseSeconds(0)
     setElapsedSeconds(0)
     setActiveSessionId(null)
   }, [])
@@ -150,5 +157,5 @@ export function useTimer(): TimerState {
     timerRepository.adjustStartTime(newStartDate.getTime())
   }, [])
 
-  return { isRunning, elapsedSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime }
+  return { isRunning, elapsedSeconds, baseSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime }
 }


### PR DESCRIPTION
## Summary

- 三角ボタンでの追加実行時、「◯分経過」が既存タスクの累計の続きから増えるように
- useTimer に表示用オフセット baseSeconds を追加（elapsedSeconds と分離）
- ジュースの注ぎアニメーションは従来どおり0から

## Test Plan

- [x] npm test 365件 / typecheck パス
- [x] 実機で延長時の継続表示・新規タイマーの0始まり・停止後のリセットを確認

> #13（テーマ刷新）の上に積んだスタックPRです。#13 のマージ後にベースが main になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)