### PR TITLE
勤怠・ホワイトボードのプロキシ化と秘密全廃（Phase 3）

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -37,6 +37,10 @@ openssl rand -hex 32   # session_secret に使う値を生成
 #   session_secret: 上で生成した値
 #   slack_bot_token / slack_channel_id: 既存 .env の
 #     MAIN_VITE_SLACK_BOT_TOKEN / MAIN_VITE_SLACK_CHANNEL_ID の値を移設
+#   attendance_api_url / attendance_api_key: 既存 .env の
+#     MAIN_VITE_ATTENDANCE_API_URL / MAIN_VITE_ATTENDANCE_API_KEY の値を移設
+#   whiteboard_api_url / whiteboard_api_key: 既存 .env の
+#     MAIN_VITE_WHITEBOARD_API_URL / MAIN_VITE_WHITEBOARD_API_KEY の値を移設
 
 terraform init
 terraform apply        # 実行計画を確認して yes
@@ -101,3 +105,6 @@ open dist-release/mac-arm64/Juice.app
 - **キーローテーション**: `terraform.tfvars` を変更して `terraform apply`
 - **全セッション失効**: `session_secret` を変更して `terraform apply`
 - **全リソース削除**: `terraform destroy`
+- **勤怠の登録名が一致しない人への対応**: 本人の Slack user ID（U 始まり）と
+  勤怠システムの登録名を `attendance_user_overrides` に追加して
+  `terraform apply`

--- a/lambda/src/attendanceSend.test.ts
+++ b/lambda/src/attendanceSend.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { parseAttendanceRequest, resolveUserName, postAttendance } from './attendanceSend'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('parseAttendanceRequest', () => {
+  it('正しいボディをパースする', () => {
+    expect(parseAttendanceRequest(JSON.stringify({ text: '勤怠\n8:30 17:30 60' })))
+      .toEqual({ text: '勤怠\n8:30 17:30 60' })
+  })
+
+  it('text 欠落・空・型不正・2000字超・非JSONは null', () => {
+    expect(parseAttendanceRequest(JSON.stringify({}))).toBeNull()
+    expect(parseAttendanceRequest(JSON.stringify({ text: '  ' }))).toBeNull()
+    expect(parseAttendanceRequest(JSON.stringify({ text: 1 }))).toBeNull()
+    expect(parseAttendanceRequest(JSON.stringify({ text: 'あ'.repeat(2001) }))).toBeNull()
+    expect(parseAttendanceRequest('not json')).toBeNull()
+  })
+})
+
+describe('resolveUserName', () => {
+  const claims = { sub: 'U123', name: 'Ryota Kanayama' }
+
+  it('対応表に sub があれば優先する', () => {
+    expect(resolveUserName(claims, '{"U123":"kanayama"}')).toBe('kanayama')
+  })
+
+  it('対応表に無ければ JWT の name を使う', () => {
+    expect(resolveUserName(claims, '{}')).toBe('Ryota Kanayama')
+    expect(resolveUserName(claims, '{"U999":"other"}')).toBe('Ryota Kanayama')
+  })
+
+  it('対応表が不正な JSON でも name にフォールバックする', () => {
+    expect(resolveUserName(claims, 'broken')).toBe('Ryota Kanayama')
+  })
+})
+
+describe('postAttendance', () => {
+  const OPTS = { apiUrl: 'https://kintai.test/api/receive_slack_post', apiKey: 'KEY1' }
+
+  it('勤怠 API に form POST し status と body を透過する', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ status: 200, text: () => Promise.resolve('{}') })
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await postAttendance('kanayama', '勤怠テキスト', OPTS)
+    expect(result).toEqual({ status: 200, body: '{}' })
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://kintai.test/api/receive_slack_post?key=KEY1')
+    const params = new URLSearchParams(String(init.body))
+    expect(params.get('user_name')).toBe('kanayama')
+    expect(params.get('text')).toBe('勤怠テキスト')
+  })
+
+  it('上流の 400 もそのまま透過する', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 400, text: () => Promise.resolve('{"error_message":"format"}'),
+    }))
+    expect(await postAttendance('a', 't', OPTS))
+      .toEqual({ status: 400, body: '{"error_message":"format"}' })
+  })
+
+  it('ネットワークエラーは throw せず error を返す', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')))
+    expect(await postAttendance('a', 't', OPTS)).toEqual({ error: 'network: ECONNRESET' })
+  })
+})

