### PR TITLE
Slack 標準OAuth+users.infoによる勤怠user_name自動解決（Phase 4）

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -14,7 +14,7 @@ Slack OIDC サインインとセッション JWT 発行を行う Lambda。
 1. <https://api.slack.com/apps> → **Create New App** → **From scratch**
 2. App Name: `Juice`、ワークスペース: 会社ワークスペースを選択
 3. **OAuth & Permissions** → Scopes → **User Token Scopes** に
-   `openid` `profile` `email` を追加
+   `openid` `profile` `email` `users:read` を追加
 4. **Basic Information** → App Credentials の **Client ID** と
    **Client Secret** を控える
 5. Redirect URL はデプロイ後（手順3）に設定する
@@ -105,6 +105,9 @@ open dist-release/mac-arm64/Juice.app
 - **キーローテーション**: `terraform.tfvars` を変更して `terraform apply`
 - **全セッション失効**: `session_secret` を変更して `terraform apply`
 - **全リソース削除**: `terraform destroy`
-- **勤怠の登録名が一致しない人への対応**: 本人の Slack user ID（U 始まり）と
-  勤怠システムの登録名を `attendance_user_overrides` に追加して
-  `terraform apply`
+- **勤怠の登録名の自動解決**: サインイン時に Slack の `users.info` から
+  旧ユーザー名（@ハンドル）を取得し勤怠 user_name に使う。
+  スコープ変更（`users:read` 追加）後は既存サインイン者の再サインインが必要
+- **勤怠の登録名が一致しない人への対応**: 自動解決した旧ハンドルが勤怠 DB と
+  ズレる人は、本人の Slack user ID（U 始まり）と勤怠システムの登録名を
+  `attendance_user_overrides` に追加して `terraform apply`（対応表が最優先）

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -14,7 +14,8 @@ Slack OIDC サインインとセッション JWT 発行を行う Lambda。
 1. <https://api.slack.com/apps> → **Create New App** → **From scratch**
 2. App Name: `Juice`、ワークスペース: 会社ワークスペースを選択
 3. **OAuth & Permissions** → Scopes → **User Token Scopes** に
-   `openid` `profile` `email` `users:read` を追加
+   `users:read` と `users:read.email` を追加
+   （標準 OAuth フロー。`openid` 等の OIDC スコープは使わない）
 4. **Basic Information** → App Credentials の **Client ID** と
    **Client Secret** を控える
 5. Redirect URL はデプロイ後（手順3）に設定する
@@ -107,7 +108,7 @@ open dist-release/mac-arm64/Juice.app
 - **全リソース削除**: `terraform destroy`
 - **勤怠の登録名の自動解決**: サインイン時に Slack の `users.info` から
   旧ユーザー名（@ハンドル）を取得し勤怠 user_name に使う。
-  スコープ変更（`users:read` 追加）後は既存サインイン者の再サインインが必要
+  スコープ変更後は既存サインイン者の再サインインが必要
 - **勤怠の登録名が一致しない人への対応**: 自動解決した旧ハンドルが勤怠 DB と
   ズレる人は、本人の Slack user ID（U 始まり）と勤怠システムの登録名を
   `attendance_user_overrides` に追加して `terraform apply`（対応表が最優先）

