### PR TITLE
feat: 通知間隔の選択肢を5分からに変更

### DIFF
--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -26,7 +26,7 @@ const NAV_ITEMS: { id: Section; label: string }[] = [
 
 const heading = 'mb-2 mt-0 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground'
 
-const MINUTE_OPTIONS = [1, 5, 15, 30, 60, 90, 120] as const
+const MINUTE_OPTIONS = [5, 15, 30, 60, 90, 120] as const
 
 function minuteLabel(m: number): string {
   if (m === 60) return '1時間'


### PR DESCRIPTION
## Summary
- アイドル通知・経過時間通知のドロップダウンから「1分」を削除（最短5分に）

## Test Plan
- [x] `npm run typecheck` / `npm test`（375件）/ `npm run lint` すべて PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)