### PR TITLE
fix: OAuth state を HMAC 署名し /auth/start↔/auth/callback を結びつける（監査・中 #3）

### DIFF
--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { handler } from './handler'
 import { issueSessionJwt } from './sessionJwt'
+import { signState, verifyState } from './stateSign'
 import * as slackOidc from './slackOidc'
 import * as slackPost from './slackPost'
 import * as attendanceSend from './attendanceSend'
@@ -28,6 +29,8 @@ vi.mock('./whiteboardPost', async (importOriginal) => {
 })
 
 const STATE = 'a'.repeat(32)
+// /auth/callback には署名済み state が渡される（/auth/start が発行した形式）
+const SIGNED = signState(STATE, 'test-secret')
 
 function makeEvent(
   rawPath: string,
@@ -66,12 +69,15 @@ beforeEach(() => {
 })
 
 describe('GET /auth/start', () => {
-  it('Slack 認可 URL へ 302 リダイレクトする', async () => {
+  it('Slack 認可 URL へ 302 リダイレクトし、state は署名済み（検証で元の nonce に戻る）', async () => {
     const res = await handler(makeEvent('/auth/start', { state: STATE }))
     expect(res.statusCode).toBe(302)
     const url = new URL(res.headers!.Location)
     expect(url.origin + url.pathname).toBe('https://slack.com/oauth/v2/authorize')
-    expect(url.searchParams.get('state')).toBe(STATE)
+    const sentState = url.searchParams.get('state')!
+    // 生の nonce ではなく署名済み state を渡す
+    expect(sentState).not.toBe(STATE)
+    expect(verifyState(sentState, 'test-secret')).toBe(STATE)
     expect(url.searchParams.get('redirect_uri')).toBe(
       'https://abc.lambda-url.ap-northeast-1.on.aws/auth/callback'
     )
@@ -84,35 +90,45 @@ describe('GET /auth/start', () => {
 })
 
 describe('GET /auth/callback', () => {
-  it('本人確認 OK なら JWT 付きで juice:// へ 302', async () => {
+  it('本人確認 OK なら JWT 付きで juice:// へ 302（state は元の nonce に戻る）', async () => {
+    vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({
+      sub: 'U123', name: '金山', teamId: 'T999',
+    })
+    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: SIGNED }))
+    expect(res.statusCode).toBe(302)
+    const url = new URL(res.headers!.Location)
+    expect(url.protocol).toBe('juice:')
+    // アプリが照合できるよう、署名前の nonce を返す
+    expect(url.searchParams.get('state')).toBe(STATE)
+    expect(url.searchParams.get('token')!.split('.')).toHaveLength(3)
+  })
+
+  it('署名されていない（生の）state は 400 で拒否する', async () => {
     vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({
       sub: 'U123', name: '金山', teamId: 'T999',
     })
     const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: STATE }))
-    expect(res.statusCode).toBe(302)
-    const url = new URL(res.headers!.Location)
-    expect(url.protocol).toBe('juice:')
-    expect(url.searchParams.get('state')).toBe(STATE)
-    expect(url.searchParams.get('token')!.split('.')).toHaveLength(3)
+    expect(res.statusCode).toBe(400)
+    expect(slackOidc.fetchSlackIdentity).not.toHaveBeenCalled()
   })
 
   it('別ワークスペースのユーザーは 400 エラーページ', async () => {
     vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({
       sub: 'U123', name: 'x', teamId: 'T_OTHER',
     })
-    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: STATE }))
+    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: SIGNED }))
     expect(res.statusCode).toBe(400)
     expect(res.body).toContain('許可されていないワークスペース')
   })
 
   it('交換失敗は 400 エラーページ', async () => {
     vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({ error: 'token: bad' })
-    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: STATE }))
+    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: SIGNED }))
     expect(res.statusCode).toBe(400)
   })
 
   it('code が無ければ 400', async () => {
-    const res = await handler(makeEvent('/auth/callback', { state: STATE }))
+    const res = await handler(makeEvent('/auth/callback', { state: SIGNED }))
     expect(res.statusCode).toBe(400)
   })
 