--- a/lambda/src/attendanceSend.test.ts
+++ b/lambda/src/attendanceSend.test.ts
@@ -20,19 +20,23 @@ describe('parseAttendanceRequest', () => {
 })
 
 describe('resolveUserName', () => {
-  const claims = { sub: 'U123', name: 'Ryota Kanayama' }
+  const claims = { sub: 'U123', name: 'Ryota Kanayama', handle: 'kanayama' }
 
-  it('対応表に sub があれば優先する', () => {
-    expect(resolveUserName(claims, '{"U123":"kanayama"}')).toBe('kanayama')
+  it('対応表に sub があれば最優先する', () => {
+    expect(resolveUserName(claims, '{"U123":"override"}')).toBe('override')
   })
 
-  it('対応表に無ければ JWT の name を使う', () => {
-    expect(resolveUserName(claims, '{}')).toBe('Ryota Kanayama')
-    expect(resolveUserName(claims, '{"U999":"other"}')).toBe('Ryota Kanayama')
+  it('対応表に無ければ handle（旧ハンドル）を使う', () => {
+    expect(resolveUserName(claims, '{}')).toBe('kanayama')
+    expect(resolveUserName(claims, '{"U999":"other"}')).toBe('kanayama')
   })
 
-  it('対応表が不正な JSON でも name にフォールバックする', () => {
-    expect(resolveUserName(claims, 'broken')).toBe('Ryota Kanayama')
+  it('handle が無ければ氏名にフォールバックする', () => {
+    expect(resolveUserName({ sub: 'U123', name: 'Ryota Kanayama' }, '{}')).toBe('Ryota Kanayama')
+  })
+
+  it('対応表が不正な JSON でも handle にフォールバックする', () => {
+    expect(resolveUserName(claims, 'broken')).toBe('kanayama')
   })
 })
 

--- a/lambda/src/attendanceSend.ts
+++ b/lambda/src/attendanceSend.ts
@@ -19,11 +19,12 @@ export function parseAttendanceRequest(body: string): { text: string } | null {
 }
 
 /**
- * 勤怠の user_name を決める。対応表（sub → 勤怠登録名）が優先、
- * 無ければ JWT の氏名をそのまま使う（Phase 2/3 設計メモの決定）。
+ * 勤怠の user_name を決める。優先順位は
+ * 対応表（sub → 勤怠登録名）→ Slack 旧ハンドル → JWT の氏名
+ * （Phase 4 設計メモの決定）。
  */
 export function resolveUserName(
-  claims: Pick<SessionClaims, 'sub' | 'name'>,
+  claims: Pick<SessionClaims, 'sub' | 'name' | 'handle'>,
   overridesJson: string
 ): string {
   let overrides: Record<string, unknown> = {}
@@ -33,7 +34,8 @@ export function resolveUserName(
     // 不正な JSON は対応表なしとして扱う
   }
   const override = overrides[claims.sub]
-  return typeof override === 'string' ? override : claims.name
+  if (typeof override === 'string') return override
+  return claims.handle ?? claims.name
 }
 
 /** 勤怠 API に送信し、status と body をそのまま返す。ネットワークエラーは {error} */

--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -115,6 +115,17 @@ describe('GET /auth/callback', () => {
     const res = await handler(makeEvent('/auth/callback', { state: STATE }))
     expect(res.statusCode).toBe(400)
   })
+
+  it('handle 付き identity なら JWT に handle が入る', async () => {
+    vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({
+      sub: 'U123', name: '金山', teamId: 'T999', handle: 'kanayama',
+    })
+    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: STATE }))
+    const url = new URL(res.headers!.Location)
+    const token = url.searchParams.get('token')!
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf-8'))
+    expect(payload.handle).toBe('kanayama')
+  })
 })
 
 describe('GET /auth/me', () => {

--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -70,7 +70,7 @@ describe('GET /auth/start', () => {
     const res = await handler(makeEvent('/auth/start', { state: STATE }))
     expect(res.statusCode).toBe(302)
     const url = new URL(res.headers!.Location)
-    expect(url.origin + url.pathname).toBe('https://slack.com/openid/connect/authorize')
+    expect(url.origin + url.pathname).toBe('https://slack.com/oauth/v2/authorize')
     expect(url.searchParams.get('state')).toBe(STATE)
     expect(url.searchParams.get('redirect_uri')).toBe(
       'https://abc.lambda-url.ap-northeast-1.on.aws/auth/callback'

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -85,7 +85,7 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
       redirectUri,
     })
     if ('error' in identity) {
-      console.error('OIDC failed:', identity.error)
+      console.error('auth failed:', identity.error)
       return errorPage('Slack 認証に失敗しました。')
     }
     if (identity.teamId !== env('ALLOWED_TEAM_ID')) {

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -93,7 +93,13 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
       return errorPage('許可されていないワークスペースです。')
     }
     const token = issueSessionJwt(
-      { sub: identity.sub, name: identity.name, team: identity.teamId, email: identity.email },
+      {
+        sub: identity.sub,
+        name: identity.name,
+        team: identity.teamId,
+        email: identity.email,
+        handle: identity.handle,
+      },
       env('SESSION_SECRET')
     )
     return redirect(`juice://auth?token=${encodeURIComponent(token)}&state=${state}`)

--- a/lambda/src/sessionJwt.test.ts
+++ b/lambda/src/sessionJwt.test.ts
@@ -72,4 +72,18 @@ describe('sessionJwt', () => {
     expect(claims).not.toBeNull()
     expect(claims!.email).toBeUndefined()
   })
+
+  it('handle 付きで発行したトークンは handle を返す', () => {
+    const token = issueSessionJwt(
+      { sub: 'U1', name: 'a', team: 'T1', handle: 'kanayama' }, SECRET, NOW
+    )
+    expect(verifySessionJwt(token, SECRET, NOW)!.handle).toBe('kanayama')
+  })
+
+  it('handle 無しで発行した旧トークンも検証できる（handle は undefined）', () => {
+    const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T1' }, SECRET, NOW)
+    const claims = verifySessionJwt(token, SECRET, NOW)
+    expect(claims).not.toBeNull()
+    expect(claims!.handle).toBeUndefined()
+  })
 })

--- a/lambda/src/sessionJwt.ts
+++ b/lambda/src/sessionJwt.ts
@@ -6,6 +6,8 @@ export interface SessionClaims {
   team: string
   /** Phase 2 以降に発行されたトークンのみ保持（旧トークンは undefined） */
   email?: string
+  /** Slack 旧ユーザー名（@ハンドル）。users.info から取得。古い認可では undefined */
+  handle?: string
   iat: number
   exp: number
 }
@@ -20,7 +22,7 @@ function hmac(input: string, secret: string): Buffer {
 
 /** HS256 のセッション JWT を発行する */
 export function issueSessionJwt(
-  identity: { sub: string; name: string; team: string; email?: string },
+  identity: { sub: string; name: string; team: string; email?: string; handle?: string },
   secret: string,
   now: number = nowSec()
 ): string {

--- a/lambda/src/slackOidc.test.ts
+++ b/lambda/src/slackOidc.test.ts
@@ -28,7 +28,7 @@ describe('buildAuthorizeUrl', () => {
     expect(url.origin + url.pathname).toBe('https://slack.com/openid/connect/authorize')
     expect(url.searchParams.get('response_type')).toBe('code')
     expect(url.searchParams.get('client_id')).toBe('CID')
-    expect(url.searchParams.get('scope')).toBe('openid profile email')
+    expect(url.searchParams.get('scope')).toBe('openid profile email users:read')
     expect(url.searchParams.get('redirect_uri')).toBe('https://x/auth/callback')
     expect(url.searchParams.get('state')).toBe('abc')
   })
@@ -39,9 +39,12 @@ describe('fetchSlackIdentity', () => {
     const fetchMock = mockFetchSequence([
       { ok: true, access_token: 'xoxp-test' },
       { ok: true, sub: 'U123', name: '金山', email: 'kanayama@jsl.co.jp', 'https://slack.com/team_id': 'T999' },
+      { ok: true, user: { name: 'kanayama' } },
     ])
     const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ sub: 'U123', name: '金山', teamId: 'T999', email: 'kanayama@jsl.co.jp' })
+    expect(result).toEqual({
+      sub: 'U123', name: '金山', teamId: 'T999', email: 'kanayama@jsl.co.jp', handle: 'kanayama',
+    })
     // 1回目: トークン交換に code と client_secret が送られている
     const [tokenUrl, tokenInit] = fetchMock.mock.calls[0]
     expect(tokenUrl).toBe('https://slack.com/api/openid.connect.token')
@@ -51,6 +54,10 @@ describe('fetchSlackIdentity', () => {
     const [userUrl, userInit] = fetchMock.mock.calls[1]
     expect(userUrl).toBe('https://slack.com/api/openid.connect.userInfo')
     expect(userInit.headers.Authorization).toBe('Bearer xoxp-test')
+    // 3回目: users.info に access_token と user=sub が渡っている
+    const [usersUrl, usersInit] = fetchMock.mock.calls[2]
+    expect(usersUrl).toBe('https://slack.com/api/users.info?user=U123')
+    expect(usersInit.headers.Authorization).toBe('Bearer xoxp-test')
   })
 
   it('トークン交換失敗時は error を返す', async () => {
@@ -72,18 +79,32 @@ describe('fetchSlackIdentity', () => {
     mockFetchSequence([
       { ok: true, access_token: 'xoxp-test' },
       { ok: true, sub: 'U123', 'https://slack.com/team_id': 'T999' },
+      { ok: true, user: { name: 'handle1' } },
     ])
     const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ sub: 'U123', name: 'U123', teamId: 'T999', email: undefined })
+    expect(result).toEqual({ sub: 'U123', name: 'U123', teamId: 'T999', email: undefined, handle: 'handle1' })
   })
 
   it('email が無くても成功する（email は undefined）', async () => {
     mockFetchSequence([
       { ok: true, access_token: 'xoxp-test' },
       { ok: true, sub: 'U123', name: 'x', 'https://slack.com/team_id': 'T999' },
+      { ok: true, user: { name: 'handle1' } },
     ])
     const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ sub: 'U123', name: 'x', teamId: 'T999', email: undefined })
+    expect(result).toEqual({ sub: 'U123', name: 'x', teamId: 'T999', email: undefined, handle: 'handle1' })
+  })
+
+  it('users.info が失敗しても handle 無しで identity を返す', async () => {
+    mockFetchSequence([
+      { ok: true, access_token: 'xoxp-test' },
+      { ok: true, sub: 'U123', name: '金山', 'https://slack.com/team_id': 'T999' },
+      { ok: false, error: 'missing_scope' },
+    ])
+    const result = await fetchSlackIdentity(OPTS)
+    expect(result).toEqual({
+      sub: 'U123', name: '金山', teamId: 'T999', email: undefined, handle: undefined,
+    })
   })
 
   it('fetch が network error で reject しても throw せず error を返す', async () => {

--- a/lambda/src/slackOidc.test.ts
+++ b/lambda/src/slackOidc.test.ts
@@ -107,6 +107,18 @@ describe('fetchSlackIdentity', () => {
     })
   })
 
+  it('users.info のネットワークエラーでも handle 無しで identity を返す', async () => {
+    const fn = vi.fn()
+    fn.mockResolvedValueOnce({ json: () => Promise.resolve({ ok: true, access_token: 'xoxp-test' }) })
+    fn.mockResolvedValueOnce({ json: () => Promise.resolve({ ok: true, sub: 'U123', name: '金山', 'https://slack.com/team_id': 'T999' }) })
+    fn.mockRejectedValueOnce(new Error('ETIMEDOUT'))
+    vi.stubGlobal('fetch', fn)
+    const result = await fetchSlackIdentity(OPTS)
+    expect(result).toEqual({
+      sub: 'U123', name: '金山', teamId: 'T999', email: undefined, handle: undefined,
+    })
+  })
+
   it('fetch が network error で reject しても throw せず error を返す', async () => {
     const fn = vi.fn().mockRejectedValueOnce(new Error('getaddrinfo ENOTFOUND'))
     vi.stubGlobal('fetch', fn)

--- a/lambda/src/slackOidc.test.ts
+++ b/lambda/src/slackOidc.test.ts
@@ -21,108 +21,64 @@ function mockFetchSequence(responses: object[]): ReturnType<typeof vi.fn> {
 afterEach(() => vi.unstubAllGlobals())
 
 describe('buildAuthorizeUrl', () => {
-  it('Slack 認可 URL に必須パラメータが含まれる', () => {
+  it('標準 OAuth の認可 URL に user_scope を含める', () => {
     const url = new URL(
       buildAuthorizeUrl({ clientId: 'CID', redirectUri: 'https://x/auth/callback', state: 'abc' })
     )
-    expect(url.origin + url.pathname).toBe('https://slack.com/openid/connect/authorize')
-    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.origin + url.pathname).toBe('https://slack.com/oauth/v2/authorize')
     expect(url.searchParams.get('client_id')).toBe('CID')
-    expect(url.searchParams.get('scope')).toBe('openid profile email users:read')
+    expect(url.searchParams.get('user_scope')).toBe('users:read,users:read.email')
     expect(url.searchParams.get('redirect_uri')).toBe('https://x/auth/callback')
     expect(url.searchParams.get('state')).toBe('abc')
   })
 })
 
 describe('fetchSlackIdentity', () => {
-  it('トークン交換 → userInfo で本人情報を返す', async () => {
+  it('oauth.v2.access → users.info で本人情報を返す', async () => {
     const fetchMock = mockFetchSequence([
-      { ok: true, access_token: 'xoxp-test' },
-      { ok: true, sub: 'U123', name: '金山', email: 'kanayama@jsl.co.jp', 'https://slack.com/team_id': 'T999' },
-      { ok: true, user: { name: 'kanayama' } },
+      { ok: true, authed_user: { id: 'U123', access_token: 'xoxp-test' }, team: { id: 'T999' } },
+      { ok: true, user: { name: 'kanayama', real_name: '金山 良太', profile: { email: 'kanayama@jsl.co.jp' } } },
     ])
     const result = await fetchSlackIdentity(OPTS)
     expect(result).toEqual({
-      sub: 'U123', name: '金山', teamId: 'T999', email: 'kanayama@jsl.co.jp', handle: 'kanayama',
+      sub: 'U123', name: '金山 良太', teamId: 'T999', email: 'kanayama@jsl.co.jp', handle: 'kanayama',
     })
-    // 1回目: トークン交換に code と client_secret が送られている
+    // 1回目: oauth.v2.access に code と client_secret が送られている
     const [tokenUrl, tokenInit] = fetchMock.mock.calls[0]
-    expect(tokenUrl).toBe('https://slack.com/api/openid.connect.token')
+    expect(tokenUrl).toBe('https://slack.com/api/oauth.v2.access')
     expect(String(tokenInit.body)).toContain('code=CODE123')
     expect(String(tokenInit.body)).toContain('client_secret=CSECRET')
-    // 2回目: userInfo に access_token が渡っている
-    const [userUrl, userInit] = fetchMock.mock.calls[1]
-    expect(userUrl).toBe('https://slack.com/api/openid.connect.userInfo')
-    expect(userInit.headers.Authorization).toBe('Bearer xoxp-test')
-    // 3回目: users.info に access_token と user=sub が渡っている
-    const [usersUrl, usersInit] = fetchMock.mock.calls[2]
+    // 2回目: users.info に access_token と user=sub が渡っている
+    const [usersUrl, usersInit] = fetchMock.mock.calls[1]
     expect(usersUrl).toBe('https://slack.com/api/users.info?user=U123')
     expect(usersInit.headers.Authorization).toBe('Bearer xoxp-test')
   })
 
-  it('トークン交換失敗時は error を返す', async () => {
+  it('real_name が無ければ name、それも無ければ sub を name に使う', async () => {
+    mockFetchSequence([
+      { ok: true, authed_user: { id: 'U123', access_token: 'xoxp-test' }, team: { id: 'T999' } },
+      { ok: true, user: { name: 'kanayama', profile: {} } },
+    ])
+    expect(await fetchSlackIdentity(OPTS)).toEqual({
+      sub: 'U123', name: 'kanayama', teamId: 'T999', email: undefined, handle: 'kanayama',
+    })
+  })
+
+  it('oauth.v2.access 失敗時は error を返す', async () => {
     mockFetchSequence([{ ok: false, error: 'invalid_code' }])
-    const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ error: 'token: invalid_code' })
+    expect(await fetchSlackIdentity(OPTS)).toEqual({ error: 'oauth: invalid_code' })
   })
 
-  it('userInfo 失敗時は error を返す', async () => {
+  it('users.info 失敗時は error を返す', async () => {
     mockFetchSequence([
-      { ok: true, access_token: 'xoxp-test' },
-      { ok: false, error: 'invalid_auth' },
+      { ok: true, authed_user: { id: 'U123', access_token: 'xoxp-test' }, team: { id: 'T999' } },
+      { ok: false, error: 'user_not_found' },
     ])
-    const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ error: 'userInfo: invalid_auth' })
+    expect(await fetchSlackIdentity(OPTS)).toEqual({ error: 'usersInfo: user_not_found' })
   })
 
-  it('name が無い場合は sub を name に使う', async () => {
-    mockFetchSequence([
-      { ok: true, access_token: 'xoxp-test' },
-      { ok: true, sub: 'U123', 'https://slack.com/team_id': 'T999' },
-      { ok: true, user: { name: 'handle1' } },
-    ])
-    const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ sub: 'U123', name: 'U123', teamId: 'T999', email: undefined, handle: 'handle1' })
-  })
-
-  it('email が無くても成功する（email は undefined）', async () => {
-    mockFetchSequence([
-      { ok: true, access_token: 'xoxp-test' },
-      { ok: true, sub: 'U123', name: 'x', 'https://slack.com/team_id': 'T999' },
-      { ok: true, user: { name: 'handle1' } },
-    ])
-    const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ sub: 'U123', name: 'x', teamId: 'T999', email: undefined, handle: 'handle1' })
-  })
-
-  it('users.info が失敗しても handle 無しで identity を返す', async () => {
-    mockFetchSequence([
-      { ok: true, access_token: 'xoxp-test' },
-      { ok: true, sub: 'U123', name: '金山', 'https://slack.com/team_id': 'T999' },
-      { ok: false, error: 'missing_scope' },
-    ])
-    const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({
-      sub: 'U123', name: '金山', teamId: 'T999', email: undefined, handle: undefined,
-    })
-  })
-
-  it('users.info のネットワークエラーでも handle 無しで identity を返す', async () => {
-    const fn = vi.fn()
-    fn.mockResolvedValueOnce({ json: () => Promise.resolve({ ok: true, access_token: 'xoxp-test' }) })
-    fn.mockResolvedValueOnce({ json: () => Promise.resolve({ ok: true, sub: 'U123', name: '金山', 'https://slack.com/team_id': 'T999' }) })
-    fn.mockRejectedValueOnce(new Error('ETIMEDOUT'))
-    vi.stubGlobal('fetch', fn)
-    const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({
-      sub: 'U123', name: '金山', teamId: 'T999', email: undefined, handle: undefined,
-    })
-  })
-
-  it('fetch が network error で reject しても throw せず error を返す', async () => {
-    const fn = vi.fn().mockRejectedValueOnce(new Error('getaddrinfo ENOTFOUND'))
-    vi.stubGlobal('fetch', fn)
-    const result = await fetchSlackIdentity(OPTS)
-    expect(result).toEqual({ error: 'network: getaddrinfo ENOTFOUND' })
+  it('ネットワークエラーは throw せず error を返す', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')))
+    expect(await fetchSlackIdentity(OPTS)).toEqual({ error: 'network: ECONNRESET' })
   })
 })

--- a/lambda/src/slackOidc.ts
+++ b/lambda/src/slackOidc.ts
@@ -4,6 +4,8 @@ export interface SlackIdentity {
   teamId: string
   /** email スコープで取得。古い認可では undefined になりうる */
   email?: string
+  /** Slack 旧ユーザー名（@ハンドル）。users.info から取得。取得失敗時は undefined */
+  handle?: string
 }
 
 export interface SlackOidcError {
@@ -19,7 +21,7 @@ export function buildAuthorizeUrl(opts: {
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: opts.clientId,
-    scope: 'openid profile email',
+    scope: 'openid profile email users:read',
     redirect_uri: opts.redirectUri,
     state: opts.state,
   })
@@ -38,6 +40,12 @@ interface UserInfoResponse {
   name?: string
   email?: string
   'https://slack.com/team_id'?: string
+  error?: string
+}
+
+interface UsersInfoResponse {
+  ok: boolean
+  user?: { name?: string }
   error?: string
 }
 
@@ -76,7 +84,21 @@ export async function fetchSlackIdentity(opts: {
     if (!user.ok || !user.sub || !teamId) {
       return { error: `userInfo: ${user.error ?? 'unknown'}` }
     }
-    return { sub: user.sub, name: user.name || user.sub, teamId, email: user.email }
+    // users.info の name は廃止された旧ユーザー名（@ハンドル）。勤怠 DB の
+    // slack_user_name はこの値から登録されているため照合に使う。
+    // 取得失敗はサインインを止めず handle を undefined にする。
+    let handle: string | undefined
+    try {
+      const usersRes = await fetch(
+        `https://slack.com/api/users.info?user=${encodeURIComponent(user.sub)}`,
+        { headers: { Authorization: `Bearer ${token.access_token}` } }
+      )
+      const usersInfo = (await usersRes.json()) as UsersInfoResponse
+      if (usersInfo.ok) handle = usersInfo.user?.name
+    } catch {
+      // users.info の失敗はサインインを止めない
+    }
+    return { sub: user.sub, name: user.name || user.sub, teamId, email: user.email, handle }
   } catch (e) {
     return { error: `network: ${e instanceof Error ? e.message : 'unknown'}` }
   }

--- a/lambda/src/slackOidc.ts
+++ b/lambda/src/slackOidc.ts
@@ -2,9 +2,9 @@ export interface SlackIdentity {
   sub: string
   name: string
   teamId: string
-  /** email スコープで取得。古い認可では undefined になりうる */
+  /** users.info の profile.email。取得できなければ undefined */
   email?: string
-  /** Slack 旧ユーザー名（@ハンドル）。users.info から取得。取得失敗時は undefined */
+  /** Slack 旧ユーザー名（@ハンドル）= users.info の name。勤怠照合に使う */
   handle?: string
 }
 
@@ -12,46 +12,37 @@ export interface SlackOidcError {
   error: string
 }
 
-/** Slack の OIDC 認可 URL を組み立てる */
+/** Slack 標準 OAuth v2 の認可 URL を組み立てる（user_scope で本人トークンを得る） */
 export function buildAuthorizeUrl(opts: {
   clientId: string
   redirectUri: string
   state: string
 }): string {
   const params = new URLSearchParams({
-    response_type: 'code',
     client_id: opts.clientId,
-    scope: 'openid profile email users:read',
+    user_scope: 'users:read,users:read.email',
     redirect_uri: opts.redirectUri,
     state: opts.state,
   })
-  return `https://slack.com/openid/connect/authorize?${params}`
+  return `https://slack.com/oauth/v2/authorize?${params}`
 }
 
-interface TokenResponse {
+interface OAuthAccessResponse {
   ok: boolean
-  access_token?: string
-  error?: string
-}
-
-interface UserInfoResponse {
-  ok: boolean
-  sub?: string
-  name?: string
-  email?: string
-  'https://slack.com/team_id'?: string
+  authed_user?: { id?: string; access_token?: string }
+  team?: { id?: string }
   error?: string
 }
 
 interface UsersInfoResponse {
   ok: boolean
-  user?: { name?: string }
+  user?: { name?: string; real_name?: string; profile?: { email?: string } }
   error?: string
 }
 
 /**
- * 認可コードを交換し、userInfo で本人情報を取得する。
- * code は TLS で Slack と直接交換するため ID トークンの署名検証は不要。
+ * 認可コードを oauth.v2.access で交換し、users.info で本人情報を取得する。
+ * 本人確認は users.info に依存するため、いずれの失敗も {error} を返す。
  */
 export async function fetchSlackIdentity(opts: {
   clientId: string
@@ -60,45 +51,40 @@ export async function fetchSlackIdentity(opts: {
   redirectUri: string
 }): Promise<SlackIdentity | SlackOidcError> {
   try {
-    const tokenRes = await fetch('https://slack.com/api/openid.connect.token', {
+    const tokenRes = await fetch('https://slack.com/api/oauth.v2.access', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({
-        grant_type: 'authorization_code',
         client_id: opts.clientId,
         client_secret: opts.clientSecret,
         code: opts.code,
         redirect_uri: opts.redirectUri,
       }),
     })
-    const token = (await tokenRes.json()) as TokenResponse
-    if (!token.ok || !token.access_token) {
-      return { error: `token: ${token.error ?? 'unknown'}` }
+    const token = (await tokenRes.json()) as OAuthAccessResponse
+    const sub = token.authed_user?.id
+    const accessToken = token.authed_user?.access_token
+    const teamId = token.team?.id
+    if (!token.ok || !sub || !accessToken || !teamId) {
+      return { error: `oauth: ${token.error ?? 'unknown'}` }
     }
 
-    const userRes = await fetch('https://slack.com/api/openid.connect.userInfo', {
-      headers: { Authorization: `Bearer ${token.access_token}` },
-    })
-    const user = (await userRes.json()) as UserInfoResponse
-    const teamId = user['https://slack.com/team_id']
-    if (!user.ok || !user.sub || !teamId) {
-      return { error: `userInfo: ${user.error ?? 'unknown'}` }
+    const usersRes = await fetch(
+      `https://slack.com/api/users.info?user=${encodeURIComponent(sub)}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    )
+    const usersInfo = (await usersRes.json()) as UsersInfoResponse
+    if (!usersInfo.ok || !usersInfo.user) {
+      return { error: `usersInfo: ${usersInfo.error ?? 'unknown'}` }
     }
-    // users.info の name は廃止された旧ユーザー名（@ハンドル）。勤怠 DB の
-    // slack_user_name はこの値から登録されているため照合に使う。
-    // 取得失敗はサインインを止めず handle を undefined にする。
-    let handle: string | undefined
-    try {
-      const usersRes = await fetch(
-        `https://slack.com/api/users.info?user=${encodeURIComponent(user.sub)}`,
-        { headers: { Authorization: `Bearer ${token.access_token}` } }
-      )
-      const usersInfo = (await usersRes.json()) as UsersInfoResponse
-      if (usersInfo.ok) handle = usersInfo.user?.name
-    } catch {
-      // users.info の失敗はサインインを止めない
+    const u = usersInfo.user
+    return {
+      sub,
+      name: u.real_name || u.name || sub,
+      teamId,
+      email: u.profile?.email,
+      handle: u.name,
     }
-    return { sub: user.sub, name: user.name || user.sub, teamId, email: user.email, handle }
   } catch (e) {
     return { error: `network: ${e instanceof Error ? e.message : 'unknown'}` }
   }


### PR DESCRIPTION
## やったこと

- 認証フローを **OIDC（Sign in with Slack）から標準 OAuth v2 + users.info に置換**
  - OIDC アプリには users:read を足せない/OIDCトークンはWeb APIを呼べない、というSlack制約のため
- User Token Scopes を `users:read` `users:read.email` に変更
- 本人情報（sub/氏名/メール/旧ハンドル/team）をすべて users.info から取得
- 勤怠の user_name 解決を「対応表 → 旧ハンドル → 氏名」に変更
- アプリ側の変更はゼロ（Lambda 完結）

## 背景

勤怠DBの slack_user_name は廃止された Slack 旧ユーザー名（@ハンドル）で、OIDC では取得不可。Web API users.info の name フィールドがこれを返すため、標準 OAuth でユーザートークンを取得して照合する。

## 検証

- テスト 485 件 / typecheck / lint / terraform validate 通過、最終レビュー Merge 可
- デプロイ手順: Slack の User Token Scopes を users:read/users:read.email に変更 → 再インストール → apply → 再サインイン → 勤怠送信で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)