### PR TITLE
feat: ジュース満杯時間をデフォルト25分・経過通知間隔に連動

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -119,7 +119,7 @@ function PopoverView() {
 }
 
 export function TimerPage({ sessions }: { sessions: SessionsState }) {
-  const { isRunning, elapsedSeconds, baseSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime } = useTimer()
+  const { isRunning, elapsedSeconds, baseSeconds, fillSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime } = useTimer()
   const workday = useWorkday(sessions.today)
   const suggestions = useSuggestions(sessions.todaySessions)
   const [activeTimerName, setActiveTimerName] = useState('')
@@ -174,6 +174,7 @@ export function TimerPage({ sessions }: { sessions: SessionsState }) {
             name={activeTimerName}
             elapsedSeconds={elapsedSeconds}
             baseSeconds={baseSeconds}
+            fillSeconds={fillSeconds}
             color={activeColor}
             initialProjectCode={activeTimerProjectCode}
             initialWorkCategory={activeTimerWorkCategory}

--- a/src/renderer/src/components/Popover/ActiveTimer.test.tsx
+++ b/src/renderer/src/components/Popover/ActiveTimer.test.tsx
@@ -138,4 +138,20 @@ describe('ActiveTimer', () => {
     const juiceLevel = container.querySelector('[data-testid="juice-level"]')
     expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,60 /)
   })
+
+  it('fillSeconds=0でもNaNにならず液面は最下部になる', () => {
+    const { container } = render(
+      <ActiveTimer name="テスト" elapsedSeconds={60} fillSeconds={0} color="#FF9500" onStop={vi.fn()} />
+    )
+    const juiceLevel = container.querySelector('[data-testid="juice-level"]')
+    expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,120 /)
+  })
+
+  it('elapsedSecondsがfillSecondsを超えても液面は最上部のまま', () => {
+    const { container } = render(
+      <ActiveTimer name="テスト" elapsedSeconds={3000} color="#FF9500" onStop={vi.fn()} />
+    )
+    const juiceLevel = container.querySelector('[data-testid="juice-level"]')
+    expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,0 /)
+  })
 })

--- a/src/renderer/src/components/Popover/ActiveTimer.test.tsx
+++ b/src/renderer/src/components/Popover/ActiveTimer.test.tsx
@@ -41,9 +41,9 @@ describe('ActiveTimer', () => {
     expect(screen.getByRole('textbox', { name: '作業区分' })).toHaveValue('設計')
   })
 
-  it('elapsedSecondsが900の時、液面が最上部（surfaceY: 0）になる', () => {
+  it('elapsedSecondsが1500（デフォルト満杯秒数）の時、液面が最上部（surfaceY: 0）になる', () => {
     const { container } = render(
-      <ActiveTimer name="テスト" elapsedSeconds={900} color="#FF9500" onStop={vi.fn()} />
+      <ActiveTimer name="テスト" elapsedSeconds={1500} color="#FF9500" onStop={vi.fn()} />
     )
     const juiceLevel = container.querySelector('[data-testid="juice-level"]')
     expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,0 /)
@@ -121,5 +121,21 @@ describe('ActiveTimer', () => {
     )
     const juiceLevel = container.querySelector('[data-testid="juice-level"]')
     expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,120 /)
+  })
+
+  it('fillSeconds=1800のとき、elapsedSeconds=1800で液面が最上部になる', () => {
+    const { container } = render(
+      <ActiveTimer name="テスト" elapsedSeconds={1800} fillSeconds={1800} color="#FF9500" onStop={vi.fn()} />
+    )
+    const juiceLevel = container.querySelector('[data-testid="juice-level"]')
+    expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,0 /)
+  })
+
+  it('fillSeconds=1800のとき、elapsedSeconds=900で液面が50%（surfaceY: 60）になる', () => {
+    const { container } = render(
+      <ActiveTimer name="テスト" elapsedSeconds={900} fillSeconds={1800} color="#FF9500" onStop={vi.fn()} />
+    )
+    const juiceLevel = container.querySelector('[data-testid="juice-level"]')
+    expect(juiceLevel?.getAttribute('d')).toMatch(/^M-120,60 /)
   })
 })

