### PR TITLE
fix: 日付ソースの統一・customOrder同期・勤怠差分の調整（監査・中 #6/#7）

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -82,10 +82,10 @@ function PopoverView() {
         <div className={styles.page} style={{ display: currentPage === 'timer' ? 'flex' : 'none' }}>
           <TimerPage sessions={sessions} />
         </div>
-        {currentPage === 'calendar' && <CalendarPage todaySessions={sessions.todaySessions} />}
+        {currentPage === 'calendar' && <CalendarPage todaySessions={sessions.todaySessions} today={sessions.today} />}
         {currentPage === 'attendance' && (
           <div className={styles.attendanceContent}>
-            <AttendanceReport sessions={sessions.todaySessions} />
+            <AttendanceReport sessions={sessions.todaySessions} today={sessions.today} />
           </div>
         )}
       </main>
@@ -121,7 +121,7 @@ function PopoverView() {
 export function TimerPage({ sessions }: { sessions: SessionsState }) {
   const { isRunning, elapsedSeconds, baseSeconds, fillSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime } = useTimer()
   const workday = useWorkday(sessions.today)
-  const suggestions = useSuggestions(sessions.todaySessions)
+  const suggestions = useSuggestions(sessions.todaySessions, sessions.today)
   const [activeTimerName, setActiveTimerName] = useState('')
   const [activeTimerProjectCode, setActiveTimerProjectCode] = useState('')
   const [activeTimerWorkCategory, setActiveTimerWorkCategory] = useState('')

--- a/src/renderer/src/components/Calendar/CalendarPage.tsx
+++ b/src/renderer/src/components/Calendar/CalendarPage.tsx
@@ -6,11 +6,12 @@ import { DayDetail } from './DayDetail'
 
 interface Props {
   todaySessions?: Session[]
+  today: string
 }
 
-export function CalendarPage({ todaySessions = [] }: Props) {
+export function CalendarPage({ todaySessions = [], today }: Props) {
   const cal = useCalendar()
-  const suggestions = useSuggestions(todaySessions)
+  const suggestions = useSuggestions(todaySessions, today)
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden font-[var(--font-family)]">
       {cal.selectedDate ? (

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -8,14 +8,15 @@ import { Check, Copy, SendDiagonal } from 'iconoir-react'
 
 interface Props {
   sessions: Session[]
+  today: string
 }
 
 const actionButton =
   'flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-[8px] border-0 p-[9px] text-[13px] font-semibold text-white transition-all hover:-translate-y-px'
 
-export function AttendanceReport({ sessions }: Props) {
+export function AttendanceReport({ sessions, today }: Props) {
   const { breakMinutes, setBreakMinutes, text, canSend, copied, sending, sendResult, copy, send } =
-    useAttendanceReport(sessions)
+    useAttendanceReport(sessions, today)
 
   return (
     <Card className="flex min-h-0 flex-1 flex-col rounded-xl bg-[var(--glass-bg)] p-3 [backdrop-filter:blur(12px)]">

--- a/src/renderer/src/components/Popover/SessionList.test.tsx
+++ b/src/renderer/src/components/Popover/SessionList.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SessionList } from './SessionList'
@@ -55,6 +55,32 @@ describe('SessionList — 合計時間表示', () => {
     const session = makeSession({ totalTime: 76 })
     render(<SessionList sessions={[session]} />)
     expect(screen.getAllByText(/76分/).length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('SessionList — customOrder 同期', () => {
+  const KEY = 'sessionOrder.2026-02-25'
+  afterEach(() => localStorage.removeItem(KEY))
+
+  it('削除済み（存在しない）IDを localStorage から除去する', async () => {
+    localStorage.setItem(KEY, JSON.stringify(['2', '1', 'STALE-DELETED']))
+    render(<SessionList sessions={sessions} today="2026-02-25" />)
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(['2', '1'])
+    })
+  })
+
+  it('customOrder に無い新規セッションを末尾に取り込む', async () => {
+    localStorage.setItem(KEY, JSON.stringify(['2', '1']))
+    const withNew = [
+      ...sessions,
+      makeSession({ id: '3', taskId: '3', name: '新規作業',
+        times: [{ startTime: '2026-02-25T12:00:00', endTime: '2026-02-25T12:10:00' }], totalTime: 10 }),
+    ]
+    render(<SessionList sessions={withNew} today="2026-02-25" />)
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(['2', '1', '3'])
+    })
   })
 })
 

--- a/src/renderer/src/components/Popover/SessionList.tsx
+++ b/src/renderer/src/components/Popover/SessionList.tsx
@@ -61,6 +61,19 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
     setCustomOrder(dailyStore.getSessionOrder(todayKey))
   }, [todayKey])
 
+  // セッションの追加/削除に customOrder を追従させる。
+  // orderSessions の結果（削除IDを除き、新規IDを末尾に取り込んだ順）で正規化して
+  // 表示と localStorage を一致させ、死んだIDが溜まるのを防ぐ。
+  useEffect(() => {
+    if (!customOrder) return
+    const synced = orderSessions(sessions, customOrder).map(s => s.id)
+    const changed = synced.length !== customOrder.length || synced.some((id, i) => id !== customOrder[i])
+    if (changed) {
+      setCustomOrder(synced)
+      dailyStore.setSessionOrder(todayKey, synced)
+    }
+  }, [sessions, customOrder, todayKey])
+
   const sortedSessions = orderSessions(sessions, customOrder)
   const totalMinutes = sessions.reduce((acc, s) => acc + s.totalTime, 0)
   const { page, totalPages, pagedItems: pagedSessions, animKey, changePage } = usePagination(sortedSessions, 4)

--- a/src/renderer/src/domain/attendance.test.ts
+++ b/src/renderer/src/domain/attendance.test.ts
@@ -35,12 +35,32 @@ describe('buildAttendanceText', () => {
     expect(result).toBe('勤怠\n08:37 18:40 60\nZZ 社内MTG 打合せ 180\nZZ 1on1 打合せ 363')
   })
 
-  it('タイマー合計が実労働時間以上なら差分を加算しない', () => {
+  it('タイマー合計が実労働時間と同じなら変化しない（差分0）', () => {
     // 勤務: 09:00〜12:00 = 180分, 休憩0分 → 実労働180分
     // タイマー合計: 180分, 差分: 0分
     const sessions = [makeSession()]
     const result = buildAttendanceText(sessions, '09:00', '12:00', 0)
     expect(result).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 180')
+  })
+
+  it('タイマー合計が実労働時間を超える場合は最後のタスクから差し引いて合計を一致させる', () => {
+    // 勤務: 09:00〜12:00 = 180分, 休憩0分 → 実労働180分
+    // タイマー合計: 200分, 差分: -20分 → 200-20=180
+    const sessions = [makeSession({ totalTime: 200 })]
+    const result = buildAttendanceText(sessions, '09:00', '12:00', 0)
+    expect(result).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 180')
+  })
+
+  it('マイナス差分が最後のタスクを超える場合は手前のタスクへ繰り越す', () => {
+    // 勤務: 09:00〜12:00 = 180分, 休憩30分 → 実労働150分
+    // タイマー合計: 180+60=240分, 差分: -90分
+    // 末尾 1on1(60) → 60-90=-30 で 0 にして除外、残り -30 を 社内MTG(180) へ → 150
+    const sessions = [
+      makeSession({ id: 'a', taskId: 't1', name: '社内MTG', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 180 }),
+      makeSession({ id: 'b', taskId: 't2', name: '1on1', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 60 }),
+    ]
+    const result = buildAttendanceText(sessions, '09:00', '12:00', 30)
+    expect(result).toBe('勤怠\n09:00 12:00 30\nZZ 社内MTG 打合せ 150')
   })
 
   it('totalTimeが0のセッションはスキップする', () => {

--- a/src/renderer/src/domain/attendance.ts
+++ b/src/renderer/src/domain/attendance.ts
@@ -39,19 +39,32 @@ export function buildAttendanceText(
     }
   }
 
-  const groups = Array.from(map.values()).filter(g => g.totalMinutes > 0)
+  let groups = Array.from(map.values()).filter(g => g.totalMinutes > 0)
 
-  // 勤務時間から休憩を引いた実労働時間と、タイマー合計の差分を最後のタスクに加算
+  // 勤務時間から休憩を引いた実労働時間と、タイマー合計の差分を末尾のタスクから順に調整し、
+  // 報告合計を実労働時間に一致させる。
+  // - プラス差分（計測しきれなかった分）: 最後のタスクに加算
+  // - マイナス差分（タイマー超過）: 最後のタスクから差し引き、負になる分は手前へ繰り越す
   if (groups.length > 0 && workStart && workEnd) {
     const startMin = parseHHMM(workStart)
     const endMin = parseHHMM(workEnd)
     if (startMin != null && endMin != null) {
       const actualWorkMinutes = endMin - startMin - breakMinutes
       const timerTotal = groups.reduce((sum, g) => sum + g.totalMinutes, 0)
-      const diff = actualWorkMinutes - timerTotal
-      if (diff > 0) {
-        groups[groups.length - 1].totalMinutes += diff
+      let diff = actualWorkMinutes - timerTotal
+      for (let i = groups.length - 1; i >= 0 && diff !== 0; i--) {
+        const adjusted = groups[i].totalMinutes + diff
+        if (adjusted >= 0) {
+          groups[i].totalMinutes = adjusted
+          diff = 0
+        } else {
+          // このタスクで吸収しきれないマイナス分を手前へ繰り越す
+          diff = adjusted
+          groups[i].totalMinutes = 0
+        }
       }
+      // 調整で 0 になったタスクは報告から除く
+      groups = groups.filter(g => g.totalMinutes > 0)
     }
   }
 

--- a/src/renderer/src/hooks/useAttendanceReport.test.ts
+++ b/src/renderer/src/hooks/useAttendanceReport.test.ts
@@ -26,42 +26,42 @@ beforeEach(() => {
 describe('useAttendanceReport — 送信結果の分類', () => {
   it('成功時は success', async () => {
     send.mockResolvedValue({ ok: true, status: 200, body: '{}' })
-    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    const { result } = renderHook(() => useAttendanceReport([makeSession()], '2026-06-12'))
     await act(async () => { await result.current.send() })
     expect(result.current.sendResult).toBe('success')
   })
 
   it('未サインイン（status 0）は auth', async () => {
     send.mockResolvedValue({ ok: false, status: 0, body: 'Slack サインインが必要です（設定 > アカウント）' })
-    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    const { result } = renderHook(() => useAttendanceReport([makeSession()], '2026-06-12'))
     await act(async () => { await result.current.send() })
     expect(result.current.sendResult).toBe('auth')
   })
 
   it('セッション切れ（status 401）は auth', async () => {
     send.mockResolvedValue({ ok: false, status: 401, body: '{"error":"unauthorized"}' })
-    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    const { result } = renderHook(() => useAttendanceReport([makeSession()], '2026-06-12'))
     await act(async () => { await result.current.send() })
     expect(result.current.sendResult).toBe('auth')
   })
 
   it('勤怠 API の入力不備（status 400）は error', async () => {
     send.mockResolvedValue({ ok: false, status: 400, body: '{"error_message":"format"}' })
-    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    const { result } = renderHook(() => useAttendanceReport([makeSession()], '2026-06-12'))
     await act(async () => { await result.current.send() })
     expect(result.current.sendResult).toBe('error')
   })
 
   it('上流エラー（status 502）は error', async () => {
     send.mockResolvedValue({ ok: false, status: 502, body: 'attendance api error' })
-    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    const { result } = renderHook(() => useAttendanceReport([makeSession()], '2026-06-12'))
     await act(async () => { await result.current.send() })
     expect(result.current.sendResult).toBe('error')
   })
 
   it('例外時は error', async () => {
     send.mockRejectedValue(new Error('boom'))
-    const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+    const { result } = renderHook(() => useAttendanceReport([makeSession()], '2026-06-12'))
     await act(async () => { await result.current.send() })
     expect(result.current.sendResult).toBe('error')
   })
@@ -70,7 +70,7 @@ describe('useAttendanceReport — 送信結果の分類', () => {
     vi.useFakeTimers()
     try {
       send.mockResolvedValue({ ok: false, status: 0, body: 'x' })
-      const { result } = renderHook(() => useAttendanceReport([makeSession()]))
+      const { result } = renderHook(() => useAttendanceReport([makeSession()], '2026-06-12'))
       await act(async () => { await result.current.send() })
       expect(result.current.sendResult).toBe('auth')
       act(() => { vi.advanceTimersByTime(3000) })

--- a/src/renderer/src/hooks/useAttendanceReport.ts
+++ b/src/renderer/src/hooks/useAttendanceReport.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { Session } from '../types/session'
-import { formatLocalDate, orderSessions } from '../../../shared/sessionUtils'
+import { orderSessions } from '../../../shared/sessionUtils'
 import { dailyStore } from '../dailyStore'
 import { buildAttendanceText, isValidWorkTime } from '../domain/attendance'
 import { attendanceRepository } from '../repositories/attendanceRepository'
@@ -19,13 +19,13 @@ export interface AttendanceReportState {
 }
 
 /** 勤怠レポート画面のオーケストレーション。domain / repository を組み合わせ state を持つ。 */
-export function useAttendanceReport(sessions: Session[]): AttendanceReportState {
+export function useAttendanceReport(sessions: Session[], today: string): AttendanceReportState {
   const [breakMinutes, setBreakMinutes] = useState(60)
   const [copied, setCopied] = useState(false)
   const [sending, setSending] = useState(false)
   const [sendResult, setSendResult] = useState<'success' | 'auth' | 'error' | null>(null)
 
-  const todayKey = formatLocalDate(Date.now())
+  const todayKey = today
   const workStart = dailyStore.getWorkStart(todayKey)
   const workEnd = dailyStore.getWorkEnd(todayKey)
   const orderedSessions = orderSessions(sessions, dailyStore.getSessionOrder(todayKey))

--- a/src/renderer/src/hooks/useSessions.ts
+++ b/src/renderer/src/hooks/useSessions.ts
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { Session } from '../types/session'
-import { formatLocalDate } from '../../../shared/sessionUtils'
 import { appendRunningInterval, createManualSession, hasRunningInterval } from '../domain/session'
 import { sessionRepository } from '../repositories/sessionRepository'
 import { attendanceRepository } from '../repositories/attendanceRepository'
+import { useToday } from './useToday'
 
 export interface SessionsState {
   today: string
@@ -22,20 +22,11 @@ export interface SessionsState {
   startTelework: () => Promise<void>
 }
 
-/** 今日のセッション一覧と変更操作を統括する。フォーカス復帰時の日付更新も担う。 */
+/** 今日のセッション一覧と変更操作を統括する。日付は useToday（単一ソース）に従う。 */
 export function useSessions(): SessionsState {
   const [todaySessions, setTodaySessions] = useState<Session[]>([])
-  const [today, setToday] = useState(() => formatLocalDate(Date.now()))
-  const [yearMonth, setYearMonth] = useState(() => formatLocalDate(Date.now()).slice(0, 7))
-
-  useEffect(() => {
-    const handleFocus = (): void => {
-      setToday(formatLocalDate(Date.now()))
-      setYearMonth(formatLocalDate(Date.now()).slice(0, 7))
-    }
-    window.addEventListener('focus', handleFocus)
-    return () => window.removeEventListener('focus', handleFocus)
-  }, [])
+  const today = useToday()
+  const yearMonth = today.slice(0, 7)
 
   useEffect(() => {
     sessionRepository.list(yearMonth).then(sessions => {

--- a/src/renderer/src/hooks/useSuggestions.test.ts
+++ b/src/renderer/src/hooks/useSuggestions.test.ts
@@ -40,7 +40,7 @@ describe('useSuggestions', () => {
       return [makeSession({ id: 'b', name: '先月の作業', projectCode: 'P002' })]
     })
 
-    const { result } = renderHook(() => useSuggestions([]))
+    const { result } = renderHook(() => useSuggestions([], formatLocalDate(Date.now())))
 
     await waitFor(() => {
       expect(result.current.names.map(n => n.name)).toEqual(
@@ -61,7 +61,7 @@ describe('useSuggestions', () => {
       makeSession({ id: 'a', name: '保存済みの作業', projectCode: '新コード', date: today }),
     ]
 
-    const { result } = renderHook(() => useSuggestions(todaySessions))
+    const { result } = renderHook(() => useSuggestions(todaySessions, today))
 
     await waitFor(() => {
       expect(result.current.projectCodes).toEqual(['新コード'])

--- a/src/renderer/src/hooks/useSuggestions.ts
+++ b/src/renderer/src/hooks/useSuggestions.ts
@@ -1,15 +1,14 @@
 import { useState, useEffect, useMemo } from 'react'
 import type { Session } from '../types/session'
-import { formatLocalDate } from '../../../shared/sessionUtils'
 import { buildSuggestions, previousYearMonth, type Suggestions } from '../domain/suggestions'
 import { sessionRepository } from '../repositories/sessionRepository'
 
 /** 今月・先月のセッションと当日セッション（メモリ上の最新）から入力候補を生成する */
-export function useSuggestions(todaySessions: Session[]): Suggestions {
+export function useSuggestions(todaySessions: Session[], today: string): Suggestions {
   const [pastSessions, setPastSessions] = useState<Session[]>([])
+  const yearMonth = today.slice(0, 7)
 
   useEffect(() => {
-    const yearMonth = formatLocalDate(Date.now()).slice(0, 7)
     Promise.all([
       sessionRepository.list(yearMonth),
       sessionRepository.list(previousYearMonth(yearMonth)),
@@ -17,12 +16,11 @@ export function useSuggestions(todaySessions: Session[]): Suggestions {
       .then(([current, previous]) => setPastSessions([...current, ...previous]))
       // IPC 障害時は候補なしのまま続行する
       .catch(() => {})
-  }, [])
+  }, [yearMonth])
 
   return useMemo(() => {
-    const today = formatLocalDate(Date.now())
     // 当日分はファイルより todaySessions を優先する（編集・追加が即反映される）
     const merged = [...pastSessions.filter(s => s.date !== today), ...todaySessions]
     return buildSuggestions(merged)
-  }, [pastSessions, todaySessions])
+  }, [pastSessions, todaySessions, today])
 }

--- a/src/renderer/src/hooks/useToday.test.ts
+++ b/src/renderer/src/hooks/useToday.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useToday } from './useToday'
+
+describe('useToday', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('初期値は今日の日付（YYYY-MM-DD）', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 13, 12, 0, 0))
+    const { result } = renderHook(() => useToday())
+    expect(result.current).toBe('2026-06-13')
+  })
+
+  it('深夜0時を跨ぐとタイマーで日付が更新される', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 13, 23, 59, 50))
+    const { result } = renderHook(() => useToday())
+    expect(result.current).toBe('2026-06-13')
+    // 翌日 00:00:01 のタイマー発火まで進める
+    act(() => { vi.advanceTimersByTime(13 * 1000) })
+    expect(result.current).toBe('2026-06-14')
+  })
+
+  it('focus 復帰時に日付を再評価する', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 13, 12, 0, 0))
+    const { result } = renderHook(() => useToday())
+    expect(result.current).toBe('2026-06-13')
+    // ポップオーバーを開いたまま日付が変わった状況を再現
+    vi.setSystemTime(new Date(2026, 5, 14, 9, 0, 0))
+    act(() => { window.dispatchEvent(new Event('focus')) })
+    expect(result.current).toBe('2026-06-14')
+  })
+})

--- a/src/renderer/src/hooks/useToday.ts
+++ b/src/renderer/src/hooks/useToday.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react'
+import { formatLocalDate } from '../../../shared/sessionUtils'
+
+/**
+ * ローカルの「今日」(YYYY-MM-DD) を返す単一ソース。
+ * 日付が変わると自動更新する（深夜0時のタイマー・フォーカス復帰・タブ可視化）。
+ * 各 hook が個別に formatLocalDate(Date.now()) を評価して二系統化するのを防ぐ。
+ */
+export function useToday(): string {
+  const [today, setToday] = useState(() => formatLocalDate(Date.now()))
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>
+
+    const scheduleNextMidnight = (): void => {
+      const now = new Date()
+      // 翌日 00:00:01（日付境界を確実に跨いだ直後）に発火させる
+      const next = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 1)
+      clearTimeout(timer)
+      timer = setTimeout(sync, next.getTime() - now.getTime())
+    }
+
+    function sync(): void {
+      const current = formatLocalDate(Date.now())
+      setToday(prev => (prev === current ? prev : current))
+      scheduleNextMidnight()
+    }
+
+    const onVisible = (): void => { if (!document.hidden) sync() }
+
+    window.addEventListener('focus', sync)
+    document.addEventListener('visibilitychange', onVisible)
+    scheduleNextMidnight()
+
+    return () => {
+      clearTimeout(timer)
+      window.removeEventListener('focus', sync)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [])
+
+  return today
+}


### PR DESCRIPTION
監査の中・レンダラー2件（#6, #7）。挙動変更を含むため要確認。

## #6 日付ソースの単一化
- `useToday` フックを新設。「今日」を単一ソース化し、深夜0時のタイマー・`focus`・`visibilitychange` で自動更新。
- `useSessions`/`useSuggestions`/`useAttendanceReport` が個別に `Date.now()` を評価していたのを `today` 受け渡しに統一。日跨ぎ時の不整合を解消。

## #7a customOrder の追加/削除同期
- `SessionList` で、セッションの追加/削除に customOrder を追従。削除済みIDを除去し新規IDを取り込み、表示と localStorage を一致させる（死んだIDの蓄積防止）。

## #7b 勤怠差分の調整（※送信内容に影響・ユーザー確認済み）
- 端数差分を末尾タスクから順に適用し、報告合計を実労働時間に一致させる。
- プラス差分（計測漏れ）→ 最後のタスクに加算（従来通り）。
- マイナス差分（タイマー超過）→ 差し引いて過報告を防止（新規）。負になる分は手前のタスクへ繰り越し。

## テスト
- typecheck パス / 全テスト 507 件パス（+5: useToday×3、customOrder同期×2、勤怠マイナス差分×2 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)