### PR TITLE
fix: 監査で判明した重大度「高」の3件を修正

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,10 +31,12 @@ if (!app.requestSingleInstanceLock()) {
 process.on('SIGTERM', () => app.quit())
 process.on('SIGINT', () => app.quit())
 
-const dataDir = join(os.homedir(), 'Library', 'Application Support', 'Juice')
+// 上で setPath('userData', ...) によって dev は juice-timer-dev、パッケージ版は Juice に分離済み。
+// 全ストアで userData を使い、dev とパッケージ版のセッション・設定・認証データを一貫して分離する。
+const dataDir = app.getPath('userData')
 const sessionStore = new SessionStore(dataDir)
 const settingsStore = new SettingsStore(dataDir)
-const authStore = new AuthStore(app.getPath('userData'))
+const authStore = new AuthStore(dataDir)
 
 // 開発時は汎用 Electron.app に紐づくため juice:// の E2E はパッケージ版で確認する
 // juice:// カスタムスキーム（Slack サインインのコールバック受信）

--- a/src/main/windows/setup.ts
+++ b/src/main/windows/setup.ts
@@ -36,10 +36,11 @@ export function createSetupWindow(settingsStore: SettingsStore): void {
     setupWindow.loadFile(join(__dirname, '../renderer/index.html'), { hash: 'setup' })
   }
 
-  setupWindow.on('closed', () => {
+  setupWindow.on('closed', async () => {
     setupWindow = null
-    // セットアップ未完了でウィンドウを閉じた場合はアプリ終了
-    if (!settingsStore.isSetupCompleted()) {
+    // セットアップ未完了でウィンドウを閉じた場合はアプリ終了。
+    // isSetupCompleted は Promise を返すため await しないと常に truthy 判定になる。
+    if (!(await settingsStore.isSetupCompleted())) {
       app.quit()
     }
   })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -126,6 +126,7 @@ export function TimerPage({ sessions }: { sessions: SessionsState }) {
   const [activeTimerProjectCode, setActiveTimerProjectCode] = useState('')
   const [activeTimerWorkCategory, setActiveTimerWorkCategory] = useState('')
   const [midnightSession, setMidnightSession] = useState<Session | null>(null)
+  const [stopError, setStopError] = useState(false)
 
   const handleStart = (name: string, projectCode = '', workCategory = ''): void => {
     setActiveTimerName(name)
@@ -143,8 +144,17 @@ export function TimerPage({ sessions }: { sessions: SessionsState }) {
   }
 
   const handleStop = async (projectCode: string, workCategory: string): Promise<void> => {
-    const result = await stop({ projectCode, workCategory })
+    let result: Session | null
+    try {
+      result = await stop({ projectCode, workCategory })
+    } catch (err) {
+      // 保存に失敗してもタイマーは継続している（計測データは保持）。再試行を促す。
+      console.error('セッションの保存に失敗しました:', err)
+      setStopError(true)
+      return
+    }
     if (!result) return
+    setStopError(false)
     // 日付を跨いだ場合はリストに追加せず通知バナーを表示
     if (result.date !== sessions.today) {
       setMidnightSession(result)
@@ -164,6 +174,13 @@ export function TimerPage({ sessions }: { sessions: SessionsState }) {
         <div className={styles.midnightBanner}>
           <span>「{midnightSession.name}」を {midnightSession.date} として保存しました</span>
           <button onClick={() => setMidnightSession(null)}><Xmark width={14} height={14} /></button>
+        </div>
+      )}
+
+      {stopError && (
+        <div className={styles.midnightBanner}>
+          <span>保存に失敗しました。タイマーは継続中です。もう一度停止してください</span>
+          <button onClick={() => setStopError(false)}><Xmark width={14} height={14} /></button>
         </div>
       )}
 

--- a/src/renderer/src/hooks/useTimer.test.ts
+++ b/src/renderer/src/hooks/useTimer.test.ts
@@ -62,6 +62,27 @@ describe('useTimer', () => {
     expect(mockUpdateSession).not.toHaveBeenCalled()
   })
 
+  it('stop の保存が失敗したら計測を継続し、例外を伝播する（データロス防止）', async () => {
+    mockSaveSession.mockRejectedValueOnce(new Error('disk full'))
+    const { result } = renderHook(() => useTimer())
+    act(() => { result.current.start('テスト作業') })
+    act(() => { vi.advanceTimersByTime(60000) })
+    await act(async () => {
+      await expect(result.current.stop()).rejects.toThrow('disk full')
+    })
+    // 保存に失敗しても計測は止めない（ユーザーが再試行できる）
+    expect(result.current.isRunning).toBe(true)
+    // interval が張り直され、開始時刻も保持されているので計測が継続する
+    act(() => { vi.advanceTimersByTime(2000) })
+    expect(result.current.elapsedSeconds).toBe(62)
+    // 再試行すると成功し、計測した区間が保存される
+    let session: Session | null = null
+    await act(async () => { session = await result.current.stop() })
+    expect(session).not.toBeNull()
+    expect(result.current.isRunning).toBe(false)
+    expect(mockSaveSession).toHaveBeenCalledTimes(2)
+  })
+
   it('30秒未満で止めると totalTime が 0 になる（四捨五入）', async () => {
     const { result } = renderHook(() => useTimer())
     act(() => { result.current.start('テスト作業') })

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -112,17 +112,16 @@ export function useTimer(): TimerState {
 
     const newIntervalMinutes = Math.round((Date.now() - startTimeRef.current.getTime()) / 60000)
 
-    if (extendingSessionRef.current) {
+    const extending = extendingSessionRef.current
+    if (extending) {
       // extend mode: 既存セッションの times に追記し totalTime を加算
-      const existing = extendingSessionRef.current
       resultSession = {
-        ...existing,
-        projectCode: opts?.projectCode ?? existing.projectCode,
-        workCategory: opts?.workCategory ?? existing.workCategory,
-        totalTime: existing.totalTime + newIntervalMinutes,
-        times: [...existing.times, newInterval],
+        ...extending,
+        projectCode: opts?.projectCode ?? extending.projectCode,
+        workCategory: opts?.workCategory ?? extending.workCategory,
+        totalTime: extending.totalTime + newIntervalMinutes,
+        times: [...extending.times, newInterval],
       }
-      await sessionRepository.update(resultSession)
     } else {
       // new mode: 新規セッションを作成
       resultSession = {
@@ -136,7 +135,23 @@ export function useTimer(): TimerState {
         date: formatLocalDate(startTimeRef.current.getTime()),
         color: activeColorRef.current,
       }
-      await sessionRepository.save(resultSession)
+    }
+
+    try {
+      if (extending) {
+        await sessionRepository.update(resultSession)
+      } else {
+        await sessionRepository.save(resultSession)
+      }
+    } catch (err) {
+      // 保存に失敗した場合は計測を止めずに継続させ、データロスを防ぐ。
+      // interval を張り直し（開始時刻 ref は保持済み）、呼び出し側で再試行できるよう例外を伝播する。
+      intervalRef.current = setInterval(() => {
+        if (startTimeRef.current) {
+          setElapsedSeconds(Math.floor((Date.now() - startTimeRef.current.getTime()) / 1000))
+        }
+      }, 1000)
+      throw err
     }
 
     startTimeRef.current = null


### PR DESCRIPTION
プロジェクト全体監査で判明した重大度「高」の3件を修正。

## 修正内容
- **dev/パッケージ版のデータ分離崩壊** ([index.ts](src/main/index.ts)) — `sessionStore`/`settingsStore` が本番パス `Juice` をハードコードしており、dev でも本番のセッション・設定を読み書きしていた。`userData` 基準に統一（パッケージ版は同一パスなので移行不要、dev のみ分離が効く）。
- **セットアップ中断時のゾンビ化** ([setup.ts](src/main/windows/setup.ts)) — `isSetupCompleted()` が `Promise` を返すため `!settingsStore.isSetupCompleted()` が常に false となり、`app.quit()` が一度も発火していなかった。`await` を追加。
- **タイマー停止時の保存失敗でデータ消失** ([useTimer.ts](src/renderer/src/hooks/useTimer.ts), [App.tsx](src/renderer/src/App.tsx)) — 保存失敗時に try/catch が無く計測区間が消失していた。失敗時は計測を継続し再試行可能にし、呼び出し側でエラーバナーを表示。

## テスト
- typecheck パス
- 全テスト 494 件パス（useTimer の保存失敗ケースを 1 件追加）
- ※ index.ts / setup.ts のメインプロセス変更は自動テスト対象外。型チェックとコード確認による検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)