### PR TITLE
fix: メインプロセスのファイルI/Oとjson入力を堅牢化（監査・中 #1/#2）

### DIFF
--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -121,5 +121,19 @@ export function registerIpcHandlers(
   handle('holidays:get', () => getHolidays())
   handle('window:hide', () => hidePopover())
   handle('window:resize', (_, { width, height }) => resizePopover(width, height))
-  handle('shell:openUrl', (_, url) => { shell.openExternal(url) })
+  handle('shell:openUrl', (_, url) => {
+    // http(s) のみ許可する。file:// 等の他スキームを外部に開かせない。
+    let protocol: string
+    try {
+      protocol = new URL(url).protocol
+    } catch {
+      logger.warn('blocked openExternal for invalid url:', url)
+      return
+    }
+    if (protocol === 'http:' || protocol === 'https:') {
+      shell.openExternal(url)
+    } else {
+      logger.warn('blocked openExternal for non-http(s) url:', url)
+    }
+  })
 }

--- a/src/main/serialQueue.ts
+++ b/src/main/serialQueue.ts
@@ -1,0 +1,15 @@
+/**
+ * 直列実行キュー。read-modify-write を伴うファイル操作を順番に実行し、
+ * 並行 IPC による lost-update（後勝ちで一方の変更が消える）を防ぐ。
+ *
+ * 返された enqueue に渡した操作は、前の操作が解決（成功・失敗どちらでも）するまで待ってから実行される。
+ */
+export function createSerialQueue(): <T>(op: () => Promise<T>) => Promise<T> {
+  let tail: Promise<unknown> = Promise.resolve()
+  return <T>(op: () => Promise<T>): Promise<T> => {
+    const run = tail.then(op, op)
+    // 失敗してもチェーンを止めないよう、キューの末尾は常に解決済みにする
+    tail = run.then(() => undefined, () => undefined)
+    return run
+  }
+}

--- a/src/main/sessionStore.test.ts
+++ b/src/main/sessionStore.test.ts
@@ -123,6 +123,32 @@ describe('SessionStore', () => {
     expect(sessions).toEqual([])
   })
 