--- a/src/renderer/src/components/Popover/ActiveTimer.tsx
+++ b/src/renderer/src/components/Popover/ActiveTimer.tsx
@@ -9,6 +9,8 @@ interface Props {
   elapsedSeconds: number
   /** 延長時に引き継ぐ累計秒。表示にのみ加算され、水位アニメーションには影響しない */
   baseSeconds?: number
+  /** 水位が満杯になるまでの秒数。経過時間通知の間隔、未設定なら25分 */
+  fillSeconds?: number
   color: string
   initialProjectCode?: string
   initialWorkCategory?: string
@@ -17,16 +19,18 @@ interface Props {
   onStop: (projectCode: string, workCategory: string) => void
 }
 
-// 15分で満杯（最大100%）
-function juiceLevel(seconds: number): number {
-  return Math.min((seconds / 900) * 100, 100)
+// fillSeconds で満杯（最大100%）。デフォルトは25分
+const DEFAULT_FILL_SECONDS = 1500
+
+function juiceLevel(seconds: number, fillSeconds: number): number {
+  return Math.min((seconds / fillSeconds) * 100, 100)
 }
 
-export function ActiveTimer({ name, elapsedSeconds, baseSeconds = 0, color, initialProjectCode, initialWorkCategory, projectCodeSuggestions = [], workCategorySuggestions = [], onStop }: Props) {
+export function ActiveTimer({ name, elapsedSeconds, baseSeconds = 0, fillSeconds = DEFAULT_FILL_SECONDS, color, initialProjectCode, initialWorkCategory, projectCodeSuggestions = [], workCategorySuggestions = [], onStop }: Props) {
   const [projectCode, setProjectCode] = useState(initialProjectCode ?? '')
   const [workCategory, setWorkCategory] = useState(initialWorkCategory ?? '')
   const resolvedColor = resolveJuiceColor(color)
-  const level = juiceLevel(elapsedSeconds)
+  const level = juiceLevel(elapsedSeconds, fillSeconds)
   // 液面の y 座標（0=満杯/上端、120=空/下端）。
   // 山の高さを不均一にした 1 周期(=120px, 30px幅の山4つ)を 3 つ並べて x=-120..240 を埋め、
   // 下端(120)まで閉じて塗りつぶす。横スクロール(-120px)で 1 周期ぶんシームレスにループ。

--- a/src/renderer/src/components/Popover/ActiveTimer.tsx
+++ b/src/renderer/src/components/Popover/ActiveTimer.tsx
@@ -9,7 +9,7 @@ interface Props {
   elapsedSeconds: number
   /** 延長時に引き継ぐ累計秒。表示にのみ加算され、水位アニメーションには影響しない */
   baseSeconds?: number
-  /** 水位が満杯になるまでの秒数。経過時間通知の間隔、未設定なら25分 */
+  /** 水位が100%になるまでの秒数。デフォルトは25分（1500秒） */
   fillSeconds?: number
   color: string
   initialProjectCode?: string
@@ -23,6 +23,7 @@ interface Props {
 const DEFAULT_FILL_SECONDS = 1500
 
 function juiceLevel(seconds: number, fillSeconds: number): number {
+  if (fillSeconds <= 0) return 0
   return Math.min((seconds / fillSeconds) * 100, 100)
 }
 

--- a/src/renderer/src/hooks/useTimer.test.ts
+++ b/src/renderer/src/hooks/useTimer.test.ts
@@ -5,6 +5,7 @@ import type { Session } from '../types/session'
 
 const mockSaveSession = vi.fn().mockResolvedValue(undefined)
 const mockUpdateSession = vi.fn().mockResolvedValue(undefined)
+const mockGetElapsedSettings = vi.fn()
 vi.stubGlobal('electronAPI', {
   saveSession: mockSaveSession,
   updateSession: mockUpdateSession,
@@ -16,6 +17,7 @@ vi.stubGlobal('electronAPI', {
   deleteSession: vi.fn().mockResolvedValue(undefined),
   timerStarted: vi.fn().mockResolvedValue(undefined),
   timerStopped: vi.fn().mockResolvedValue(undefined),
+  getElapsedSettings: mockGetElapsedSettings,
 })
 
 describe('useTimer', () => {
@@ -23,6 +25,7 @@ describe('useTimer', () => {
     vi.useFakeTimers()
     mockSaveSession.mockClear()
     mockUpdateSession.mockClear()
+    mockGetElapsedSettings.mockReset().mockResolvedValue({ enabled: false, minutes: 30 })
   })
 
   afterEach(() => {
@@ -236,6 +239,65 @@ describe('useTimer', () => {
       act(() => { result.current.startMore(existing) })
       act(() => { result.current.cancel() })
       expect(result.current.baseSeconds).toBe(0)
+    })
+  })
+
+  describe('fillSeconds（ジュース満杯秒数）', () => {
+    const existing: Session = {
+      id: 'id-1',
+      taskId: 'task-1',
+      name: '既存作業',
+      projectCode: 'P001',
+      workCategory: '設計',
+      times: [{ startTime: '2026-06-11T09:00:00', endTime: '2026-06-11T09:25:00' }],
+      date: '2026-06-11',
+      color: 'strawberry',
+      totalTime: 25,
+    }
+
+    it('初期値は1500（25分）', () => {
+      const { result } = renderHook(() => useTimer())
+      expect(result.current.fillSeconds).toBe(1500)
+    })
+
+    it('経過時間通知OFFでstartすると1500', async () => {
+      mockGetElapsedSettings.mockResolvedValue({ enabled: false, minutes: 30 })
+      const { result } = renderHook(() => useTimer())
+      await act(async () => { result.current.start('テスト') })
+      expect(result.current.fillSeconds).toBe(1500)
+    })
+
+    it('経過時間通知ON（30分）でstartすると1800', async () => {
+      mockGetElapsedSettings.mockResolvedValue({ enabled: true, minutes: 30 })
+      const { result } = renderHook(() => useTimer())
+      await act(async () => { result.current.start('テスト') })
+      expect(result.current.fillSeconds).toBe(1800)
+    })
+
+    it('経過時間通知ON（60分）でstartMoreすると3600', async () => {
+      mockGetElapsedSettings.mockResolvedValue({ enabled: true, minutes: 60 })
+      const { result } = renderHook(() => useTimer())
+      await act(async () => { result.current.startMore(existing) })
+      expect(result.current.fillSeconds).toBe(3600)
+    })
+
+    it('設定読み込みに失敗してもタイマーは開始され1500になる', async () => {
+      mockGetElapsedSettings.mockRejectedValue(new Error('read error'))
+      const { result } = renderHook(() => useTimer())
+      await act(async () => { result.current.start('テスト') })
+      expect(result.current.isRunning).toBe(true)
+      expect(result.current.fillSeconds).toBe(1500)
+    })
+
+    it('通知ONで開始→OFFに変更→再startで1500に戻る', async () => {
+      mockGetElapsedSettings.mockResolvedValue({ enabled: true, minutes: 30 })
+      const { result } = renderHook(() => useTimer())
+      await act(async () => { result.current.start('テスト') })
+      expect(result.current.fillSeconds).toBe(1800)
+      act(() => { result.current.cancel() })
+      mockGetElapsedSettings.mockResolvedValue({ enabled: false, minutes: 30 })
+      await act(async () => { result.current.start('テスト2') })
+      expect(result.current.fillSeconds).toBe(1500)
     })
   })
 })

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -4,12 +4,27 @@ import { formatLocalDateTime, formatLocalDate } from '../../../shared/sessionUti
 import { JUICE_COLOR_KEYS, randomColor } from '../domain/colors'
 import { timerRepository } from '../repositories/timerRepository'
 import { sessionRepository } from '../repositories/sessionRepository'
+import { settingsRepository } from '../repositories/settingsRepository'
+
+/** ジュースが満杯になるまでの秒数。経過時間通知ONならその間隔、OFFなら25分（ポモドーロの作業時間と同じ） */
+const DEFAULT_FILL_SECONDS = 1500
+
+async function resolveFillSeconds(): Promise<number> {
+  try {
+    const { enabled, minutes } = await settingsRepository.getElapsed()
+    return enabled ? minutes * 60 : DEFAULT_FILL_SECONDS
+  } catch {
+    return DEFAULT_FILL_SECONDS
+  }
+}
 
 export interface TimerState {
   isRunning: boolean
   elapsedSeconds: number
   /** 延長時に引き継ぐ累計秒（表示用オフセット）。新規タイマーでは0 */
   baseSeconds: number
+  /** ジュース水位が満杯になるまでの秒数（タイマー開始時の設定で決まる） */
+  fillSeconds: number
   activeColor: string
   activeSessionId: string | null
   start: (name: string, color?: string) => void
@@ -23,6 +38,7 @@ export function useTimer(): TimerState {
   const [isRunning, setIsRunning] = useState(false)
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const [baseSeconds, setBaseSeconds] = useState(0)
+  const [fillSeconds, setFillSeconds] = useState(DEFAULT_FILL_SECONDS)
   const [activeColor, setActiveColor] = useState<string>(JUICE_COLOR_KEYS[0])
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
 
@@ -48,6 +64,8 @@ export function useTimer(): TimerState {
     setElapsedSeconds(0)
     setIsRunning(true)
     setActiveSessionId(null)
+    setFillSeconds(DEFAULT_FILL_SECONDS)
+    resolveFillSeconds().then(setFillSeconds)
     timerRepository.started()
     intervalRef.current = setInterval(() => {
       if (startTimeRef.current) {
@@ -69,6 +87,8 @@ export function useTimer(): TimerState {
     setElapsedSeconds(0)
     setIsRunning(true)
     setActiveSessionId(existingSession.id)
+    setFillSeconds(DEFAULT_FILL_SECONDS)
+    resolveFillSeconds().then(setFillSeconds)
     timerRepository.started()
     intervalRef.current = setInterval(() => {
       if (startTimeRef.current) {
@@ -157,5 +177,5 @@ export function useTimer(): TimerState {
     timerRepository.adjustStartTime(newStartDate.getTime())
   }, [])
 
-  return { isRunning, elapsedSeconds, baseSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime }
+  return { isRunning, elapsedSeconds, baseSeconds, fillSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime }
 }


### PR DESCRIPTION
## Summary
- ジュース水位の満杯時間を15分固定から**デフォルト25分**に変更（ポモドーロの作業時間と一致）
- **経過時間通知が ON の場合はその通知間隔で満杯**（満杯と同時に通知が届く）
- 満杯秒数はタイマー開始（start / 延長）時点の設定で決定。読み込み失敗時は25分にフォールバック

## Test Plan
- [x] `npm run typecheck` / `npm test`（385件）/ `npm run lint` すべて PASS
- [ ] 実機でタイマー開始 → 水位ペースの確認（経過通知 ON/OFF それぞれ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)