### PR TITLE
勤怠送信のエラーを認証エラーと送信失敗で出し分ける

### DIFF
--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -45,14 +45,22 @@ export function AttendanceReport({ sessions }: Props) {
           className={`${actionButton} disabled:transform-none disabled:cursor-not-allowed disabled:opacity-60 ${
             sendResult === 'success'
               ? 'bg-[linear-gradient(135deg,#26de81,#20c870)]'
-              : sendResult === 'error'
+              : sendResult === 'auth' || sendResult === 'error'
                 ? 'bg-[linear-gradient(135deg,#ef4444,#dc2626)]'
                 : 'bg-[linear-gradient(135deg,#3b82f6,#2563eb)] shadow-[0_4px_12px_rgba(59,130,246,0.3)] hover:shadow-[0_6px_16px_rgba(59,130,246,0.4)]'
           }`}
           onClick={send}
           disabled={sending || !canSend}
         >
-          {sending ? '送信中...' : sendResult === 'success' ? <><Check width={14} height={14} /> 送信しました</> : sendResult === 'error' ? '送信失敗' : <><SendDiagonal width={14} height={14} /> 送る</>}
+          {sending
+            ? '送信中...'
+            : sendResult === 'success'
+              ? <><Check width={14} height={14} /> 送信しました</>
+              : sendResult === 'auth'
+                ? '認証が必要です'
+                : sendResult === 'error'
+                  ? '送信失敗'
+                  : <><SendDiagonal width={14} height={14} /> 送る</>}
         </button>
       </div>
     </Card>

--- a/src/renderer/src/hooks/useAttendanceReport.test.ts
+++ b/src/renderer/src/hooks/useAttendanceReport.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAttendanceReport } from './useAttendanceReport'
+import type { Session } from '../types/session'
+
+const send = vi.fn()
+vi.mock('../repositories/attendanceRepository', () => ({
+  attendanceRepository: {
+    send: (...args: unknown[]) => send(...args),
+  },
+}))
+
+function makeSession(): Session {
+  return {
+    id: '1', taskId: '1', name: '作業', projectCode: 'P', workCategory: 'C',
+    times: [{ startTime: '2026-06-12T10:00:00', endTime: '2026-06-12T11:00:00' }],
+    date: '2026-06-12', color: '#FF9500', totalTime: 60,
+  }
+}
+
+beforeEach(() => {
+  send.mockReset()
+})
+
+describe('useAttendanceReport — 送信結果の分類', () => {
+  it('成功時は success', async () => {
+    send.mockResolvedValue({ ok: true, status: 200, body: '{}' })
+    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    await act(async () => { await result.current.send() })
+    expect(result.current.sendResult).toBe('success')
+  })
+
+  it('未サインイン（status 0）は auth', async () => {
+    send.mockResolvedValue({ ok: false, status: 0, body: 'Slack サインインが必要です（設定 > アカウント）' })
+    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    await act(async () => { await result.current.send() })
+    expect(result.current.sendResult).toBe('auth')
+  })
+
+  it('セッション切れ（status 401）は auth', async () => {
+    send.mockResolvedValue({ ok: false, status: 401, body: '{"error":"unauthorized"}' })
+    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    await act(async () => { await result.current.send() })
+    expect(result.current.sendResult).toBe('auth')
+  })
+
+  it('勤怠 API の入力不備（status 400）は error', async () => {
+    send.mockResolvedValue({ ok: false, status: 400, body: '{"error_message":"format"}' })
+    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    await act(async () => { await result.current.send() })
+    expect(result.current.sendResult).toBe('error')
+  })
+
+  it('上流エラー（status 502）は error', async () => {
+    send.mockResolvedValue({ ok: false, status: 502, body: 'attendance api error' })
+    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    await act(async () => { await result.current.send() })
+    expect(result.current.sendResult).toBe('error')
+  })
+
+  it('例外時は error', async () => {
+    send.mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    await act(async () => { await result.current.send() })
+    expect(result.current.sendResult).toBe('error')
+  })
+
+  it('送信結果は3秒後にクリアされる', async () => {
+    vi.useFakeTimers()
+    try {
+      send.mockResolvedValue({ ok: false, status: 0, body: 'x' })
+      const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+      await act(async () => { await result.current.send() })
+      expect(result.current.sendResult).toBe('auth')
+      act(() => { vi.advanceTimersByTime(3000) })
+      expect(result.current.sendResult).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/hooks/useAttendanceReport.ts
+++ b/src/renderer/src/hooks/useAttendanceReport.ts
@@ -12,7 +12,8 @@ export interface AttendanceReportState {
   canSend: boolean
   copied: boolean
   sending: boolean
-  sendResult: 'success' | 'error' | null
+  // 'auth' = 未サインイン / セッション切れ、'error' = 入力不備など上流エラー
+  sendResult: 'success' | 'auth' | 'error' | null
   copy: () => void
   send: () => Promise<void>
 }
@@ -22,7 +23,7 @@ export function useAttendanceReport(sessions: Session[]): AttendanceReportState 
   const [breakMinutes, setBreakMinutes] = useState(60)
   const [copied, setCopied] = useState(false)
   const [sending, setSending] = useState(false)
-  const [sendResult, setSendResult] = useState<'success' | 'error' | null>(null)
+  const [sendResult, setSendResult] = useState<'success' | 'auth' | 'error' | null>(null)
 
   const todayKey = formatLocalDate(Date.now())
   const workStart = dailyStore.getWorkStart(todayKey)
@@ -48,7 +49,10 @@ export function useAttendanceReport(sessions: Session[]): AttendanceReportState 
     setSendResult(null)
     try {
       const result = await attendanceRepository.send(text)
-      setSendResult(result.ok ? 'success' : 'error')
+      // status 0（未サインイン）/ 401（セッション切れ）は認証エラーとして区別する
+      if (result.ok) setSendResult('success')
+      else if (result.status === 0 || result.status === 401) setSendResult('auth')
+      else setSendResult('error')
     } catch {
       setSendResult('error')
     } finally {


### PR DESCRIPTION
## やったこと

- 勤怠送信の結果表示を「認証が必要です」（未サインイン・セッション切れ）と「送信失敗」（入力不備など上流エラー）に分けた
- 判定は status で分岐（0/401 → 認証、その他の非2xx → 送信失敗）
- フックの送信結果分類のユニットテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)