### PR TITLE
feat: ポモドーロタイマー通知を追加

### DIFF
--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -10,6 +10,7 @@ import { broadcastThemeToAll } from '../windows/themeBroadcast'
 import { startIdleCheck } from '../notifications/idle'
 import { recordActivity } from '../notifications/activity'
 import { onTimerStarted, onTimerStopped, onTimerAdjustStartTime, reschedule } from '../notifications/elapsed'
+import * as pomodoro from '../notifications/pomodoro'
 import { sendAttendance } from '../integrations/attendance'
 import { sendSlackTeleworkStart } from '../integrations/slack'
 import { sendWhiteboardTeleworkStart } from '../integrations/whiteboard'
@@ -55,6 +56,11 @@ export function registerIpcHandlers(
     await settingsStore.setElapsedSettings(enabled, minutes)
     reschedule(settingsStore)
   })
+  handle('settings:getPomodoroSettings', () => settingsStore.getPomodoroSettings())
+  handle('settings:setPomodoroSettings', async (_, { enabled }) => {
+    await settingsStore.setPomodoroSettings(enabled)
+    pomodoro.reschedule(settingsStore)
+  })
 
   // settings: userName / integrations
   handle('settings:getUserName', () => settingsStore.getUserName())
@@ -71,9 +77,18 @@ export function registerIpcHandlers(
   })
 
   // timer signals
-  handle('timer:started', () => onTimerStarted(settingsStore))
-  handle('timer:stopped', () => onTimerStopped())
-  handle('timer:adjustStartTime', (_, newStartMs) => onTimerAdjustStartTime(newStartMs, settingsStore))
+  handle('timer:started', () => {
+    onTimerStarted(settingsStore)
+    pomodoro.onTimerStarted(settingsStore)
+  })
+  handle('timer:stopped', () => {
+    onTimerStopped()
+    pomodoro.onTimerStopped()
+  })
+  handle('timer:adjustStartTime', (_, newStartMs) => {
+    onTimerAdjustStartTime(newStartMs, settingsStore)
+    pomodoro.onTimerAdjustStartTime(newStartMs, settingsStore)
+  })
 
   // attendance
   handle('attendance:send', (_, text) => sendAttendance(settingsStore, text))

