### PR TITLE
fix: Lambda の勤怠レスポンス正規化と全fetchのタイムアウト（監査・中 #5/#4）

### DIFF
--- a/lambda/src/attendanceSend.test.ts
+++ b/lambda/src/attendanceSend.test.ts
@@ -43,24 +43,25 @@ describe('resolveUserName', () => {
 describe('postAttendance', () => {
   const OPTS = { apiUrl: 'https://kintai.test/api/receive_slack_post', apiKey: 'KEY1' }
 
-  it('勤怠 API に form POST し status と body を透過する', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200, text: () => Promise.resolve('{}') })
+  it('勤怠 API に form POST し ok/status/body と timeout signal を付ける', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('{}') })
     vi.stubGlobal('fetch', fetchMock)
     const result = await postAttendance('kanayama', '勤怠テキスト', OPTS)
-    expect(result).toEqual({ status: 200, body: '{}' })
+    expect(result).toEqual({ ok: true, status: 200, body: '{}' })
     const [url, init] = fetchMock.mock.calls[0]
     expect(url).toBe('https://kintai.test/api/receive_slack_post?key=KEY1')
+    expect(init.signal).toBeInstanceOf(AbortSignal)
     const params = new URLSearchParams(String(init.body))
     expect(params.get('user_name')).toBe('kanayama')
     expect(params.get('text')).toBe('勤怠テキスト')
   })
 
-  it('上流の 400 もそのまま透過する', async () => {
+  it('上流の 400 は ok:false で返す（body は診断用に保持）', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      status: 400, text: () => Promise.resolve('{"error_message":"format"}'),
+      ok: false, status: 400, text: () => Promise.resolve('{"error_message":"format"}'),
     }))
     expect(await postAttendance('a', 't', OPTS))
