### PR TITLE
chore: Lambda ランタイムを nodejs22.x へ移行

### DIFF
--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -8,7 +8,7 @@
       "name": "juice-lambda",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/node": "^20.11.5",
+        "@types/node": "^22.0.0",
         "esbuild": "^0.21.5"
       }
     },
@@ -404,9 +404,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "description": "Juice の認証・API プロキシ Lambda",
   "scripts": {
-    "build": "esbuild src/handler.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/handler.js"
+    "build": "esbuild src/handler.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/handler.js"
   },
   "devDependencies": {
-    "@types/node": "^20.11.5",
+    "@types/node": "^22.0.0",
     "esbuild": "^0.21.5"
   }
 }

--- a/lambda/terraform/main.tf
+++ b/lambda/terraform/main.tf
@@ -43,7 +43,7 @@ resource "aws_iam_role_policy_attachment" "logs" {
 resource "aws_lambda_function" "juice_proxy" {
   function_name    = "juice-proxy"
   role             = aws_iam_role.lambda.arn
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   handler          = "handler.handler"
   filename         = data.archive_file.lambda.output_path
   source_code_hash = data.archive_file.lambda.output_base64sha256


### PR DESCRIPTION
Node.js 20.x ランタイムのサポート終了に対応。

- `main.tf` の runtime を `nodejs22.x` に
- esbuild `--target=node22`、`@types/node` を 22 系に
- ビルド確認済み

反映には `terraform apply` が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)