--- a/src/main/notifications/pomodoro.test.ts
+++ b/src/main/notifications/pomodoro.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SettingsStore } from '../settingsStore'
+
+const { notificationCtor, showMock, isSupportedMock } = vi.hoisted(() => ({
+  notificationCtor: vi.fn(),
+  showMock: vi.fn(),
+  isSupportedMock: vi.fn(() => true),
+}))
+
+vi.mock('electron', () => ({
+  Notification: class {
+    constructor(opts: { title: string; body: string }) {
+      notificationCtor(opts)
+    }
+    on(): void {}
+    show(): void {
+      showMock()
+    }
+    static isSupported(): boolean {
+      return isSupportedMock()
+    }
+  },
+}))
+
+vi.mock('../windows/popover', () => ({
+  showPopoverFromNotification: vi.fn(),
+}))
+
+import { onTimerStarted, onTimerStopped, onTimerAdjustStartTime } from './pomodoro'
+
+const MINUTE = 60 * 1000
+
+/** enabled を後から切り替えられる SettingsStore モック */
+function makeSettingsStore(initialEnabled: boolean): {
+  store: SettingsStore
+  setEnabled: (v: boolean) => void
+} {
+  let enabled = initialEnabled
+  const store = {
+    getPomodoroSettings: vi.fn(async () => ({ enabled })),
+  } as unknown as SettingsStore
+  return { store, setEnabled: (v) => { enabled = v } }
+}
+
+describe('pomodoro notifications', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    isSupportedMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    onTimerStopped() // モジュール内 state をリセット
+    vi.useRealTimers()
+  })
+
+  it('開始から25分で休憩通知が出る', async () => {
+    const { store } = makeSettingsStore(true)
+    onTimerStarted(store)
+
+    await vi.advanceTimersByTimeAsync(25 * MINUTE)
+
+    expect(showMock).toHaveBeenCalledTimes(1)
+    expect(notificationCtor).toHaveBeenCalledWith({
+      title: 'Juice',
+      body: '25分経ちました。5分休憩してください',
+    })
+  })
+
+  it('30分で再開通知、55分で次の休憩通知が出る（サイクル継続）', async () => {
+    const { store } = makeSettingsStore(true)
+    onTimerStarted(store)
+
+    await vi.advanceTimersByTimeAsync(30 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(2)
+    expect(notificationCtor).toHaveBeenLastCalledWith({
+      title: 'Juice',
+      body: '休憩終了です。作業を再開しましょう',
+    })
+
+    await vi.advanceTimersByTimeAsync(25 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(3)
+    expect(notificationCtor).toHaveBeenLastCalledWith({
+      title: 'Juice',
+      body: '25分経ちました。5分休憩してください',
+    })
+  })
+
+  it('停止後は通知が出ない', async () => {
+    const { store } = makeSettingsStore(true)
+    onTimerStarted(store)
+    onTimerStopped()
+
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+
+    expect(showMock).not.toHaveBeenCalled()
+  })
+
+  it('設定OFFのときは通知せず、ONに戻すと次の境界から通知される', async () => {
+    const { store, setEnabled } = makeSettingsStore(false)
+    onTimerStarted(store)
+
+    await vi.advanceTimersByTimeAsync(25 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+
+    setEnabled(true)
+    await vi.advanceTimersByTimeAsync(5 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(1)
+    expect(notificationCtor).toHaveBeenLastCalledWith({
+      title: 'Juice',
+      body: '休憩終了です。作業を再開しましょう',
+    })
+  })
+
+  it('開始時刻を調整すると新しい起点から25分で通知される', async () => {
+    const { store } = makeSettingsStore(true)
+    onTimerStarted(store)
+
+    await vi.advanceTimersByTimeAsync(10 * MINUTE)
+    onTimerAdjustStartTime(Date.now(), store) // 起点を「今」に変更
+
+    await vi.advanceTimersByTimeAsync(24 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('Notification 非対応環境では通知しない', async () => {
+    isSupportedMock.mockReturnValue(false)
+    const { store } = makeSettingsStore(true)
+    onTimerStarted(store)
+
+    await vi.advanceTimersByTimeAsync(25 * MINUTE)
+
+    expect(showMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/notifications/pomodoro.test.ts
+++ b/src/main/notifications/pomodoro.test.ts
@@ -12,7 +12,9 @@ vi.mock('electron', () => ({
     constructor(opts: { title: string; body: string }) {
       notificationCtor(opts)
     }
-    on(): void {}
+    on(): void {
+      // no-op
+    }
     show(): void {
       showMock()
     }
@@ -134,5 +136,25 @@ describe('pomodoro notifications', () => {
     await vi.advanceTimersByTimeAsync(25 * MINUTE)
 
     expect(showMock).not.toHaveBeenCalled()
+  })
+
+  it('設定読み込みに失敗してもサイクルが継続する', async () => {
+    let failOnce = true
+    const store = {
+      getPomodoroSettings: vi.fn(async () => {
+        if (failOnce) {
+          failOnce = false
+          throw new Error('read error')
+        }
+        return { enabled: true }
+      }),
+    } as unknown as SettingsStore
+    onTimerStarted(store)
+
+    await vi.advanceTimersByTimeAsync(25 * MINUTE) // ここで読み込み失敗
+    expect(showMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(5 * MINUTE) // 次の境界では成功
+    expect(showMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/notifications/pomodoro.ts
+++ b/src/main/notifications/pomodoro.ts
@@ -1,0 +1,66 @@
+import { Notification } from 'electron'
+import { showPopoverFromNotification } from '../windows/popover'
+import type { SettingsStore } from '../settingsStore'
+
+// ポモドーロ通知の state はこのモジュールに閉じ込める。
+// サイクル: 作業25分 → 休憩5分 の30分周期（固定）。
+const WORK_MS = 25 * 60 * 1000
+const CYCLE_MS = 30 * 60 * 1000
+
+const BREAK_MESSAGE = '25分経ちました。5分休憩してください'
+const RESUME_MESSAGE = '休憩終了です。作業を再開しましょう'
+
+let cycleStartTime: Date | null = null
+let boundaryTimeout: ReturnType<typeof setTimeout> | null = null
+
+function clearTimer(): void {
+  if (boundaryTimeout) {
+    clearTimeout(boundaryTimeout)
+    boundaryTimeout = null
+  }
+}
+
+/** 次のフェーズ境界（起点から 25分 / 30分 / 55分 / 60分 …）に setTimeout を予約する */
+function scheduleNext(settingsStore: SettingsStore): void {
+  clearTimer()
+  if (!cycleStartTime) return
+
+  const pos = (Date.now() - cycleStartTime.getTime()) % CYCLE_MS
+  const delay = pos < WORK_MS ? WORK_MS - pos : CYCLE_MS - pos
+
+  boundaryTimeout = setTimeout(async () => {
+    const settings = await settingsStore.getPomodoroSettings()
+    if (cycleStartTime && settings.enabled && Notification.isSupported()) {
+      // スリープ等で発火が遅れるケースに備え、フェーズは発火時点の経過時間から判定する
+      const firedPos = (Date.now() - cycleStartTime.getTime()) % CYCLE_MS
+      const notif = new Notification({
+        title: 'Juice',
+        body: firedPos >= WORK_MS ? BREAK_MESSAGE : RESUME_MESSAGE,
+      })
+      notif.on('click', () => showPopoverFromNotification(settingsStore))
+      notif.show()
+    }
+    scheduleNext(settingsStore)
+  }, delay)
+}
+
+export function onTimerStarted(settingsStore: SettingsStore): void {
+  cycleStartTime = new Date()
+  scheduleNext(settingsStore)
+}
+
+export function onTimerStopped(): void {
+  cycleStartTime = null
+  clearTimer()
+}
+
+export function onTimerAdjustStartTime(newStartMs: number, settingsStore: SettingsStore): void {
+  if (!cycleStartTime) return
+  cycleStartTime = new Date(newStartMs)
+  scheduleNext(settingsStore)
+}
+
+/** 設定変更時の再スケジュール（タイマー稼働中のみ反映） */
+export function reschedule(settingsStore: SettingsStore): void {
+  if (cycleStartTime) scheduleNext(settingsStore)
+}

--- a/src/main/notifications/pomodoro.ts
+++ b/src/main/notifications/pomodoro.ts
@@ -29,18 +29,23 @@ function scheduleNext(settingsStore: SettingsStore): void {
   const delay = pos < WORK_MS ? WORK_MS - pos : CYCLE_MS - pos
 
   boundaryTimeout = setTimeout(async () => {
-    const settings = await settingsStore.getPomodoroSettings()
-    if (cycleStartTime && settings.enabled && Notification.isSupported()) {
-      // スリープ等で発火が遅れるケースに備え、フェーズは発火時点の経過時間から判定する
-      const firedPos = (Date.now() - cycleStartTime.getTime()) % CYCLE_MS
-      const notif = new Notification({
-        title: 'Juice',
-        body: firedPos >= WORK_MS ? BREAK_MESSAGE : RESUME_MESSAGE,
-      })
-      notif.on('click', () => showPopoverFromNotification(settingsStore))
-      notif.show()
+    try {
+      const settings = await settingsStore.getPomodoroSettings()
+      if (cycleStartTime && settings.enabled && Notification.isSupported()) {
+        // スリープ等で発火が遅れるケースに備え、フェーズは発火時点の経過時間から判定する
+        const firedPos = (Date.now() - cycleStartTime.getTime()) % CYCLE_MS
+        const notif = new Notification({
+          title: 'Juice',
+          body: firedPos >= WORK_MS ? BREAK_MESSAGE : RESUME_MESSAGE,
+        })
+        notif.on('click', () => showPopoverFromNotification(settingsStore))
+        notif.show()
+      }
+    } catch {
+      // 設定読み込み失敗時は通知をスキップして次サイクルを継続
+    } finally {
+      scheduleNext(settingsStore)
     }
-    scheduleNext(settingsStore)
   }, delay)
 }
 

--- a/src/main/settingsStore.test.ts
+++ b/src/main/settingsStore.test.ts
@@ -93,4 +93,14 @@ describe('SettingsStore', () => {
     const settings = await store.getWhiteboardSettings()
     expect(settings).toEqual({ enabled: true, email: 'test@jsl.co.jp' })
   })
+
+  it('ポモドーロ設定のデフォルトは無効', async () => {
+    const s = await store.getPomodoroSettings()
+    expect(s).toEqual({ enabled: false })
+  })
+
+  it('ポモドーロ設定を保存して取得できる', async () => {
+    await store.setPomodoroSettings(true)
+    expect(await store.getPomodoroSettings()).toEqual({ enabled: true })
+  })
 })

--- a/src/main/settingsStore.test.ts
+++ b/src/main/settingsStore.test.ts
@@ -103,4 +103,10 @@ describe('SettingsStore', () => {
     await store.setPomodoroSettings(true)
     expect(await store.getPomodoroSettings()).toEqual({ enabled: true })
   })
+
+  it('ポモドーロ設定を変更できる', async () => {
+    await store.setPomodoroSettings(true)
+    await store.setPomodoroSettings(false)
+    expect(await store.getPomodoroSettings()).toEqual({ enabled: false })
+  })
 })

--- a/src/main/settingsStore.ts
+++ b/src/main/settingsStore.ts
@@ -7,6 +7,7 @@ interface Settings {
   idleNotificationMinutes: number
   elapsedNotificationEnabled: boolean
   elapsedNotificationMinutes: number
+  pomodoroEnabled: boolean
   userName: string
   setupCompleted: boolean
   whiteboardEnabled: boolean
@@ -21,6 +22,7 @@ const DEFAULT_SETTINGS: Settings = {
   idleNotificationMinutes: 60,
   elapsedNotificationEnabled: false,
   elapsedNotificationMinutes: 30,
+  pomodoroEnabled: false,
   userName: '',
   setupCompleted: false,
   whiteboardEnabled: false,
@@ -126,6 +128,16 @@ export class SettingsStore {
   async setElapsedSettings(enabled: boolean, minutes: number): Promise<void> {
     const s = await this.readAll()
     await this.writeAll({ ...s, elapsedNotificationEnabled: enabled, elapsedNotificationMinutes: minutes })
+  }
+
+  async getPomodoroSettings(): Promise<{ enabled: boolean }> {
+    const s = await this.readAll()
+    return { enabled: s.pomodoroEnabled }
+  }
+
+  async setPomodoroSettings(enabled: boolean): Promise<void> {
+    const s = await this.readAll()
+    await this.writeAll({ ...s, pomodoroEnabled: enabled })
   }
 
   async getUserName(): Promise<string> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,6 +30,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setIdleSettings: (enabled: boolean, minutes: number) => invoke('settings:setIdleSettings', { enabled, minutes }),
   getElapsedSettings: () => invoke('settings:getElapsedSettings', undefined),
   setElapsedSettings: (enabled: boolean, minutes: number) => invoke('settings:setElapsedSettings', { enabled, minutes }),
+  getPomodoroSettings: () => invoke('settings:getPomodoroSettings', undefined),
+  setPomodoroSettings: (enabled: boolean) => invoke('settings:setPomodoroSettings', { enabled }),
 
   getUserName: () => invoke('settings:getUserName', undefined),
   setUserName: (userName: string) => invoke('settings:setUserName', userName),

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -38,9 +38,9 @@ function minuteLabel(m: number): string {
 export function SettingsView() {
   const [activeSection, setActiveSection] = useState<Section>('theme')
   const {
-    activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes,
+    activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
     userName, whiteboardEnabled, whiteboardEmail, slackProjectCode, slackProjectName,
-    setTheme, setIdle, setElapsed, setUserName, setWhiteboard, setSlack,
+    setTheme, setIdle, setElapsed, setPomodoro, setUserName, setWhiteboard, setSlack,
   } = useSettings()
 
   return (
@@ -161,6 +161,27 @@ export function SettingsView() {
                     </div>
                   </>
                 )}
+              </CardContent>
+            </Card>
+
+            <h2 className={heading} style={{ marginTop: '1.5rem' }}>ポモドーロタイマー</h2>
+            <Card>
+              <CardContent className="p-0">
+                <div className="flex items-center justify-between gap-3 p-3.5">
+                  <div>
+                    <Label htmlFor="pomodoro" className="text-[13px] font-medium text-foreground">
+                      ポモドーロタイマー
+                    </Label>
+                    <p className="mt-0.5 text-[11px] text-muted-foreground">
+                      25分ごとに5分の休憩を通知する
+                    </p>
+                  </div>
+                  <Switch
+                    id="pomodoro"
+                    checked={pomodoroEnabled}
+                    onCheckedChange={setPomodoro}
+                  />
+                </div>
               </CardContent>
             </Card>
           </>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -2,7 +2,7 @@
 
 import type { Session } from '../../shared/types'
 import type {
-  AttendanceSendResult, SlackSettings, ToggleSettings, WhiteboardSettings,
+  AttendanceSendResult, PomodoroSettings, SlackSettings, ToggleSettings, WhiteboardSettings,
 } from '../../shared/ipc'
 
 // preload が contextBridge 経由でレンダラーに公開する API。
@@ -22,6 +22,8 @@ interface ElectronAPI {
   setIdleSettings: (enabled: boolean, minutes: number) => Promise<void>
   getElapsedSettings: () => Promise<ToggleSettings>
   setElapsedSettings: (enabled: boolean, minutes: number) => Promise<void>
+  getPomodoroSettings: () => Promise<PomodoroSettings>
+  setPomodoroSettings: (enabled: boolean) => Promise<void>
   getUserName: () => Promise<string>
   setUserName: (userName: string) => Promise<void>
 

--- a/src/renderer/src/hooks/useSettings.ts
+++ b/src/renderer/src/hooks/useSettings.ts
@@ -9,6 +9,7 @@ export interface SettingsState {
   idleMinutes: number
   elapsedEnabled: boolean
   elapsedMinutes: number
+  pomodoroEnabled: boolean
   userName: string
   whiteboardEnabled: boolean
   whiteboardEmail: string
@@ -17,6 +18,7 @@ export interface SettingsState {
   setTheme: (themeId: string) => void
   setIdle: (enabled: boolean, minutes: number) => void
   setElapsed: (enabled: boolean, minutes: number) => void
+  setPomodoro: (enabled: boolean) => void
   setUserName: (userName: string) => void
   setWhiteboard: (enabled: boolean, email: string) => void
   setSlack: (projectCode: string, projectName: string) => void
@@ -29,6 +31,7 @@ export function useSettings(): SettingsState {
   const [idleMinutes, setIdleMinutes] = useState(60)
   const [elapsedEnabled, setElapsedEnabled] = useState(false)
   const [elapsedMinutes, setElapsedMinutes] = useState(30)
+  const [pomodoroEnabled, setPomodoroEnabled] = useState(false)
   const [userName, setUserNameState] = useState('')
   const [whiteboardEnabled, setWhiteboardEnabled] = useState(false)
   const [whiteboardEmail, setWhiteboardEmail] = useState('')
@@ -46,6 +49,9 @@ export function useSettings(): SettingsState {
       setElapsedEnabled(enabled)
       setElapsedMinutes(minutes)
     })
+    settingsRepository.getPomodoro().then(({ enabled }) => {
+      setPomodoroEnabled(enabled)
+    })
     settingsRepository.getUserName().then(setUserNameState)
     settingsRepository.getWhiteboard().then(({ enabled, email }) => {
       setWhiteboardEnabled(enabled)
@@ -58,7 +64,7 @@ export function useSettings(): SettingsState {
   }, [])
 
   return {
-    activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes,
+    activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
     userName, whiteboardEnabled, whiteboardEmail, slackProjectCode, slackProjectName,
 
     setTheme: (themeId): void => {
@@ -76,6 +82,10 @@ export function useSettings(): SettingsState {
       setElapsedEnabled(enabled)
       setElapsedMinutes(minutes)
       settingsRepository.setElapsed(enabled, minutes)
+    },
+    setPomodoro: (enabled): void => {
+      setPomodoroEnabled(enabled)
+      settingsRepository.setPomodoro(enabled)
     },
     setUserName: (value): void => {
       setUserNameState(value)

--- a/src/renderer/src/repositories/settingsRepository.ts
+++ b/src/renderer/src/repositories/settingsRepository.ts
@@ -25,6 +25,13 @@ export const settingsRepository = {
     return window.electronAPI.setElapsedSettings(enabled, minutes)
   },
 
+  getPomodoro(): Promise<{ enabled: boolean }> {
+    return window.electronAPI.getPomodoroSettings()
+  },
+  setPomodoro(enabled: boolean): Promise<void> {
+    return window.electronAPI.setPomodoroSettings(enabled)
+  },
+
   getUserName(): Promise<string> {
     return window.electronAPI.getUserName()
   },

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -24,6 +24,10 @@ export interface SlackSettings {
   projectName: string
 }
 
+export interface PomodoroSettings {
+  enabled: boolean
+}
+
 /**
  * IPC リクエスト/レスポンスのマップ。
  * key = チャンネル名、value = [引数, 戻り値] のタプル。
@@ -44,6 +48,8 @@ export interface IpcContract {
   'settings:setIdleSettings': [ToggleSettings, void]
   'settings:getElapsedSettings': [void, ToggleSettings]
   'settings:setElapsedSettings': [ToggleSettings, void]
+  'settings:getPomodoroSettings': [void, PomodoroSettings]
+  'settings:setPomodoroSettings': [PomodoroSettings, void]
   'settings:getUserName': [void, string]
   'settings:setUserName': [userName: string, void]
 


### PR DESCRIPTION
## Summary
- タイマー稼働中、25分で「5分休憩してください」、30分で「休憩終了」を通知（以降30分周期で繰り返し）
- 設定画面の通知タブに ON/OFF トグルを追加（デフォルト OFF、25分/5分は固定）
- 既存の経過時間通知とは独立した別系統（`src/main/notifications/pomodoro.ts`）。延長時は再開時点から0分カウント

## Test Plan
- [x] `npm run typecheck` / `npm test`（375件）/ `npm run lint` すべて PASS
- [x] 実機で設定 ON → タイマー開始 → 通知文言とクリック時のポップオーバー表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)