-      .toEqual({ status: 400, body: '{"error_message":"format"}' })
+      .toEqual({ ok: false, status: 400, body: '{"error_message":"format"}' })
   })
 
   it('ネットワークエラーは throw せず error を返す', async () => {

--- a/lambda/src/attendanceSend.ts
+++ b/lambda/src/attendanceSend.ts
@@ -1,4 +1,5 @@
 import type { SessionClaims } from './sessionJwt'
+import { FETCH_TIMEOUT_MS } from './http'
 
 const MAX_TEXT_LENGTH = 2000
 
@@ -38,19 +39,24 @@ export function resolveUserName(
   return claims.handle ?? claims.name
 }
 
-/** 勤怠 API に送信し、status と body をそのまま返す。ネットワークエラーは {error} */
+/**
+ * 勤怠 API に送信する。ok（2xx か）と status、診断用の body を返す。
+ * body は呼び出し側でログにのみ使い、クライアントへは透過しない（内部情報の漏えい防止）。
+ * ネットワークエラー・タイムアウトは {error}。
+ */
 export async function postAttendance(
   userName: string,
   text: string,
   opts: { apiUrl: string; apiKey: string }
-): Promise<{ status: number; body: string } | { error: string }> {
+): Promise<{ ok: boolean; status: number; body: string } | { error: string }> {
   try {
     const res = await fetch(`${opts.apiUrl}?key=${opts.apiKey}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({ user_name: userName, text }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })
-    return { status: res.status, body: await res.text() }
+    return { ok: res.ok, status: res.status, body: await res.text() }
   } catch (e) {
     return { error: `network: ${e instanceof Error ? e.message : 'unknown'}` }
   }

--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -192,30 +192,31 @@ describe('POST /api/attendance.send', () => {
     return makeEvent('/api/attendance.send', {}, headers, { method: 'POST', body })
   }
 
-  it('JWT の name を user_name にして勤怠 API の応答を透過する', async () => {
-    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ status: 200, body: '{}' })
+  it('JWT の name を user_name にして成功時は 200 {ok:true} に正規化する', async () => {
+    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ ok: true, status: 200, body: '{}' })
     const token = issueSessionJwt({ sub: 'U1', name: 'Ryota Kanayama', team: 'T999' }, 'test-secret')
     const res = await handler(makeAttEvent(BODY, token))
     expect(res.statusCode).toBe(200)
-    expect(res.body).toBe('{}')
+    expect(JSON.parse(res.body!)).toEqual({ ok: true })
     expect(attendanceSend.postAttendance).toHaveBeenCalledWith(
       'Ryota Kanayama', '勤怠\n8:30 17:30 60', { apiUrl: 'https://kintai.test/api', apiKey: 'AKEY' }
     )
   })
 
   it('対応表にある sub は登録名で送る', async () => {
-    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ status: 200, body: '{}' })
+    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ ok: true, status: 200, body: '{}' })
     const token = issueSessionJwt({ sub: 'U_OVR', name: '別名', team: 'T999' }, 'test-secret')
     await handler(makeAttEvent(BODY, token))
     expect(vi.mocked(attendanceSend.postAttendance).mock.calls[0][0]).toBe('override-name')
   })
 
-  it('上流の 400 を透過する', async () => {
-    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ status: 400, body: '{"error_message":"x"}' })
+  it('上流の非2xx は生 body を返さず 502 に正規化する', async () => {
+    vi.mocked(attendanceSend.postAttendance).mockResolvedValue({ ok: false, status: 400, body: '{"error_message":"x"}' })
     const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T999' }, 'test-secret')
     const res = await handler(makeAttEvent(BODY, token))
-    expect(res.statusCode).toBe(400)
-    expect(res.body).toBe('{"error_message":"x"}')
+    expect(res.statusCode).toBe(502)
+    expect(res.body).not.toContain('error_message')
+    expect(JSON.parse(res.body!)).toEqual({ error: 'attendance upstream error', status: 400 })
   })
 
   it('JWT 無しは 401、text 不正は 400、ネットワークエラーは 502', async () => {

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -140,12 +140,12 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
       console.error('attendance.send failed:', result.error)
       return json(502, { error: 'attendance api error' })
     }
-    // 勤怠 API の応答をそのまま返す（アプリの結果表示用）
-    return {
-      statusCode: result.status,
-      headers: { 'Content-Type': 'application/json; charset=utf-8' },
-      body: result.body,
+    if (!result.ok) {
+      // 上流の非 2xx は内部情報（生 body）を返さず正規化する。body はログのみ。
+      console.error('attendance.send upstream non-2xx:', result.status, result.body)
+      return json(502, { error: 'attendance upstream error', status: result.status })
     }
+    return json(200, { ok: true })
   }
 
   if (

--- a/lambda/src/http.ts
+++ b/lambda/src/http.ts
@@ -1,0 +1,7 @@
+/**
+ * 外部 API 呼び出しのタイムアウト（ms）。
+ * Lambda 自体の timeout（10s）より十分短く設定し、ハングした接続が
+ * 同時実行枠を占有し続けて他リクエストをスロットルさせるのを防ぐ。
+ * /auth/callback は Slack を2回逐次呼ぶため、2回分でも 10s を割らない値にする。
+ */
+export const FETCH_TIMEOUT_MS = 4000

--- a/lambda/src/slackOidc.ts
+++ b/lambda/src/slackOidc.ts
@@ -1,3 +1,5 @@
+import { FETCH_TIMEOUT_MS } from './http'
+
 export interface SlackIdentity {
   sub: string
   name: string
@@ -60,6 +62,7 @@ export async function fetchSlackIdentity(opts: {
         code: opts.code,
         redirect_uri: opts.redirectUri,
       }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })
     const token = (await tokenRes.json()) as OAuthAccessResponse
     const sub = token.authed_user?.id
@@ -71,7 +74,10 @@ export async function fetchSlackIdentity(opts: {
 
     const usersRes = await fetch(
       `https://slack.com/api/users.info?user=${encodeURIComponent(sub)}`,
-      { headers: { Authorization: `Bearer ${accessToken}` } }
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      }
     )
     const usersInfo = (await usersRes.json()) as UsersInfoResponse
     if (!usersInfo.ok || !usersInfo.user) {

--- a/lambda/src/slackPost.ts
+++ b/lambda/src/slackPost.ts
@@ -1,3 +1,5 @@
+import { FETCH_TIMEOUT_MS } from './http'
+
 export type TeleworkKind = 'telework_start' | 'telework_end'
 
 export interface SlackPostRequest {
@@ -47,6 +49,7 @@ export async function postToSlack(
         Authorization: `Bearer ${opts.botToken}`,
       },
       body: JSON.stringify({ channel: opts.channelId, text }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })
     const result = (await res.json()) as { ok: boolean; error?: string }
     if (!result.ok) return { error: result.error ?? 'unknown' }

--- a/lambda/src/whiteboardPost.ts
+++ b/lambda/src/whiteboardPost.ts
@@ -1,3 +1,5 @@
+import { FETCH_TIMEOUT_MS } from './http'
+
 // magnet_id: ホワイトボード上の状態を示す値（旧 src/main/integrations/whiteboard.ts と同じ）
 const MAGNET_TELEWORK = 2
 const MAGNET_LEAVE = 3
@@ -20,6 +22,7 @@ export async function postWhiteboard(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ magnet_id: magnetId, email }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })
     if (!magnet.ok) return { error: `magnet: ${magnet.status}` }
 
@@ -27,6 +30,7 @@ export async function postWhiteboard(
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({ come_to_the_office: String(comeToOffice), email }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })
     if (!attendance.ok) return { error: `attendance: ${attendance.status}` }
     return { ok: true }


### PR DESCRIPTION
監査の中・Lambda 2件。

## #5 勤怠レスポンスの正規化
- 勤怠 API の生 body をクライアントへ透過するのをやめ、成功→`200 {ok:true}`、上流非2xx→`502 {error, status}` に正規化。内部エラー情報の漏えいと上流ステータスへの結合を解消。
- 生 body は診断用にサーバログ（CloudWatch）にのみ出力。
- レンダラーは `ok`/`status` のみ参照し body を表示に使っていないため UX 変更なし。

## #4 fetch タイムアウト
- 全外部 fetch（Slack `oauth.v2.access`/`users.info`、`chat.postMessage`、勤怠、ホワイトボード×2）に `AbortSignal.timeout`（`http.ts` の共通定数 4000ms）を付与。ハングした接続が Lambda の同時実行枠を占有し続けるのを防ぐ。`/auth/callback` の逐次2回でも 10s を割らない値。

## テスト
- typecheck パス / 全テスト 500 件パス / lambda ビルド確認
- 勤怠の正規化・timeout signal 付与をテストで検証（既存の透過前提テストを新契約に更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)