@@ -120,7 +136,7 @@ describe('GET /auth/callback', () => {
     vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({
       sub: 'U123', name: '金山', teamId: 'T999', handle: 'kanayama',
     })
-    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: STATE }))
+    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: SIGNED }))
     const url = new URL(res.headers!.Location)
     const token = url.searchParams.get('token')!
     const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf-8'))

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -3,6 +3,7 @@ import { issueSessionJwt, verifySessionJwt } from './sessionJwt'
 import { buildTeleworkMessage, parseSlackPostRequest, postToSlack } from './slackPost'
 import { parseAttendanceRequest, postAttendance, resolveUserName } from './attendanceSend'
 import { postWhiteboard } from './whiteboardPost'
+import { signState, verifyState } from './stateSign'
 
 interface FunctionUrlEvent {
   rawPath: string
@@ -69,15 +70,19 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
   if (path === '/auth/start') {
     const state = query.state ?? ''
     if (!STATE_PATTERN.test(state)) return errorPage('state パラメータが不正です。')
+    // アプリの nonce に HMAC 署名と発行時刻を付けて Slack へ渡す。
+    // /auth/callback で「自分が発行した state か・TTL 内か」を検証できるようにする。
+    const signedState = signState(state, env('SESSION_SECRET'))
     return redirect(
-      buildAuthorizeUrl({ clientId: env('SLACK_CLIENT_ID'), redirectUri, state })
+      buildAuthorizeUrl({ clientId: env('SLACK_CLIENT_ID'), redirectUri, state: signedState })
     )
   }
 
   if (path === '/auth/callback') {
-    const state = query.state ?? ''
     const code = query.code ?? ''
-    if (!STATE_PATTERN.test(state) || !code) return errorPage('パラメータが不足しています。')
+    // 署名済み state を検証し、元の nonce を取り出す（署名不一致・期限切れは拒否）
+    const nonce = verifyState(query.state ?? '', env('SESSION_SECRET'))
+    if (!nonce || !code) return errorPage('パラメータが不足しています。')
     const identity = await fetchSlackIdentity({
       clientId: env('SLACK_CLIENT_ID'),
       clientSecret: env('SLACK_CLIENT_SECRET'),
@@ -102,7 +107,8 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
       },
       env('SESSION_SECRET')
     )
-    return redirect(`juice://auth?token=${encodeURIComponent(token)}&state=${state}`)
+    // アプリは自身が生成した nonce で照合するため、署名前の nonce を返す
+    return redirect(`juice://auth?token=${encodeURIComponent(token)}&state=${nonce}`)
   }
 
   if (path === '/auth/me') {

--- a/lambda/src/stateSign.test.ts
+++ b/lambda/src/stateSign.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import { signState, verifyState } from './stateSign'
+
+const SECRET = 'test-secret'
+const NONCE = 'a'.repeat(32)
+
+describe('signState / verifyState', () => {
+  it('署名した state を検証すると元の nonce が返る', () => {
+    const signed = signState(NONCE, SECRET, 1000)
+    expect(verifyState(signed, SECRET, 1000)).toBe(NONCE)
+  })
+
+  it('署名に使った state は raw nonce とは異なる', () => {
+    const signed = signState(NONCE, SECRET, 1000)
+    expect(signed).not.toBe(NONCE)
+    expect(signed.split('.')).toHaveLength(2)
+  })
+
+  it('別の secret では検証に失敗する（署名不一致）', () => {
+    const signed = signState(NONCE, SECRET, 1000)
+    expect(verifyState(signed, 'other-secret', 1000)).toBeNull()
+  })
+
+  it('改竄された payload は検証に失敗する', () => {
+    const signed = signState(NONCE, SECRET, 1000)
+    const [, sig] = signed.split('.')
+    const forged = Buffer.from('evil.1000').toString('base64url') + '.' + sig
+    expect(verifyState(forged, SECRET, 1000)).toBeNull()
+  })
+
+  it('TTL（10分）を超えると失効する', () => {
+    const signed = signState(NONCE, SECRET, 1000)
+    expect(verifyState(signed, SECRET, 1000 + 10 * 60)).toBe(NONCE) // 境界は有効
+    expect(verifyState(signed, SECRET, 1000 + 10 * 60 + 1)).toBeNull()
+  })
+
+  it('未来すぎる発行時刻（時計ずれ60秒超）は弾く', () => {
+    const signed = signState(NONCE, SECRET, 2000)
+    expect(verifyState(signed, SECRET, 2000 - 61)).toBeNull()
+  })
+
+  it('形式不正（ドット数違い・非base64url）は null', () => {
+    expect(verifyState('only-one-part', SECRET, 1000)).toBeNull()
+    expect(verifyState('a.b.c', SECRET, 1000)).toBeNull()
+  })
+})

--- a/lambda/src/stateSign.ts
+++ b/lambda/src/stateSign.ts
@@ -1,0 +1,48 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+// OAuth の state を /auth/start ↔ /auth/callback で結びつけるための HMAC 署名。
+// Function URL はステートレスなため、サーバ側に保存を持たずに
+// 「この state は自分の /auth/start が発行したものか」「TTL 内か」を検証する。
+// アプリ側の nonce 照合（signIn.ts）に対する多層防御。
+
+const STATE_TTL_SEC = 10 * 60 // アプリ側 STATE_TTL_MS と一致させる
+
+const nowSec = (): number => Math.floor(Date.now() / 1000)
+
+/**
+ * アプリ生成の nonce に発行時刻と HMAC 署名を付け、Slack へ渡す state を作る。
+ * 形式: base64url("<nonce>.<issuedAt>").<sig>
+ */
+export function signState(nonce: string, secret: string, now: number = nowSec()): string {
+  const payload = `${nonce}.${now}`
+  const encoded = Buffer.from(payload).toString('base64url')
+  const sig = createHmac('sha256', secret).update(payload).digest('base64url')
+  return `${encoded}.${sig}`
+}
+
+/**
+ * 署名済み state を検証し、元の nonce を返す。
+ * 署名不一致・期限切れ・形式不正は null。
+ */
+export function verifyState(signed: string, secret: string, now: number = nowSec()): string | null {
+  const parts = signed.split('.')
+  if (parts.length !== 2) return null
+  let payload: string
+  try {
+    payload = Buffer.from(parts[0], 'base64url').toString('utf-8')
+  } catch {
+    return null
+  }
+  const expected = createHmac('sha256', secret).update(payload).digest()
+  const actual = Buffer.from(parts[1], 'base64url')
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null
+
+  const sep = payload.lastIndexOf('.')
+  if (sep < 0) return null
+  const nonce = payload.slice(0, sep)
+  const issuedAt = Number(payload.slice(sep + 1))
+  if (!nonce || !Number.isFinite(issuedAt)) return null
+  // 期限切れ、および未来すぎる発行時刻（時計ずれ許容60秒）を弾く
+  if (now - issuedAt > STATE_TTL_SEC || issuedAt - now > 60) return null
+  return nonce
+}


### PR DESCRIPTION
監査の中・最後（#3）。OAuth state の CSRF 防御を Lambda 側にも多層化。

## 背景
Function URL はステートレスで、`/auth/start` と `/auth/callback` の state を結びつけていなかった（形式検証のみ）。実体的な照合はアプリ側（`signIn.ts`：ワンショット・10分TTL・nonce一致）に依存。

## 対応（ステートレス HMAC 署名・インフラ追加なし）
- `/auth/start`: アプリの nonce に発行時刻＋HMAC署名を付与して Slack へ渡す（`stateSign.ts`）。
- `/auth/callback`: 署名と TTL（10分）を検証してから code 交換。署名なしの生 state や期限切れは **400 で拒否**し、`/auth/callback` に任意 state を直接投げる経路を遮断。
- アプリへは署名前の nonce を返すため **既存アプリと完全後方互換**。
- HMAC は既存の `SESSION_SECRET` を流用（JWT と同じ primitive、`timingSafeEqual`）。

## 設計判断
DynamoDB 等でワンタイム保証を持たせる案もあるが、アプリ側で実害は緩和済みかつ Lambda は意図的に最小構成のため、インフラを増やさないステートレス HMAC を採用。

## テスト
- typecheck パス / 全テスト 515 件パス / lambda ビルド確認
- `stateSign` 単体7件（署名往復・改竄拒否・TTL境界・時計ずれ）＋ handler の署名検証（生 state 拒否・nonce 復元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)