+  it('パストラバーサルを含む yearMonth を拒否する', async () => {
+    await expect(store.getSessions('../../etc/passwd')).rejects.toThrow()
+    await expect(store.deleteSession('x', '../../../tmp/evil')).rejects.toThrow()
+  })
+
+  it('不正な date を持つセッションの保存を拒否する', async () => {
+    const bad = {
+      id: 'bad', taskId: 'bad', name: 'x', projectCode: '', workCategory: '',
+      times: [{ startTime: '2026-02-25T10:00:00', endTime: '2026-02-25T10:30:00' }],
+      date: '../../../tmp/evil', color: '#FF9500', totalTime: 30,
+    }
+    await expect(store.saveSession(bad)).rejects.toThrow()
+  })
+
+  it('並行 save でも全件が保存される（lost-update なし）', async () => {
+    const make = (n: number) => ({
+      id: `id-${n}`, taskId: `id-${n}`, name: `作業${n}`, projectCode: '', workCategory: '',
+      times: [{ startTime: '2026-02-25T10:00:00', endTime: '2026-02-25T10:30:00' }],
+      date: '2026-02-25', color: '#FF9500', totalTime: 30,
+    })
+    // 同一月へ 10 件を並行保存（直列化されていないと read-modify-write が競合して取りこぼす）
+    await Promise.all(Array.from({ length: 10 }, (_, i) => store.saveSession(make(i))))
+    const sessions = await store.getSessions('2026-02')
+    expect(sessions).toHaveLength(10)
+  })
+
   it('totalTime のない旧フォーマットは times[] から移行して保持する', async () => {
     const primaryPath = join(testDir, 'sessions-2026-02.json')
     const legacy = {

--- a/src/main/sessionStore.ts
+++ b/src/main/sessionStore.ts
@@ -1,6 +1,12 @@
 import { readFile, writeFile, mkdir, rename } from 'fs/promises'
 import { join } from 'path'
 import type { Session, SessionFile, TimeInterval } from '../shared/types'
+import { createSerialQueue } from './serialQueue'
+
+/** "YYYY-MM"。ファイルパスに連結する前にパストラバーサルを防ぐため検証する */
+const YEAR_MONTH = /^\d{4}-\d{2}$/
+/** "YYYY-MM-DD"。session.date から yearMonth を導出する前に検証する */
+const DATE = /^\d{4}-\d{2}-\d{2}$/
 
 /** 旧フォーマット（totalTime なし）のセッション向けに times[] から合計分を算出 */
 function totalTimeFromIntervals(times: TimeInterval[]): number {
@@ -14,11 +20,26 @@ function totalTimeFromIntervals(times: TimeInterval[]): number {
 export class SessionStore {
   constructor(private dataDir: string) {}
 
+  /** write 系（read-modify-write）を直列化し、並行 IPC による lost-update を防ぐ */
+  private enqueue = createSerialQueue()
+
   private filePath(yearMonth: string): string {
+    if (!YEAR_MONTH.test(yearMonth)) {
+      throw new Error(`invalid yearMonth: ${yearMonth}`)
+    }
     return join(this.dataDir, `sessions-${yearMonth}.json`)
   }
 
+  /** session.date を検証し yearMonth を導出する */
+  private yearMonthOf(session: Session): string {
+    if (!DATE.test(session.date)) {
+      throw new Error(`invalid session.date: ${session.date}`)
+    }
+    return session.date.slice(0, 7)
+  }
+
   async getSessions(yearMonth: string): Promise<Session[]> {
+    const filePath = this.filePath(yearMonth) // 不正な yearMonth はここで throw（try の外で検証）
     const parse = (content: string): Session[] => {
       const data: SessionFile = JSON.parse(content)
       return data.sessions.map(s => ({
@@ -29,10 +50,10 @@ export class SessionStore {
       }))
     }
     try {
-      return parse(await readFile(this.filePath(yearMonth), 'utf-8'))
+      return parse(await readFile(filePath, 'utf-8'))
     } catch {
       try {
-        return parse(await readFile(`${this.filePath(yearMonth)}.bak`, 'utf-8'))
+        return parse(await readFile(`${filePath}.bak`, 'utf-8'))
       } catch {
         return []
       }
@@ -40,28 +61,36 @@ export class SessionStore {
   }
 
   async saveSession(session: Session): Promise<void> {
-    const yearMonth = session.date.slice(0, 7)
-    const sessions = await this.getSessions(yearMonth)
-    sessions.push(session)
-    await this.write(yearMonth, sessions)
+    const yearMonth = this.yearMonthOf(session)
+    await this.enqueue(async () => {
+      const sessions = await this.getSessions(yearMonth)
+      sessions.push(session)
+      await this.write(yearMonth, sessions)
+    })
   }
 
   async updateSession(session: Session): Promise<void> {
-    const yearMonth = session.date.slice(0, 7)
-    const sessions = await this.getSessions(yearMonth)
-    const index = sessions.findIndex((s) => s.id === session.id)
-    if (index !== -1) {
-      sessions[index] = session
-    } else {
-      sessions.push(session)
-    }
-    await this.write(yearMonth, sessions)
+    const yearMonth = this.yearMonthOf(session)
+    await this.enqueue(async () => {
+      const sessions = await this.getSessions(yearMonth)
+      const index = sessions.findIndex((s) => s.id === session.id)
+      if (index !== -1) {
+        sessions[index] = session
+      } else {
+        sessions.push(session)
+      }
+      await this.write(yearMonth, sessions)
+    })
   }
 
   async deleteSession(id: string, yearMonth: string): Promise<void> {
-    const sessions = await this.getSessions(yearMonth)
-    const filtered = sessions.filter(s => s.id !== id)
-    await this.write(yearMonth, filtered)
+    // 先に検証してから直列化（不正な yearMonth は即時に拒否する）
+    this.filePath(yearMonth)
+    await this.enqueue(async () => {
+      const sessions = await this.getSessions(yearMonth)
+      const filtered = sessions.filter(s => s.id !== id)
+      await this.write(yearMonth, filtered)
+    })
   }
 
   private async write(yearMonth: string, sessions: Session[]): Promise<void> {

--- a/src/main/settingsStore.test.ts
+++ b/src/main/settingsStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { SettingsStore } from './settingsStore'
-import { rm, mkdir } from 'fs/promises'
+import { rm, mkdir, writeFile, readFile } from 'fs/promises'
 import { join } from 'path'
 import os from 'os'
 
@@ -108,5 +108,37 @@ describe('SettingsStore', () => {
     await store.setPomodoroSettings(true)
     await store.setPomodoroSettings(false)
     expect(await store.getPomodoroSettings()).toEqual({ enabled: false })
+  })
+
+  it('settings.json が破損していても .bak から復元する', async () => {
+    // 2回書き込んで .bak を作る（1回目が .bak に退避される）
+    await store.setTheme('soda')
+    await store.setElapsedSettings(true, 45)
+    // プライマリを破損させる
+    await writeFile(join(testDir, 'settings.json'), 'INVALID JSON', 'utf-8')
+    // .bak には setTheme('soda') 直後の状態が入っている
+    const themeId = await store.getTheme()
+    expect(themeId).toBe('soda')
+  })
+
+  it('書き込み時に .bak が作成される', async () => {
+    await store.setTheme('berry')
+    await store.setTheme('matcha')
+    const bak = JSON.parse(await readFile(join(testDir, 'settings.json.bak'), 'utf-8'))
+    expect(bak.themeId).toBe('berry')
+  })
+
+  it('並行 set でも全ての変更が反映される（lost-update なし）', async () => {
+    // 異なるフィールドへの並行書き込みが互いを打ち消さないこと
+    await Promise.all([
+      store.setTheme('soda'),
+      store.setElapsedSettings(true, 60),
+      store.setPomodoroSettings(true),
+      store.setWhiteboardSettings(true),
+    ])
+    expect(await store.getTheme()).toBe('soda')
+    expect(await store.getElapsedSettings()).toEqual({ enabled: true, minutes: 60 })
+    expect(await store.getPomodoroSettings()).toEqual({ enabled: true })
+    expect(await store.getWhiteboardSettings()).toEqual({ enabled: true })
   })
 })

--- a/src/main/settingsStore.ts
+++ b/src/main/settingsStore.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, mkdir, rename } from 'fs/promises'
 import { join } from 'path'
+import { createSerialQueue } from './serialQueue'
 
 interface Settings {
   themeId: string
@@ -29,6 +30,17 @@ const DEFAULT_SETTINGS: Settings = {
 
 export class SettingsStore {
   constructor(private dataDir: string) {}
+
+  /** read-modify-write を直列化し、並行 set による lost-update を防ぐ */
+  private enqueue = createSerialQueue()
+
+  /** 現在の設定を読み、mutate を適用して書き戻す（直列化される） */
+  private update(mutate: (s: Settings) => Settings): Promise<void> {
+    return this.enqueue(async () => {
+      const s = await this.readAll()
+      await this.writeAll(mutate(s))
+    })
+  }
 
   private migrateThemeId(id: string): string {
     const map: Record<string, string> = {
@@ -74,19 +86,29 @@ export class SettingsStore {
   }
 
   private async readAll(): Promise<Settings> {
-    try {
-      const content = await readFile(this.filePath, 'utf-8')
+    const parse = (content: string): Settings => {
       const parsed = JSON.parse(content)
       return { ...DEFAULT_SETTINGS, ...parsed, themeId: this.migrateThemeId(parsed.themeId ?? DEFAULT_SETTINGS.themeId) }
+    }
+    try {
+      return parse(await readFile(this.filePath, 'utf-8'))
     } catch {
-      return { ...DEFAULT_SETTINGS }
+      // プライマリが破損/未存在なら .bak から復元を試みる
+      try {
+        return parse(await readFile(`${this.filePath}.bak`, 'utf-8'))
+      } catch {
+        return { ...DEFAULT_SETTINGS }
+      }
     }
   }
 
   private async writeAll(settings: Settings): Promise<void> {
     await mkdir(this.dataDir, { recursive: true })
     const tmpPath = `${this.filePath}.tmp`
+    const backupPath = `${this.filePath}.bak`
     await writeFile(tmpPath, JSON.stringify(settings, null, 2), 'utf-8')
+    // tmp 書き込み成功後に旧ファイルを .bak へ退避してから差し替える（破損耐性）
+    try { await rename(this.filePath, backupPath) } catch { /* ファイル未存在は無視 */ }
     await rename(tmpPath, this.filePath)
   }
 
@@ -96,8 +118,7 @@ export class SettingsStore {
   }
 
   async setTheme(themeId: string): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, themeId })
+    await this.update(s => ({ ...s, themeId }))
   }
 
   async getIdleSettings(): Promise<{ enabled: boolean; minutes: number }> {
@@ -109,8 +130,7 @@ export class SettingsStore {
   }
 
   async setIdleSettings(enabled: boolean, minutes: number): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, idleNotificationEnabled: enabled, idleNotificationMinutes: minutes })
+    await this.update(s => ({ ...s, idleNotificationEnabled: enabled, idleNotificationMinutes: minutes }))
   }
 
   async getElapsedSettings(): Promise<{ enabled: boolean; minutes: number }> {
@@ -122,8 +142,7 @@ export class SettingsStore {
   }
 
   async setElapsedSettings(enabled: boolean, minutes: number): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, elapsedNotificationEnabled: enabled, elapsedNotificationMinutes: minutes })
+    await this.update(s => ({ ...s, elapsedNotificationEnabled: enabled, elapsedNotificationMinutes: minutes }))
   }
 
   async getPomodoroSettings(): Promise<{ enabled: boolean }> {
@@ -132,8 +151,7 @@ export class SettingsStore {
   }
 
   async setPomodoroSettings(enabled: boolean): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, pomodoroEnabled: enabled })
+    await this.update(s => ({ ...s, pomodoroEnabled: enabled }))
   }
 
   async isSetupCompleted(): Promise<boolean> {
@@ -142,8 +160,7 @@ export class SettingsStore {
   }
 
   async completeSetup(): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, setupCompleted: true })
+    await this.update(s => ({ ...s, setupCompleted: true }))
   }
 
   async getWhiteboardSettings(): Promise<{ enabled: boolean }> {
@@ -152,8 +169,7 @@ export class SettingsStore {
   }
 
   async setWhiteboardSettings(enabled: boolean): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, whiteboardEnabled: enabled })
+    await this.update(s => ({ ...s, whiteboardEnabled: enabled }))
   }
 
   async getSlackSettings(): Promise<{ projectCode: string; projectName: string }> {
@@ -165,7 +181,6 @@ export class SettingsStore {
   }
 
   async setSlackSettings(projectCode: string, projectName: string): Promise<void> {
-    const s = await this.readAll()
-    await this.writeAll({ ...s, slackProjectCode: projectCode, slackProjectName: projectName })
+    await this.update(s => ({ ...s, slackProjectCode: projectCode, slackProjectName: projectName }))
   }
 }


### PR DESCRIPTION
監査の中・優先2件。メインプロセスのデータ層を堅牢化。

## #1 書き込みの直列化 + 破損耐性
- `serialQueue.ts` を追加し、`SessionStore`/`SettingsStore` の read-modify-write を直列化。並行 IPC での lost-update を防止。
- `SettingsStore` に `tmp→.bak→rename` の atomic write と `.bak` 復元を追加（`SessionStore` と同等に）。

## #2 入力検証（パストラバーサル / openExternal）
- `SessionStore` で `yearMonth`（`YYYY-MM`）と `session.date`（`YYYY-MM-DD`）を検証し、ファイルパス連結時のトラバーサルを拒否。
- `shell:openUrl` を `http(s)` のみ許可に制限。

## テスト
- 新規6件追加（パストラバーサル拒否・並行save/setのlost-update無し・settings .bak復元）
- typecheck パス / 全テスト 500 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)