--- a/lambda/src/attendanceSend.ts
+++ b/lambda/src/attendanceSend.ts
@@ -1,0 +1,55 @@
+import type { SessionClaims } from './sessionJwt'
+
+const MAX_TEXT_LENGTH = 2000
+
+/** リクエストボディから text を取り出す。不正は null */
+export function parseAttendanceRequest(body: string): { text: string } | null {
+  let data: unknown
+  try {
+    data = JSON.parse(body)
+  } catch {
+    return null
+  }
+  if (typeof data !== 'object' || data === null) return null
+  const { text } = data as Record<string, unknown>
+  if (typeof text !== 'string' || text.trim() === '' || text.length > MAX_TEXT_LENGTH) {
+    return null
+  }
+  return { text }
+}
+
+/**
+ * 勤怠の user_name を決める。対応表（sub → 勤怠登録名）が優先、
+ * 無ければ JWT の氏名をそのまま使う（Phase 2/3 設計メモの決定）。
+ */
+export function resolveUserName(
+  claims: Pick<SessionClaims, 'sub' | 'name'>,
+  overridesJson: string
+): string {
+  let overrides: Record<string, unknown> = {}
+  try {
+    overrides = JSON.parse(overridesJson)
+  } catch {
+    // 不正な JSON は対応表なしとして扱う
+  }
+  const override = overrides[claims.sub]
+  return typeof override === 'string' ? override : claims.name
+}
+
+/** 勤怠 API に送信し、status と body をそのまま返す。ネットワークエラーは {error} */
+export async function postAttendance(
+  userName: string,
+  text: string,
+  opts: { apiUrl: string; apiKey: string }
+): Promise<{ status: number; body: string } | { error: string }> {
+  try {
+    const res = await fetch(`${opts.apiUrl}?key=${opts.apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ user_name: userName, text }),
+    })
+    return { status: res.status, body: await res.text() }
+  } catch (e) {
+    return { error: `network: ${e instanceof Error ? e.message : 'unknown'}` }
+  }
+}

--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -4,6 +4,8 @@ import { handler } from './handler'
 import { issueSessionJwt } from './sessionJwt'
 import * as slackOidc from './slackOidc'
 import * as slackPost from './slackPost'
+import * as attendanceSend from './attendanceSend'
+import * as whiteboardPost from './whiteboardPost'
 
 vi.mock('./slackOidc', async (importOriginal) => {
   const mod = await importOriginal<typeof import('./slackOidc')>()
@@ -13,6 +15,16 @@ vi.mock('./slackOidc', async (importOriginal) => {
 vi.mock('./slackPost', async (importOriginal) => {
   const mod = await importOriginal<typeof import('./slackPost')>()
   return { ...mod, postToSlack: vi.fn() }
+})
+
+vi.mock('./attendanceSend', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./attendanceSend')>()
+  return { ...mod, postAttendance: vi.fn() }
+})
+
+vi.mock('./whiteboardPost', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./whiteboardPost')>()
+  return { ...mod, postWhiteboard: vi.fn() }
 })
 
 const STATE = 'a'.repeat(32)
@@ -42,8 +54,15 @@ beforeEach(() => {
   process.env.SESSION_SECRET = 'test-secret'
   process.env.SLACK_BOT_TOKEN = 'xoxb-test'
   process.env.SLACK_CHANNEL_ID = 'C123'
+  process.env.ATTENDANCE_API_URL = 'https://kintai.test/api'
+  process.env.ATTENDANCE_API_KEY = 'AKEY'
+  process.env.WHITEBOARD_API_URL = 'https://wb.test'
+  process.env.WHITEBOARD_API_KEY = 'WKEY'
+  process.env.ATTENDANCE_USER_OVERRIDES = '{"U_OVR":"override-name"}'
   vi.mocked(slackOidc.fetchSlackIdentity).mockReset()
   vi.mocked(slackPost.postToSlack).mockReset()
+  vi.mocked(attendanceSend.postAttendance).mockReset()
+  vi.mocked(whiteboardPost.postWhiteboard).mockReset()
 })
 
 describe('GET /auth/start', () => {
@@ -150,6 +169,96 @@ describe('POST /api/slack.post', () => {
     vi.mocked(slackPost.postToSlack).mockResolvedValue({ error: 'channel_not_found' })
     const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T999' }, 'test-secret')
     expect((await handler(makePostEvent(BODY, token))).statusCode).toBe(502)
+  })
+})
+
+describe('POST /api/attendance.send', () => {
+  const BODY = JSON.stringify({ text: '勤怠\n8:30 17:30 60' })
+
+  function makeAttEvent(body: string, token?: string) {
+    const headers: Record<string, string> = {}
+    if (token) headers.authorization = `Bearer ${token}`
+    return makeEvent('/api/attendance.send', {}, headers, { method: 'POST', body })
+  }
+
+  it('JWT の name を user_name にして勤怠 API の応答を透過する', async () => {
+    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ status: 200, body: '{}' })
+    const token = issueSessionJwt({ sub: 'U1', name: 'Ryota Kanayama', team: 'T999' }, 'test-secret')
+    const res = await handler(makeAttEvent(BODY, token))
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toBe('{}')
+    expect(attendanceSend.postAttendance).toHaveBeenCalledWith(
+      'Ryota Kanayama', '勤怠\n8:30 17:30 60', { apiUrl: 'https://kintai.test/api', apiKey: 'AKEY' }
+    )
+  })
+
+  it('対応表にある sub は登録名で送る', async () => {
+    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ status: 200, body: '{}' })
+    const token = issueSessionJwt({ sub: 'U_OVR', name: '別名', team: 'T999' }, 'test-secret')
+    await handler(makeAttEvent(BODY, token))
+    expect(vi.mocked(attendanceSend.postAttendance).mock.calls[0][0]).toBe('override-name')
+  })
+
+  it('上流の 400 を透過する', async () => {
+    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ status: 400, body: '{"error_message":"x"}' })
+    const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T999' }, 'test-secret')
+    const res = await handler(makeAttEvent(BODY, token))
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toBe('{"error_message":"x"}')
+  })
+
+  it('JWT 無しは 401、text 不正は 400、ネットワークエラーは 502', async () => {
+    expect((await handler(makeAttEvent(BODY))).statusCode).toBe(401)
+    const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T999' }, 'test-secret')
+    expect((await handler(makeAttEvent(JSON.stringify({ text: '' }), token))).statusCode).toBe(400)
+    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ error: 'network: x' })
+    expect((await handler(makeAttEvent(BODY, token))).statusCode).toBe(502)
+  })
+})
+
+describe('POST /api/whiteboard.*', () => {
+  function makeWbEvent(path: string, token?: string) {
+    const headers: Record<string, string> = {}
+    if (token) headers.authorization = `Bearer ${token}`
+    return makeEvent(path, {}, headers, { method: 'POST', body: '{}' })
+  }
+
+  it('email クレーム付き JWT で postWhiteboard を呼び 200', async () => {
+    vi.mocked(whiteboardPost.postWhiteboard).mockResolvedValue({ ok: true })
+    const token = issueSessionJwt(
+      { sub: 'U1', name: 'a', team: 'T999', email: 'a@jsl.co.jp' }, 'test-secret'
+    )
+    const res = await handler(makeWbEvent('/api/whiteboard.telework', token))
+    expect(res.statusCode).toBe(200)
+    expect(whiteboardPost.postWhiteboard).toHaveBeenCalledWith(
+      'telework', 'a@jsl.co.jp', { apiUrl: 'https://wb.test', apiKey: 'WKEY' }
+    )
+  })
+
+  it('leave も kind が正しく渡る', async () => {
+    vi.mocked(whiteboardPost.postWhiteboard).mockResolvedValue({ ok: true })
+    const token = issueSessionJwt(
+      { sub: 'U1', name: 'a', team: 'T999', email: 'a@jsl.co.jp' }, 'test-secret'
+    )
+    await handler(makeWbEvent('/api/whiteboard.leave', token))
+    expect(vi.mocked(whiteboardPost.postWhiteboard).mock.calls[0][0]).toBe('leave')
+  })
+
+  it('email クレームの無い JWT は 401 reauth_required（API を呼ばない）', async () => {
+    const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T999' }, 'test-secret')
+    const res = await handler(makeWbEvent('/api/whiteboard.telework', token))
+    expect(res.statusCode).toBe(401)
+    expect(JSON.parse(res.body!)).toEqual({ error: 'reauth_required' })
+    expect(whiteboardPost.postWhiteboard).not.toHaveBeenCalled()
+  })
+
+  it('JWT 無しは 401、API 失敗は 502', async () => {
+    expect((await handler(makeWbEvent('/api/whiteboard.telework'))).statusCode).toBe(401)
+    vi.mocked(whiteboardPost.postWhiteboard).mockResolvedValue({ error: 'magnet: 500' })
+    const token = issueSessionJwt(
+      { sub: 'U1', name: 'a', team: 'T999', email: 'a@jsl.co.jp' }, 'test-secret'
+    )
+    expect((await handler(makeWbEvent('/api/whiteboard.telework', token))).statusCode).toBe(502)
   })
 })
 

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -1,6 +1,8 @@
 import { buildAuthorizeUrl, fetchSlackIdentity } from './slackOidc'
 import { issueSessionJwt, verifySessionJwt } from './sessionJwt'
 import { buildTeleworkMessage, parseSlackPostRequest, postToSlack } from './slackPost'
+import { parseAttendanceRequest, postAttendance, resolveUserName } from './attendanceSend'
+import { postWhiteboard } from './whiteboardPost'
 
 interface FunctionUrlEvent {
   rawPath: string
@@ -42,6 +44,12 @@ function bearerClaims(event: FunctionUrlEvent): ReturnType<typeof verifySessionJ
   const auth = event.headers.authorization ?? event.headers.Authorization ?? ''
   const match = auth.match(/^Bearer (.+)$/)
   return match ? verifySessionJwt(match[1], env('SESSION_SECRET')) : null
+}
+
+function rawBody(event: FunctionUrlEvent): string {
+  return event.isBase64Encoded && event.body
+    ? Buffer.from(event.body, 'base64').toString('utf-8')
+    : (event.body ?? '')
 }
 
 // message には固定文言のみ渡す（ユーザー入力をエコーしない）
@@ -99,11 +107,7 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
 
   if (path === '/api/slack.post' && event.requestContext.http.method === 'POST') {
     if (!bearerClaims(event)) return json(401, { error: 'unauthorized' })
-    const rawBody =
-      event.isBase64Encoded && event.body
-        ? Buffer.from(event.body, 'base64').toString('utf-8')
-        : (event.body ?? '')
-    const request = parseSlackPostRequest(rawBody)
+    const request = parseSlackPostRequest(rawBody(event))
     if (!request) return json(400, { error: 'bad request' })
     const result = await postToSlack(buildTeleworkMessage(request), {
       botToken: env('SLACK_BOT_TOKEN'),
@@ -112,6 +116,48 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
     if ('error' in result) {
       console.error('slack.post failed:', result.error)
       return json(502, { error: 'slack api error' })
+    }
+    return json(200, { ok: true })
+  }
+
+  if (path === '/api/attendance.send' && event.requestContext.http.method === 'POST') {
+    const claims = bearerClaims(event)
+    if (!claims) return json(401, { error: 'unauthorized' })
+    const request = parseAttendanceRequest(rawBody(event))
+    if (!request) return json(400, { error: 'bad request' })
+    const userName = resolveUserName(claims, process.env.ATTENDANCE_USER_OVERRIDES ?? '{}')
+    const result = await postAttendance(userName, request.text, {
+      apiUrl: env('ATTENDANCE_API_URL'),
+      apiKey: env('ATTENDANCE_API_KEY'),
+    })
+    if ('error' in result) {
+      console.error('attendance.send failed:', result.error)
+      return json(502, { error: 'attendance api error' })
+    }
+    // 勤怠 API の応答をそのまま返す（アプリの結果表示用）
+    return {
+      statusCode: result.status,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      body: result.body,
+    }
+  }
+
+  if (
+    (path === '/api/whiteboard.telework' || path === '/api/whiteboard.leave') &&
+    event.requestContext.http.method === 'POST'
+  ) {
+    const claims = bearerClaims(event)
+    if (!claims) return json(401, { error: 'unauthorized' })
+    // email クレームは Phase 2 以降のサインインでのみ付与される
+    if (!claims.email) return json(401, { error: 'reauth_required' })
+    const kind = path === '/api/whiteboard.telework' ? 'telework' : 'leave'
+    const result = await postWhiteboard(kind, claims.email, {
+      apiUrl: env('WHITEBOARD_API_URL'),
+      apiKey: env('WHITEBOARD_API_KEY'),
+    })
+    if ('error' in result) {
+      console.error('whiteboard failed:', result.error)
+      return json(502, { error: 'whiteboard api error' })
     }
     return json(200, { ok: true })
   }

--- a/lambda/src/whiteboardPost.test.ts
+++ b/lambda/src/whiteboardPost.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { postWhiteboard } from './whiteboardPost'
+
+afterEach(() => vi.unstubAllGlobals())
+
+const OPTS = { apiUrl: 'https://wb.test', apiKey: 'WBKEY' }
+const EMAIL = 'kanayama@jsl.co.jp'
+
+function mockFetchSequence(responses: Array<{ ok: boolean; status?: number }>): ReturnType<typeof vi.fn> {
+  const fn = vi.fn()
+  for (const r of responses) fn.mockResolvedValueOnce(r)
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+describe('postWhiteboard', () => {
+  it('telework は magnet=2 と出勤=true を順に送る', async () => {
+    const fetchMock = mockFetchSequence([{ ok: true }, { ok: true }])
+    const result = await postWhiteboard('telework', EMAIL, OPTS)
+    expect(result).toEqual({ ok: true })
+    const [magnetUrl, magnetInit] = fetchMock.mock.calls[0]
+    expect(magnetUrl).toBe('https://wb.test/api/magnet?apiKey=WBKEY')
+    expect(JSON.parse(magnetInit.body)).toEqual({ magnet_id: 2, email: EMAIL })
+    const [attUrl, attInit] = fetchMock.mock.calls[1]
+    expect(attUrl).toBe('https://wb.test/api/attendance?apiKey=WBKEY')
+    const params = new URLSearchParams(String(attInit.body))
+    expect(params.get('come_to_the_office')).toBe('true')
+    expect(params.get('email')).toBe(EMAIL)
+  })
+
+  it('leave は magnet=3 と出勤=false を送る', async () => {
+    const fetchMock = mockFetchSequence([{ ok: true }, { ok: true }])
+    await postWhiteboard('leave', EMAIL, OPTS)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).magnet_id).toBe(3)
+    expect(
+      new URLSearchParams(String(fetchMock.mock.calls[1][1].body)).get('come_to_the_office')
+    ).toBe('false')
+  })
+
+  it('magnet 失敗時は attendance を呼ばず error を返す', async () => {
+    const fetchMock = mockFetchSequence([{ ok: false, status: 500 }])
+    const result = await postWhiteboard('telework', EMAIL, OPTS)
+    expect(result).toEqual({ error: 'magnet: 500' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('attendance 失敗は error を返す', async () => {
+    mockFetchSequence([{ ok: true }, { ok: false, status: 502 }])
+    expect(await postWhiteboard('telework', EMAIL, OPTS)).toEqual({ error: 'attendance: 502' })
+  })
+
+  it('ネットワークエラーでも throw しない', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ETIMEDOUT')))
+    expect(await postWhiteboard('telework', EMAIL, OPTS)).toEqual({ error: 'network: ETIMEDOUT' })
+  })
+})

--- a/lambda/src/whiteboardPost.ts
+++ b/lambda/src/whiteboardPost.ts
@@ -1,0 +1,36 @@
+// magnet_id: ホワイトボード上の状態を示す値（旧 src/main/integrations/whiteboard.ts と同じ）
+const MAGNET_TELEWORK = 2
+const MAGNET_LEAVE = 3
+
+export type WhiteboardKind = 'telework' | 'leave'
+
+/**
+ * ホワイトボードの状態を更新する（magnet → attendance の2段呼び出し）。
+ * magnet 失敗時は attendance を呼ばない。失敗は {error}（throw しない）。
+ */
+export async function postWhiteboard(
+  kind: WhiteboardKind,
+  email: string,
+  opts: { apiUrl: string; apiKey: string }
+): Promise<{ ok: true } | { error: string }> {
+  const magnetId = kind === 'telework' ? MAGNET_TELEWORK : MAGNET_LEAVE
+  const comeToOffice = kind === 'telework'
+  try {
+    const magnet = await fetch(`${opts.apiUrl}/api/magnet?apiKey=${opts.apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ magnet_id: magnetId, email }),
+    })
+    if (!magnet.ok) return { error: `magnet: ${magnet.status}` }
+
+    const attendance = await fetch(`${opts.apiUrl}/api/attendance?apiKey=${opts.apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ come_to_the_office: String(comeToOffice), email }),
+    })
+    if (!attendance.ok) return { error: `attendance: ${attendance.status}` }
+    return { ok: true }
+  } catch (e) {
+    return { error: `network: ${e instanceof Error ? e.message : 'unknown'}` }
+  }
+}

--- a/lambda/terraform/main.tf
+++ b/lambda/terraform/main.tf
@@ -57,12 +57,17 @@ resource "aws_lambda_function" "juice_proxy" {
 
   environment {
     variables = {
-      SLACK_CLIENT_ID     = var.slack_client_id
-      SLACK_CLIENT_SECRET = var.slack_client_secret
-      ALLOWED_TEAM_ID     = var.allowed_team_id
-      SESSION_SECRET      = var.session_secret
-      SLACK_BOT_TOKEN     = var.slack_bot_token
-      SLACK_CHANNEL_ID    = var.slack_channel_id
+      SLACK_CLIENT_ID           = var.slack_client_id
+      SLACK_CLIENT_SECRET       = var.slack_client_secret
+      ALLOWED_TEAM_ID           = var.allowed_team_id
+      SESSION_SECRET            = var.session_secret
+      SLACK_BOT_TOKEN           = var.slack_bot_token
+      SLACK_CHANNEL_ID          = var.slack_channel_id
+      ATTENDANCE_API_URL        = var.attendance_api_url
+      ATTENDANCE_API_KEY        = var.attendance_api_key
+      WHITEBOARD_API_URL        = var.whiteboard_api_url
+      WHITEBOARD_API_KEY        = var.whiteboard_api_key
+      ATTENDANCE_USER_OVERRIDES = var.attendance_user_overrides
     }
   }
 }

--- a/lambda/terraform/terraform.tfvars.example
+++ b/lambda/terraform/terraform.tfvars.example
@@ -5,3 +5,10 @@ allowed_team_id     = "TXXXXXXXX"
 session_secret      = "openssl rand -hex 32 の出力をここに"
 slack_bot_token     = "xoxb-..."
 slack_channel_id    = "CXXXXXXXX"
+attendance_api_url  = "https://example.com/api/receive_slack_post"
+attendance_api_key  = "xxxxxxxx"
+whiteboard_api_url  = "https://example.com"
+whiteboard_api_key  = "xxxxxxxx"
+# attendance_user_overrides は省略可（デフォルト "{}"）。
+# 勤怠の登録名が Slack の氏名と違う人が出たときだけ設定する:
+# attendance_user_overrides = "{\"U0XXXXXXX\":\"kanayama\"}"

--- a/lambda/terraform/variables.tf
+++ b/lambda/terraform/variables.tf
@@ -37,3 +37,31 @@ variable "slack_channel_id" {
   description = "テレワーク通知の投稿先チャンネル ID"
   type        = string
 }
+
+variable "attendance_api_url" {
+  description = "勤怠 API の URL（.env から移設）"
+  type        = string
+}
+
+variable "attendance_api_key" {
+  description = "勤怠 API キー（.env から移設）"
+  type        = string
+  sensitive   = true
+}
+
+variable "whiteboard_api_url" {
+  description = "ホワイトボード API の URL（.env から移設）"
+  type        = string
+}
+
+variable "whiteboard_api_key" {
+  description = "ホワイトボード API キー（.env から移設）"
+  type        = string
+  sensitive   = true
+}
+
+variable "attendance_user_overrides" {
+  description = "勤怠 user_name の対応表（Slack user ID → 勤怠登録名の JSON。空で開始しエラーが出た人だけ追加する）"
+  type        = string
+  default     = "{}"
+}

--- a/src/main/auth/promptSignIn.ts
+++ b/src/main/auth/promptSignIn.ts
@@ -1,0 +1,19 @@
+import { Notification } from 'electron'
+
+// サインイン促し通知はアプリ起動ごとに1回だけ
+let prompted = false
+
+/** Slack サインインを促す OS 通知を表示する（起動ごとに1回だけ） */
+export function promptSignIn(): void {
+  if (prompted) return
+  prompted = true
+  new Notification({
+    title: 'Juice',
+    body: '連携機能には Slack サインインが必要です。設定 > アカウントからサインインしてください。',
+  }).show()
+}
+
+/** テスト用: 通知済みフラグをリセット */
+export function _resetForTest(): void {
+  prompted = false
+}

--- a/src/main/env.d.ts
+++ b/src/main/env.d.ts
@@ -1,9 +1,5 @@
 /// <reference types="electron-vite/node" />
 
 interface ImportMetaEnv {
-  readonly MAIN_VITE_ATTENDANCE_API_URL: string
-  readonly MAIN_VITE_ATTENDANCE_API_KEY: string
-  readonly MAIN_VITE_WHITEBOARD_API_URL: string
-  readonly MAIN_VITE_WHITEBOARD_API_KEY: string
   readonly MAIN_VITE_PROXY_URL: string
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,15 @@ import { startIdleCheck } from './notifications/idle'
 import { registerIpcHandlers } from './ipc/registerHandlers'
 import { logger } from './logger'
 
+// dev とパッケージ版でプロファイルを分離する（起動ロック衝突・localStorage 混入の防止）。
+// requestSingleInstanceLock より前に設定する必要がある。
+app.setPath(
+  'userData',
+  app.isPackaged
+    ? join(os.homedir(), 'Library', 'Application Support', 'Juice')
+    : join(os.homedir(), 'Library', 'Application Support', 'juice-timer-dev')
+)
+
 // 複数インスタンスの起動を防ぐ（プロダクション向け）
 if (!app.requestSingleInstanceLock()) {
   app.quit()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -45,7 +45,7 @@ app.whenReady().then(async () => {
   registerIpcHandlers(sessionStore, settingsStore, authStore)
 
   // 初回セットアップ判定
-  const needsSetup = !(await settingsStore.isSetupCompleted()) && !(await settingsStore.getUserName())
+  const needsSetup = !(await settingsStore.isSetupCompleted())
 
   if (needsSetup) {
     // 初回起動: Dockを表示してセットアップウィンドウを開く

--- a/src/main/integrations/attendance.test.ts
+++ b/src/main/integrations/attendance.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { sendAttendance } from './attendance'
+
+const httpPost = vi.fn()
+vi.mock('../http', () => ({
+  httpPost: (...args: unknown[]) => httpPost(...args),
+}))
+
+const sendWhiteboardLeave = vi.fn().mockResolvedValue(undefined)
+vi.mock('./whiteboard', () => ({
+  sendWhiteboardLeave: (...args: unknown[]) => sendWhiteboardLeave(...args),
+}))
+
+const sendSlackTeleworkEnd = vi.fn().mockResolvedValue(undefined)
+vi.mock('./slack', () => ({
+  sendSlackTeleworkEnd: (...args: unknown[]) => sendSlackTeleworkEnd(...args),
+}))
+
+vi.mock('../logger', () => ({ logger: { error: vi.fn() } }))
+
+function makeStores(token: string | null) {
+  return {
+    settingsStore: {} as never,
+    authStore: { getToken: vi.fn().mockResolvedValue(token) } as never,
+  }
+}
+
+beforeEach(() => {
+  vi.stubEnv('MAIN_VITE_PROXY_URL', 'https://proxy.test')
+  httpPost.mockReset()
+  sendWhiteboardLeave.mockClear()
+  sendSlackTeleworkEnd.mockClear()
+})
+
+describe('sendAttendance', () => {
+  it('サインイン済みなら Lambda に text を POST し結果を透過する', async () => {
+    httpPost.mockResolvedValue({ ok: true, status: 200, body: '{}' })
+    const { settingsStore, authStore } = makeStores('jwt.x.y')
+    const result = await sendAttendance(settingsStore, authStore, '勤怠\n8:30 17:30 60')
+    expect(result).toEqual({ ok: true, status: 200, body: '{}' })
+    const [url, body, headers] = httpPost.mock.calls[0]
+    expect(url).toBe('https://proxy.test/api/attendance.send')
+    expect(JSON.parse(body)).toEqual({ text: '勤怠\n8:30 17:30 60' })
+    expect(headers.Authorization).toBe('Bearer jwt.x.y')
+  })
+
+  it('成功時はホワイトボード退勤と Slack 終了通知を発火する', async () => {
+    httpPost.mockResolvedValue({ ok: true, status: 200, body: '{}' })
+    const { settingsStore, authStore } = makeStores('jwt.x.y')
+    await sendAttendance(settingsStore, authStore, 'text')
+    expect(sendWhiteboardLeave).toHaveBeenCalledWith(settingsStore, authStore)
+    expect(sendSlackTeleworkEnd).toHaveBeenCalledWith(settingsStore, authStore)
+  })
+
+  it('失敗時は後続連携を発火しない', async () => {
+    httpPost.mockResolvedValue({ ok: false, status: 400, body: '{"error_message":"x"}' })
+    const { settingsStore, authStore } = makeStores('jwt.x.y')
+    const result = await sendAttendance(settingsStore, authStore, 'text')
+    expect(result.ok).toBe(false)
+    expect(sendWhiteboardLeave).not.toHaveBeenCalled()
+    expect(sendSlackTeleworkEnd).not.toHaveBeenCalled()
+  })
+
+  it('未サインインなら POST せず結果メッセージを返す', async () => {
+    const { settingsStore, authStore } = makeStores(null)
+    const result = await sendAttendance(settingsStore, authStore, 'text')
+    expect(result.ok).toBe(false)
+    expect(result.body).toContain('サインイン')
+    expect(httpPost).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/integrations/attendance.ts
+++ b/src/main/integrations/attendance.ts
@@ -7,25 +7,25 @@ import { sendWhiteboardLeave } from './whiteboard'
 import { sendSlackTeleworkEnd } from './slack'
 
 /**
- * 勤怠 API にテキストを送信する。成功時はホワイトボード退勤 + Slack 終了通知も発火（非同期）。
+ * Lambda 経由で勤怠を送信する。user_name は Lambda が JWT から解決する。
+ * 成功時はホワイトボード退勤 + Slack 終了通知も発火（非同期）。
  */
 export async function sendAttendance(
   settingsStore: SettingsStore,
   authStore: AuthStore,
   text: string
 ): Promise<AttendanceSendResult> {
-  const userName = await settingsStore.getUserName()
-  if (!userName) {
-    return { ok: false, status: 0, body: 'user_name が設定されていません' }
+  const token = await authStore.getToken()
+  if (!token) {
+    return { ok: false, status: 0, body: 'Slack サインインが必要です（設定 > アカウント）' }
   }
-  const formBody = `user_name=${encodeURIComponent(userName)}&text=${encodeURIComponent(text)}`
   const result = await httpPost(
-    `${import.meta.env.MAIN_VITE_ATTENDANCE_API_URL}?key=${import.meta.env.MAIN_VITE_ATTENDANCE_API_KEY}`,
-    formBody,
-    { 'Content-Type': 'application/x-www-form-urlencoded' }
+    `${import.meta.env.MAIN_VITE_PROXY_URL}/api/attendance.send`,
+    JSON.stringify({ text }),
+    { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
   )
   if (result.ok) {
-    sendWhiteboardLeave(settingsStore).catch(err => logger.error('Whiteboard leave failed:', err))
+    sendWhiteboardLeave(settingsStore, authStore).catch(err => logger.error('Whiteboard leave failed:', err))
     sendSlackTeleworkEnd(settingsStore, authStore).catch(err => logger.error('Slack telework end failed:', err))
   }
   return result

--- a/src/main/integrations/slack.test.ts
+++ b/src/main/integrations/slack.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { sendSlackTeleworkStart, sendSlackTeleworkEnd, _resetForTest } from './slack'
+import { sendSlackTeleworkStart, sendSlackTeleworkEnd } from './slack'
+import { _resetForTest } from '../auth/promptSignIn'
 
 const showNotification = vi.fn()
 vi.mock('electron', () => ({

--- a/src/main/integrations/slack.ts
+++ b/src/main/integrations/slack.ts
@@ -1,21 +1,9 @@
-import { Notification } from 'electron'
 import { httpPost } from '../http'
 import type { SettingsStore } from '../settingsStore'
 import type { AuthStore } from '../auth/authStore'
+import { promptSignIn } from '../auth/promptSignIn'
 
 type TeleworkKind = 'telework_start' | 'telework_end'
-
-// サインイン促し通知はアプリ起動ごとに1回だけ
-let signInPrompted = false
-
-function promptSignIn(): void {
-  if (signInPrompted) return
-  signInPrompted = true
-  new Notification({
-    title: 'Juice',
-    body: 'Slack 通知には Slack サインインが必要です。設定 > アカウントからサインインしてください。',
-  }).show()
-}
 
 /**
  * Lambda 経由でテレワーク通知を投稿する。
@@ -58,9 +46,4 @@ export function sendSlackTeleworkEnd(
   authStore: AuthStore
 ): Promise<void> {
   return postTelework('telework_end', settingsStore, authStore)
-}
-
-/** テスト用: サインイン促し通知のフラグをリセット */
-export function _resetForTest(): void {
-  signInPrompted = false
 }

--- a/src/main/integrations/whiteboard.test.ts
+++ b/src/main/integrations/whiteboard.test.ts
@@ -7,6 +7,7 @@ const showNotification = vi.fn()
 vi.mock('electron', () => ({
   Notification: class {
     constructor(opts: unknown) { showNotification(opts) }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     show() {}
   },
 }))

--- a/src/main/integrations/whiteboard.test.ts
+++ b/src/main/integrations/whiteboard.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { sendWhiteboardTeleworkStart, sendWhiteboardLeave } from './whiteboard'
+import { _resetForTest } from '../auth/promptSignIn'
+
+const showNotification = vi.fn()
+vi.mock('electron', () => ({
+  Notification: class {
+    constructor(opts: unknown) { showNotification(opts) }
+    show() {}
+  },
+}))
+
+const httpPost = vi.fn()
+vi.mock('../http', () => ({
+  httpPost: (...args: unknown[]) => httpPost(...args),
+}))
+
+function makeStores(token: string | null, enabled = true) {
+  return {
+    settingsStore: {
+      getWhiteboardSettings: vi.fn().mockResolvedValue({ enabled }),
+    } as never,
+    authStore: { getToken: vi.fn().mockResolvedValue(token) } as never,
+  }
+}
+
+beforeEach(() => {
+  vi.stubEnv('MAIN_VITE_PROXY_URL', 'https://proxy.test')
+  httpPost.mockReset()
+  showNotification.mockClear()
+  _resetForTest()
+})
+
+describe('sendWhiteboardTeleworkStart', () => {
+  it('サインイン済みなら /api/whiteboard.telework に POST する', async () => {
+    httpPost.mockResolvedValue({ ok: true, status: 200, body: '{}' })
+    const { settingsStore, authStore } = makeStores('jwt.x.y')
+    await sendWhiteboardTeleworkStart(settingsStore, authStore)
+    const [url, , headers] = httpPost.mock.calls[0]
+    expect(url).toBe('https://proxy.test/api/whiteboard.telework')
+    expect(headers.Authorization).toBe('Bearer jwt.x.y')
+  })
+
+  it('連携が無効なら何もしない', async () => {
+    const { settingsStore, authStore } = makeStores('jwt.x.y', false)
+    await sendWhiteboardTeleworkStart(settingsStore, authStore)
+    expect(httpPost).not.toHaveBeenCalled()
+  })
+
+  it('未サインインなら通知してスキップ', async () => {
+    const { settingsStore, authStore } = makeStores(null)
+    await sendWhiteboardTeleworkStart(settingsStore, authStore)
+    expect(httpPost).not.toHaveBeenCalled()
+    expect(showNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('401（reauth_required 含む）は通知してスキップ、throw しない', async () => {
+    httpPost.mockResolvedValue({ ok: false, status: 401, body: '{"error":"reauth_required"}' })
+    const { settingsStore, authStore } = makeStores('old.jwt.x')
+    await sendWhiteboardTeleworkStart(settingsStore, authStore)
+    expect(showNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('その他の失敗は throw する', async () => {
+    httpPost.mockResolvedValue({ ok: false, status: 502, body: 'whiteboard api error' })
+    const { settingsStore, authStore } = makeStores('jwt.x.y')
+    await expect(sendWhiteboardTeleworkStart(settingsStore, authStore))
+      .rejects.toThrow('Whiteboard proxy error: 502')
+  })
+})
+
+describe('sendWhiteboardLeave', () => {
+  it('/api/whiteboard.leave に POST する', async () => {
+    httpPost.mockResolvedValue({ ok: true, status: 200, body: '{}' })
+    const { settingsStore, authStore } = makeStores('jwt.x.y')
+    await sendWhiteboardLeave(settingsStore, authStore)
+    expect(httpPost.mock.calls[0][0]).toBe('https://proxy.test/api/whiteboard.leave')
+  })
+})

--- a/src/main/integrations/whiteboard.ts
+++ b/src/main/integrations/whiteboard.ts
@@ -1,65 +1,53 @@
 import { httpPost } from '../http'
-import { logger } from '../logger'
+import { promptSignIn } from '../auth/promptSignIn'
 import type { SettingsStore } from '../settingsStore'
+import type { AuthStore } from '../auth/authStore'
 
-// magnet_id: ホワイトボード上の状態を示す値
-const MAGNET_LEAVE = 3
-const MAGNET_TELEWORK = 2
+type WhiteboardKind = 'telework' | 'leave'
 
-/** ホワイトボードを「退勤」状態にし、勤怠 API にも come_to_the_office=false を送る */
-export async function sendWhiteboardLeave(settingsStore: SettingsStore): Promise<void> {
-  const { enabled, email } = await settingsStore.getWhiteboardSettings()
-  if (!enabled || !email) return
-
-  const apiUrl = import.meta.env.MAIN_VITE_WHITEBOARD_API_URL
-  const apiKey = import.meta.env.MAIN_VITE_WHITEBOARD_API_KEY
-  if (!apiUrl || !apiKey) return
-
-  const magnet = await httpPost(
-    `${apiUrl}/api/magnet?apiKey=${apiKey}`,
-    JSON.stringify({ magnet_id: MAGNET_LEAVE, email }),
-    { 'Content-Type': 'application/json' }
-  )
-  if (!magnet.ok) {
-    logger.error('Whiteboard magnet API failed:', magnet.status, magnet.body)
+/**
+ * Lambda 経由でホワイトボードの状態を更新する。email は Lambda が JWT から解決する。
+ * 連携無効なら何もしない。未サインイン・セッション切れは通知してスキップ（throw しない）。
+ */
+async function postWhiteboard(
+  kind: WhiteboardKind,
+  settingsStore: SettingsStore,
+  authStore: AuthStore
+): Promise<void> {
+  const { enabled } = await settingsStore.getWhiteboardSettings()
+  if (!enabled) return
+  const token = await authStore.getToken()
+  if (!token) {
+    promptSignIn()
     return
   }
-
-  const attendance = await httpPost(
-    `${apiUrl}/api/attendance?apiKey=${apiKey}`,
-    `come_to_the_office=false&email=${encodeURIComponent(email)}`,
-    { 'Content-Type': 'application/x-www-form-urlencoded' }
+  const result = await httpPost(
+    `${import.meta.env.MAIN_VITE_PROXY_URL}/api/whiteboard.${kind}`,
+    '{}',
+    { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
   )
-  if (!attendance.ok) {
-    logger.error('Whiteboard attendance API failed:', attendance.status, attendance.body)
+  if (result.status === 401) {
+    // 未認証 or email クレーム無し（reauth_required）。再サインインを促す
+    promptSignIn()
+    return
+  }
+  if (!result.ok) {
+    throw new Error(`Whiteboard proxy error: ${result.status} ${result.body}`)
   }
 }
 
-/** ホワイトボードを「テレワーク」状態にし、勤怠 API にも come_to_the_office=true を送る */
-export async function sendWhiteboardTeleworkStart(settingsStore: SettingsStore): Promise<void> {
-  const { enabled, email } = await settingsStore.getWhiteboardSettings()
-  if (!enabled || !email) return
+/** ホワイトボードを「テレワーク」状態にし、勤怠 API にも出勤を送る */
+export function sendWhiteboardTeleworkStart(
+  settingsStore: SettingsStore,
+  authStore: AuthStore
+): Promise<void> {
+  return postWhiteboard('telework', settingsStore, authStore)
+}
 
-  const apiUrl = import.meta.env.MAIN_VITE_WHITEBOARD_API_URL
-  const apiKey = import.meta.env.MAIN_VITE_WHITEBOARD_API_KEY
-  if (!apiUrl || !apiKey) return
-
-  const magnet = await httpPost(
-    `${apiUrl}/api/magnet?apiKey=${apiKey}`,
-    JSON.stringify({ magnet_id: MAGNET_TELEWORK, email }),
-    { 'Content-Type': 'application/json' }
-  )
-  if (!magnet.ok) {
-    logger.error('Whiteboard telework magnet API failed:', magnet.status, magnet.body)
-    return
-  }
-
-  const attendance = await httpPost(
-    `${apiUrl}/api/attendance?apiKey=${apiKey}`,
-    `come_to_the_office=true&email=${encodeURIComponent(email)}`,
-    { 'Content-Type': 'application/x-www-form-urlencoded' }
-  )
-  if (!attendance.ok) {
-    logger.error('Whiteboard telework attendance API failed:', attendance.status, attendance.body)
-  }
+/** ホワイトボードを「退勤」状態にし、勤怠 API にも退勤を送る */
+export function sendWhiteboardLeave(
+  settingsStore: SettingsStore,
+  authStore: AuthStore
+): Promise<void> {
+  return postWhiteboard('leave', settingsStore, authStore)
 }

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -66,14 +66,10 @@ export function registerIpcHandlers(
     pomodoro.reschedule(settingsStore)
   })
 
-  // settings: userName / integrations
-  handle('settings:getUserName', () => settingsStore.getUserName())
-  handle('settings:setUserName', async (_, userName) => {
-    await settingsStore.setUserName(userName)
-  })
+  // settings: integrations
   handle('settings:getWhiteboardSettings', () => settingsStore.getWhiteboardSettings())
-  handle('settings:setWhiteboardSettings', async (_, { enabled, email }) => {
-    await settingsStore.setWhiteboardSettings(enabled, email)
+  handle('settings:setWhiteboardSettings', async (_, { enabled }) => {
+    await settingsStore.setWhiteboardSettings(enabled)
   })
   handle('settings:getSlackSettings', () => settingsStore.getSlackSettings())
   handle('settings:setSlackSettings', async (_, { projectCode, projectName }) => {

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -93,7 +93,8 @@ export function registerIpcHandlers(
   // attendance
   handle('attendance:send', (_, text) => sendAttendance(settingsStore, authStore, text))
   handle('whiteboard:teleworkStart', async () => {
-    await sendWhiteboardTeleworkStart(settingsStore, authStore)
+    // ホワイトボード失敗時も Slack 通知は実行する（旧実装と同じ挙動）
+    await sendWhiteboardTeleworkStart(settingsStore, authStore).catch(err => logger.error('Whiteboard telework start failed:', err))
     await sendSlackTeleworkStart(settingsStore, authStore).catch(err => logger.error('Slack telework start failed:', err))
   })
 

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -97,7 +97,7 @@ export function registerIpcHandlers(
   // attendance
   handle('attendance:send', (_, text) => sendAttendance(settingsStore, authStore, text))
   handle('whiteboard:teleworkStart', async () => {
-    await sendWhiteboardTeleworkStart(settingsStore)
+    await sendWhiteboardTeleworkStart(settingsStore, authStore)
     await sendSlackTeleworkStart(settingsStore, authStore).catch(err => logger.error('Slack telework start failed:', err))
   })
 

--- a/src/main/settingsStore.test.ts
+++ b/src/main/settingsStore.test.ts
@@ -85,13 +85,13 @@ describe('SettingsStore', () => {
 
   it('ホワイトボード設定のデフォルト値が返る', async () => {
     const settings = await store.getWhiteboardSettings()
-    expect(settings).toEqual({ enabled: false, email: '' })
+    expect(settings).toEqual({ enabled: false })
   })
 
   it('ホワイトボード設定を保存して取得できる', async () => {
-    await store.setWhiteboardSettings(true, 'test@jsl.co.jp')
+    await store.setWhiteboardSettings(true)
     const settings = await store.getWhiteboardSettings()
-    expect(settings).toEqual({ enabled: true, email: 'test@jsl.co.jp' })
+    expect(settings).toEqual({ enabled: true })
   })
 
   it('ポモドーロ設定のデフォルトは無効', async () => {

--- a/src/main/settingsStore.ts
+++ b/src/main/settingsStore.ts
@@ -8,10 +8,8 @@ interface Settings {
   elapsedNotificationEnabled: boolean
   elapsedNotificationMinutes: number
   pomodoroEnabled: boolean
-  userName: string
   setupCompleted: boolean
   whiteboardEnabled: boolean
-  whiteboardEmail: string
   slackProjectCode: string
   slackProjectName: string
 }
@@ -23,10 +21,8 @@ const DEFAULT_SETTINGS: Settings = {
   elapsedNotificationEnabled: false,
   elapsedNotificationMinutes: 30,
   pomodoroEnabled: false,
-  userName: '',
   setupCompleted: false,
   whiteboardEnabled: false,
-  whiteboardEmail: '',
   slackProjectCode: '',
   slackProjectName: '',
 }
@@ -140,16 +136,6 @@ export class SettingsStore {
     await this.writeAll({ ...s, pomodoroEnabled: enabled })
   }
 
-  async getUserName(): Promise<string> {
-    const s = await this.readAll()
-    return s.userName
-  }
-
-  async setUserName(userName: string): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, userName })
-  }
-
   async isSetupCompleted(): Promise<boolean> {
     const s = await this.readAll()
     return s.setupCompleted
@@ -160,17 +146,14 @@ export class SettingsStore {
     await this.writeAll({ ...s, setupCompleted: true })
   }
 
-  async getWhiteboardSettings(): Promise<{ enabled: boolean; email: string }> {
+  async getWhiteboardSettings(): Promise<{ enabled: boolean }> {
     const s = await this.readAll()
-    return {
-      enabled: s.whiteboardEnabled,
-      email: s.whiteboardEmail,
-    }
+    return { enabled: s.whiteboardEnabled }
   }
 
-  async setWhiteboardSettings(enabled: boolean, email: string): Promise<void> {
+  async setWhiteboardSettings(enabled: boolean): Promise<void> {
     const s = await this.readAll()
-    await this.writeAll({ ...s, whiteboardEnabled: enabled, whiteboardEmail: email })
+    await this.writeAll({ ...s, whiteboardEnabled: enabled })
   }
 
   async getSlackSettings(): Promise<{ projectCode: string; projectName: string }> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,7 +23,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   updateSession: (session) => invoke('sessions:update', session),
   deleteSession: (id: string, yearMonth: string) => invoke('sessions:delete', { id, yearMonth }),
 
-  // settings: theme / notifications / userName
+  // settings: theme / notifications
   getTheme: () => invoke('settings:getTheme', undefined),
   setTheme: (themeId: string) => invoke('settings:setTheme', themeId),
   onThemeChanged: (callback: (themeId: string) => void) => on('theme-changed', callback),
@@ -35,12 +35,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getPomodoroSettings: () => invoke('settings:getPomodoroSettings', undefined),
   setPomodoroSettings: (enabled: boolean) => invoke('settings:setPomodoroSettings', { enabled }),
 
-  getUserName: () => invoke('settings:getUserName', undefined),
-  setUserName: (userName: string) => invoke('settings:setUserName', userName),
-
   // settings: integrations
   getWhiteboardSettings: () => invoke('settings:getWhiteboardSettings', undefined),
-  setWhiteboardSettings: (enabled: boolean, email: string) => invoke('settings:setWhiteboardSettings', { enabled, email }),
+  setWhiteboardSettings: (enabled: boolean) => invoke('settings:setWhiteboardSettings', { enabled }),
   getSlackSettings: () => invoke('settings:getSlackSettings', undefined),
   setSlackSettings: (projectCode: string, projectName: string) => invoke('settings:setSlackSettings', { projectCode, projectName }),
 

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -40,8 +40,8 @@ export function SettingsView() {
   const [activeSection, setActiveSection] = useState<Section>('theme')
   const {
     activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
-    userName, whiteboardEnabled, whiteboardEmail, slackProjectCode, slackProjectName,
-    setTheme, setIdle, setElapsed, setPomodoro, setUserName, setWhiteboard, setSlack,
+    whiteboardEnabled, slackProjectCode, slackProjectName,
+    setTheme, setIdle, setElapsed, setPomodoro, setWhiteboard, setSlack,
   } = useSettings()
 
   return (
@@ -193,22 +193,6 @@ export function SettingsView() {
           <>
             <h2 className={heading}>Slack アカウント</h2>
             <AccountSection />
-            <h2 className={heading}>勤怠連携</h2>
-            <Card className="mb-4">
-              <CardContent className="flex flex-col gap-3 p-3.5">
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="username" className="text-[13px] text-foreground">ユーザー名</Label>
-                  <Input
-                    id="username"
-                    type="text"
-                    className="h-8"
-                    value={userName}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => setUserName(e.target.value)}
-                    placeholder="Slack ユーザー名"
-                  />
-                </div>
-              </CardContent>
-            </Card>
 
             <h2 className={heading} style={{ marginTop: '1.5rem' }}>ホワイトボード連携</h2>
             <Card className="mb-4">
@@ -225,29 +209,9 @@ export function SettingsView() {
                   <Switch
                     id="whiteboard"
                     checked={whiteboardEnabled}
-                    onCheckedChange={(c) => setWhiteboard(c, whiteboardEmail)}
+                    onCheckedChange={setWhiteboard}
                   />
                 </div>
-                {whiteboardEnabled && (
-                  <>
-                    <Separator />
-                    <div className="flex flex-col gap-1.5 p-3.5">
-                      <Label htmlFor="whiteboard-email" className="text-[13px] text-foreground">
-                        メールアドレス
-                      </Label>
-                      <Input
-                        id="whiteboard-email"
-                        type="email"
-                        className="h-8"
-                        value={whiteboardEmail}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                          setWhiteboard(whiteboardEnabled, e.target.value)
-                        }
-                        placeholder="example@jsl.co.jp"
-                      />
-                    </div>
-                  </>
-                )}
               </CardContent>
             </Card>
 

--- a/src/renderer/src/components/Setup/SetupView.test.tsx
+++ b/src/renderer/src/components/Setup/SetupView.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SetupView } from './SetupView'
+
+const api = {
+  getTheme: vi.fn().mockResolvedValue('milk'),
+  setTheme: vi.fn().mockResolvedValue(undefined),
+  onThemeChanged: vi.fn(),
+  completeSetup: vi.fn().mockResolvedValue(undefined),
+  getAuthStatus: vi.fn(),
+  signInWithSlack: vi.fn().mockResolvedValue(undefined),
+  signOutSlack: vi.fn().mockResolvedValue(undefined),
+  onAuthChanged: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.getAuthStatus.mockResolvedValue({ signedIn: false })
+  Object.assign(window, { electronAPI: api })
+})
+
+describe('SetupView step2（サインイン）', () => {
+  async function goToStep2() {
+    render(<SetupView />)
+    await userEvent.click(await screen.findByRole('button', { name: 'はじめる' }))
+  }
+
+  it('未サインインならサインインボタンと「あとで設定する」が出る', async () => {
+    await goToStep2()
+    expect(await screen.findByRole('button', { name: 'Slack でサインイン' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'あとで設定する' })).toBeInTheDocument()
+  })
+
+  it('サインインボタンで signInWithSlack を呼ぶ', async () => {
+    await goToStep2()
+    await userEvent.click(await screen.findByRole('button', { name: 'Slack でサインイン' }))
+    expect(api.signInWithSlack).toHaveBeenCalled()
+  })
+
+  it('「あとで設定する」で step3 に進める', async () => {
+    await goToStep2()
+    await userEvent.click(screen.getByRole('button', { name: 'あとで設定する' }))
+    expect(await screen.findByRole('button', { name: '完了' })).toBeInTheDocument()
+  })
+
+  it('サインイン済みなら名前と「次へ」が出る', async () => {
+    api.getAuthStatus.mockResolvedValue({ signedIn: true, name: '金山' })
+    await goToStep2()
+    expect(await screen.findByText(/金山/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '次へ' })).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/Setup/SetupView.tsx
+++ b/src/renderer/src/components/Setup/SetupView.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react'
 import { THEMES, DARK_THEMES } from '../../themes'
 import { useSetup } from '../../hooks/useSetup'
+import { useAuthStatus } from '../../hooks/useAuthStatus'
 import { ThemeGrid } from '../ThemeGrid/ThemeGrid'
 import { Card, CardContent } from '@/components/ui/card'
-import { Label } from '@/components/ui/label'
-import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 
 const TOTAL_STEPS = 3
 
 export function SetupView() {
-  const { activeThemeId, userName, setUserName, setTheme, complete } = useSetup()
+  const { activeThemeId, setTheme, complete } = useSetup()
+  const { status, signIn } = useAuthStatus()
   const [step, setStep] = useState(1)
 
   return (
@@ -29,28 +29,19 @@ export function SetupView() {
         </div>
       )}
 
-      {/* Step 2: ユーザー名入力 */}
+      {/* Step 2: Slack サインイン */}
       {step === 2 && (
         <div className="flex flex-1 flex-col animate-fade-in" key="step2">
-          <div className="mb-5 text-center">
-            <span className="mb-1 block text-[36px]">🧃</span>
-            <h1 className="mb-1 mt-0 text-[18px] font-bold text-[var(--text-primary)]">ユーザー名</h1>
-            <p className="m-0 text-xs text-[var(--text-secondary)]">勤怠連携に使用する Slack ユーザー名を入力してください</p>
-          </div>
-          <div className="mb-4">
-            <Card>
-              <CardContent className="flex flex-col gap-1.5 p-4">
-                <Label htmlFor="setup-name" className="text-[13px] text-foreground">ユーザー名</Label>
-                <Input
-                  id="setup-name"
-                  value={userName}
-                  onChange={(e) => setUserName(e.target.value)}
-                  placeholder="例: kanayama"
-                  autoFocus
-                />
-              </CardContent>
-            </Card>
-          </div>
+          <h2 className="mb-1 text-[15px] font-semibold">Slack でサインイン</h2>
+          <p className="mb-4 text-[12px] text-muted-foreground">
+            サインインすると勤怠・ホワイトボード・Slack 通知の連携が使えます。
+            あとから設定 &gt; アカウントでもサインインできます。
+          </p>
+          {status.signedIn ? (
+            <p className="text-[13px] font-medium">✅ {status.name} としてサインイン済み</p>
+          ) : (
+            <Button onClick={signIn}>Slack でサインイン</Button>
+          )}
         </div>
       )}
 
@@ -96,7 +87,13 @@ export function SetupView() {
             <Button className="flex-1" onClick={() => setStep(2)}>はじめる</Button>
           )}
           {step === 2 && (
-            <Button className="flex-1" onClick={() => setStep(3)} disabled={!userName.trim()}>次へ</Button>
+            <Button
+              className="flex-1"
+              variant={status.signedIn ? 'default' : 'outline'}
+              onClick={() => setStep(3)}
+            >
+              {status.signedIn ? '次へ' : 'あとで設定する'}
+            </Button>
           )}
           {step === 3 && (
             <Button className="flex-1" onClick={complete}>完了</Button>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -14,7 +14,7 @@ interface ElectronAPI {
   updateSession: (session: Session) => Promise<void>
   deleteSession: (id: string, yearMonth: string) => Promise<void>
 
-  // settings: theme / notifications / userName
+  // settings: theme / notifications
   getTheme: () => Promise<string>
   setTheme: (themeId: string) => Promise<void>
   onThemeChanged: (callback: (themeId: string) => void) => void
@@ -24,12 +24,10 @@ interface ElectronAPI {
   setElapsedSettings: (enabled: boolean, minutes: number) => Promise<void>
   getPomodoroSettings: () => Promise<PomodoroSettings>
   setPomodoroSettings: (enabled: boolean) => Promise<void>
-  getUserName: () => Promise<string>
-  setUserName: (userName: string) => Promise<void>
 
   // settings: integrations
   getWhiteboardSettings: () => Promise<WhiteboardSettings>
-  setWhiteboardSettings: (enabled: boolean, email: string) => Promise<void>
+  setWhiteboardSettings: (enabled: boolean) => Promise<void>
   getSlackSettings: () => Promise<SlackSettings>
   setSlackSettings: (projectCode: string, projectName: string) => Promise<void>
 

--- a/src/renderer/src/hooks/useSettings.ts
+++ b/src/renderer/src/hooks/useSettings.ts
@@ -10,17 +10,14 @@ export interface SettingsState {
   elapsedEnabled: boolean
   elapsedMinutes: number
   pomodoroEnabled: boolean
-  userName: string
   whiteboardEnabled: boolean
-  whiteboardEmail: string
   slackProjectCode: string
   slackProjectName: string
   setTheme: (themeId: string) => void
   setIdle: (enabled: boolean, minutes: number) => void
   setElapsed: (enabled: boolean, minutes: number) => void
   setPomodoro: (enabled: boolean) => void
-  setUserName: (userName: string) => void
-  setWhiteboard: (enabled: boolean, email: string) => void
+  setWhiteboard: (enabled: boolean) => void
   setSlack: (projectCode: string, projectName: string) => void
 }
 
@@ -32,9 +29,7 @@ export function useSettings(): SettingsState {
   const [elapsedEnabled, setElapsedEnabled] = useState(false)
   const [elapsedMinutes, setElapsedMinutes] = useState(30)
   const [pomodoroEnabled, setPomodoroEnabled] = useState(false)
-  const [userName, setUserNameState] = useState('')
   const [whiteboardEnabled, setWhiteboardEnabled] = useState(false)
-  const [whiteboardEmail, setWhiteboardEmail] = useState('')
   const [slackProjectCode, setSlackProjectCode] = useState('')
   const [slackProjectName, setSlackProjectName] = useState('')
 
@@ -52,10 +47,8 @@ export function useSettings(): SettingsState {
     settingsRepository.getPomodoro().then(({ enabled }) => {
       setPomodoroEnabled(enabled)
     })
-    settingsRepository.getUserName().then(setUserNameState)
-    settingsRepository.getWhiteboard().then(({ enabled, email }) => {
+    settingsRepository.getWhiteboard().then(({ enabled }) => {
       setWhiteboardEnabled(enabled)
-      setWhiteboardEmail(email)
     })
     settingsRepository.getSlack().then(({ projectCode, projectName }) => {
       setSlackProjectCode(projectCode)
@@ -65,7 +58,7 @@ export function useSettings(): SettingsState {
 
   return {
     activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
-    userName, whiteboardEnabled, whiteboardEmail, slackProjectCode, slackProjectName,
+    whiteboardEnabled, slackProjectCode, slackProjectName,
 
     setTheme: (themeId): void => {
       // 即時反映（IPC待ちなし）
@@ -87,14 +80,9 @@ export function useSettings(): SettingsState {
       setPomodoroEnabled(enabled)
       settingsRepository.setPomodoro(enabled)
     },
-    setUserName: (value): void => {
-      setUserNameState(value)
-      settingsRepository.setUserName(value.trim())
-    },
-    setWhiteboard: (enabled, email): void => {
+    setWhiteboard: (enabled): void => {
       setWhiteboardEnabled(enabled)
-      setWhiteboardEmail(email)
-      settingsRepository.setWhiteboard(enabled, email.trim())
+      settingsRepository.setWhiteboard(enabled)
     },
     setSlack: (projectCode, projectName): void => {
       setSlackProjectCode(projectCode)

--- a/src/renderer/src/hooks/useSetup.ts
+++ b/src/renderer/src/hooks/useSetup.ts
@@ -5,8 +5,6 @@ import { DEFAULT_THEME_ID } from '../theme/themeParams'
 
 export interface SetupState {
   activeThemeId: string
-  userName: string
-  setUserName: (value: string) => void
   setTheme: (themeId: string) => void
   complete: () => Promise<void>
 }
@@ -14,7 +12,6 @@ export interface SetupState {
 /** セットアップウィザードのオーケストレーション。テーマ即時反映と完了処理を統括。 */
 export function useSetup(): SetupState {
   const [activeThemeId, setActiveThemeId] = useState(DEFAULT_THEME_ID)
-  const [userName, setUserNameState] = useState('')
 
   useEffect(() => {
     settingsRepository.getTheme().then(setActiveThemeId)
@@ -23,8 +20,6 @@ export function useSetup(): SetupState {
 
   return {
     activeThemeId,
-    userName,
-    setUserName: setUserNameState,
     setTheme: (themeId): void => {
       // 即時反映（IPC待ちなし）
       applyTheme(themeId)
@@ -32,7 +27,6 @@ export function useSetup(): SetupState {
       settingsRepository.setTheme(themeId)
     },
     complete: async (): Promise<void> => {
-      await settingsRepository.setUserName(userName.trim())
       await settingsRepository.completeSetup()
     },
   }

--- a/src/renderer/src/repositories/settingsRepository.ts
+++ b/src/renderer/src/repositories/settingsRepository.ts
@@ -32,18 +32,11 @@ export const settingsRepository = {
     return window.electronAPI.setPomodoroSettings(enabled)
   },
 
-  getUserName(): Promise<string> {
-    return window.electronAPI.getUserName()
-  },
-  setUserName(userName: string): Promise<void> {
-    return window.electronAPI.setUserName(userName)
-  },
-
-  getWhiteboard(): Promise<{ enabled: boolean; email: string }> {
+  getWhiteboard(): Promise<{ enabled: boolean }> {
     return window.electronAPI.getWhiteboardSettings()
   },
-  setWhiteboard(enabled: boolean, email: string): Promise<void> {
-    return window.electronAPI.setWhiteboardSettings(enabled, email)
+  setWhiteboard(enabled: boolean): Promise<void> {
+    return window.electronAPI.setWhiteboardSettings(enabled)
   },
 
   getSlack(): Promise<{ projectCode: string; projectName: string }> {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -16,7 +16,6 @@ export interface ToggleSettings {
 
 export interface WhiteboardSettings {
   enabled: boolean
-  email: string
 }
 
 export interface SlackSettings {
@@ -48,7 +47,7 @@ export interface IpcContract {
   'sessions:update': [session: Session, void]
   'sessions:delete': [{ id: string; yearMonth: string }, void]
 
-  // settings: theme / notifications / userName
+  // settings: theme / notifications
   'settings:getTheme': [void, string]
   'settings:setTheme': [themeId: string, void]
   'settings:getIdleSettings': [void, ToggleSettings]
@@ -57,12 +56,10 @@ export interface IpcContract {
   'settings:setElapsedSettings': [ToggleSettings, void]
   'settings:getPomodoroSettings': [void, PomodoroSettings]
   'settings:setPomodoroSettings': [PomodoroSettings, void]
-  'settings:getUserName': [void, string]
-  'settings:setUserName': [userName: string, void]
 
   // settings: integrations
   'settings:getWhiteboardSettings': [void, WhiteboardSettings]
-  'settings:setWhiteboardSettings': [WhiteboardSettings, void]
+  'settings:setWhiteboardSettings': [{ enabled: boolean }, void]
   'settings:getSlackSettings': [void, SlackSettings]
   'settings:setSlackSettings': [SlackSettings, void]
 


### PR DESCRIPTION
## やったこと

- Lambda に `/api/attendance.send`（user_name は対応表 ?? JWT の氏名で解決、勤怠 API 応答を透過）と `/api/whiteboard.telework` / `.leave`（email は JWT クレーム、無ければ reauth_required）を追加
- 勤怠・ホワイトボード連携を Lambda 経由に書き換え、API キーをバイナリから撤去（`.env` は PROXY_URL のみに）
- 設定モデルからユーザー名・メールアドレス入力を全レイヤ削除（本人情報は JWT 由来に）
- 初回セットアップを「Slack でサインイン」（スキップ可）に置き換え
- dev とパッケージ版の userData を分離（起動ロック衝突・localStorage 混入の根治）
- Terraform に5変数追加（勤怠/WB の URL・キー、user_name 対応表）

## 検証

- テスト 482 件 / typecheck / lint / terraform validate 通過
- 最終レビュー Merge 可（指摘の1行修正も反映済み）
- デプロイ・実機 E2E はマージ後に実施（tfvars 移設 → apply → .env 削除 → パッケージ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)