### PR TITLE
ページをまたぐタイマーの並び替えができない問題を修正

### DIFF
--- a/src/renderer/src/components/Popover/SessionList.test.tsx
+++ b/src/renderer/src/components/Popover/SessionList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SessionList } from './SessionList'
 import type { Session } from '../../types/session'
@@ -300,5 +300,57 @@ describe('SessionList — 業務終了', () => {
     fireEvent.change(screen.getByLabelText('分'), { target: { value: '30' } })
     fireEvent.keyDown(screen.getByLabelText('分'), { key: 'Enter' })
     expect(onWorkEnd).toHaveBeenCalledWith('18:30')
+  })
+})
+
+describe('SessionList — ページをまたぐ並び替え', () => {
+  const fiveSessions: Session[] = ['1', '2', '3', '4', '5'].map(id =>
+    makeSession({ id, taskId: id, name: `ジュース${id}` })
+  )
+
+  // jsdom には DragEvent が無いため、clientX と dataTransfer を持つ MouseEvent で代用する
+  function makeDragEvent(type: string, clientX = 0): MouseEvent {
+    const ev = new MouseEvent(type, { bubbles: true, cancelable: true, clientX })
+    Object.defineProperty(ev, 'dataTransfer', {
+      value: { effectAllowed: '', dropEffect: '' },
+    })
+    return ev
+  }
+
+  it('2ページ目のタイマーをドラッグ中にページを戻して1ページ目に入れられる', () => {
+    vi.useFakeTimers()
+    try {
+      localStorage.removeItem('sessionOrder.2026-02-25')
+      const { container } = render(<SessionList sessions={fiveSessions} today="2026-02-25" />)
+      const getUl = () => container.querySelector('ul')!
+
+      // 2ページ目へ（ページサイズ4なので ジュース5 は2ページ目）
+      fireEvent.wheel(getUl(), { deltaY: 100 })
+      expect(screen.getByText('ジュース5')).toBeInTheDocument()
+      expect(screen.queryByText('ジュース1')).not.toBeInTheDocument()
+
+      // ジュース5 をドラッグ開始し、リスト左端でホールド → 400ms でページが戻る
+      const li5 = screen.getByText('ジュース5').closest('li')!
+      fireEvent(li5, makeDragEvent('dragstart'))
+      fireEvent(getUl(), makeDragEvent('dragover', 10))
+      act(() => {
+        vi.advanceTimersByTime(400)
+      })
+      expect(screen.getByText('ジュース1')).toBeInTheDocument()
+      expect(screen.queryByText('ジュース5')).not.toBeInTheDocument()
+
+      // 1ページ目の ジュース1 の上にドロップ（ドラッグ元の li5 は既にアンマウント済み。
+      // 実ブラウザでは dragend が React に届かないため、drop で確定できる必要がある）
+      const li1 = screen.getByText('ジュース1').closest('li')!
+      fireEvent(li1, makeDragEvent('dragover', 200))
+      fireEvent(li1, makeDragEvent('drop', 200))
+
+      expect(JSON.parse(localStorage.getItem('sessionOrder.2026-02-25')!))
+        .toEqual(['5', '1', '2', '3', '4'])
+      // 1ページ目の先頭が ジュース5 になっている
+      expect(screen.getByText('ジュース5')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/renderer/src/components/Popover/SessionList.tsx
+++ b/src/renderer/src/components/Popover/SessionList.tsx
@@ -114,7 +114,8 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
     }
   }
 
-  const handleDragEnd = () => {
+  // 並び替えを確定して D&D の状態をリセットする（drop と dragend のどちらが先でも一度だけ実行される）
+  const commitReorder = () => {
     if (pageChangeTimerRef.current) {
       clearTimeout(pageChangeTimerRef.current)
       pageChangeTimerRef.current = null
@@ -138,6 +139,18 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
 
     dailyStore.setSessionOrder(todayKey, currentOrder)
     setCustomOrder(currentOrder)
+  }
+
+  // ページをまたぐ並び替えではドラッグ元の要素がアンマウントされ dragend が React に届かないため、
+  // ドロップ先（マウントされている側）で発火する drop で確定する
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    commitReorder()
+  }
+
+  const handleDragEnd = () => {
+    // 同一ページ内では drop の後に dragend も届くが、refs は消費済みなので二重確定しない
+    commitReorder()
   }
 
   const openAddDialog = () => {
@@ -233,6 +246,7 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
           className="m-0 flex min-h-0 flex-1 list-none animate-slide-up flex-col gap-1.5 overflow-y-auto px-0 py-px [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           key={animKey}
           onDragOver={handleListDragOver}
+          onDrop={handleDrop}
           onWheel={e => {
             if (totalPages <= 1) return
             if (e.deltaY > 0 && page < totalPages - 1) changePage(page + 1)


### PR DESCRIPTION
## やったこと

- ページ切り替え時にドラッグ元の `<li>` がアンマウントされ、`dragend` が React に届かず並び替えが確定されない問題を修正
- ドロップ先（マウントされている側）で発火する `drop` イベントで並び替えを確定するように変更
- 同一ページ内の並び替え挙動は不変（drop 確定後の dragend は no-op）
- ページをまたぐ D&D の再現テストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)