### PR TITLE
fix: 各所の防御的ハードニング（監査・低）

### DIFF
--- a/src/main/integrations/holidays.ts
+++ b/src/main/integrations/holidays.ts
@@ -8,8 +8,12 @@ export async function getHolidays(): Promise<Record<string, string>> {
   if (holidaysCache) return holidaysCache
   try {
     const response = await net.fetch('https://holidays-jp.github.io/api/v1/date.json')
-    holidaysCache = await response.json()
-    return holidaysCache ?? {}
+    if (!response.ok) return {}
+    const data = await response.json()
+    // 外部 API が壊れた形を返しても後段で誤動作しないよう検証する
+    if (typeof data !== 'object' || data === null) return {}
+    holidaysCache = data as Record<string, string>
+    return holidaysCache
   } catch {
     return {}
   }

--- a/src/main/windows/tray.ts
+++ b/src/main/windows/tray.ts
@@ -7,6 +7,8 @@ import type { SettingsStore } from '../settingsStore'
 let tray: Tray | null = null
 
 export function createTray(settingsStore: SettingsStore): void {
+  // 二重生成防止: 既存の Tray があれば破棄してから作り直す（アイコンの重複を防ぐ）
+  tray?.destroy()
   const iconPath = join(__dirname, '../../resources/icon.png')
   const icon = nativeImage.createFromPath(iconPath).resize({ width: 22, height: 22 })
   tray = new Tray(icon)

--- a/src/renderer/src/dailyStore.test.ts
+++ b/src/renderer/src/dailyStore.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { dailyStore } from './dailyStore'
+
+const DATE = '2026-06-13'
+const KEY = `sessionOrder.${DATE}`
+
+describe('dailyStore.getSessionOrder', () => {
+  afterEach(() => localStorage.clear())
+
+  it('未保存なら null', () => {
+    expect(dailyStore.getSessionOrder(DATE)).toBeNull()
+  })
+
+  it('保存した順序を配列で返す', () => {
+    dailyStore.setSessionOrder(DATE, ['b', 'a'])
+    expect(dailyStore.getSessionOrder(DATE)).toEqual(['b', 'a'])
+  })
+
+  it('破損した JSON でも例外を投げず null を返す', () => {
+    localStorage.setItem(KEY, '{壊れた')
+    expect(() => dailyStore.getSessionOrder(DATE)).not.toThrow()
+    expect(dailyStore.getSessionOrder(DATE)).toBeNull()
+  })
+
+  it('配列でない / 文字列以外を含む値は null を返す', () => {
+    localStorage.setItem(KEY, JSON.stringify({ not: 'array' }))
+    expect(dailyStore.getSessionOrder(DATE)).toBeNull()
+    localStorage.setItem(KEY, JSON.stringify(['a', 1, 'b']))
+    expect(dailyStore.getSessionOrder(DATE)).toBeNull()
+  })
+})

--- a/src/renderer/src/dailyStore.ts
+++ b/src/renderer/src/dailyStore.ts
@@ -32,7 +32,14 @@ export const dailyStore = {
 
   getSessionOrder(date: string): string[] | null {
     const stored = localStorage.getItem(`${SESSION_ORDER}.${date}`)
-    return stored ? JSON.parse(stored) : null
+    if (!stored) return null
+    // 破損・手動改変された値で画面全体がクラッシュしないよう防御する
+    try {
+      const parsed = JSON.parse(stored)
+      return Array.isArray(parsed) && parsed.every(x => typeof x === 'string') ? parsed : null
+    } catch {
+      return null
+    }
   },
   setSessionOrder(date: string, order: string[]): void {
     localStorage.setItem(`${SESSION_ORDER}.${date}`, JSON.stringify(order))

--- a/src/renderer/src/hooks/useSessions.ts
+++ b/src/renderer/src/hooks/useSessions.ts
@@ -65,12 +65,11 @@ export function useSessions(): SessionsState {
   }, [])
 
   const remove = useCallback(async (sessionId: string): Promise<void> => {
-    const session = todaySessions.find(s => s.id === sessionId)
-    if (session) {
-      await sessionRepository.remove(sessionId, session.date.slice(0, 7))
-    }
+    // todaySessions は date === today に絞られているため yearMonth は常に当月。
+    // todaySessions に依存させず関数の再生成を防ぐ。
+    await sessionRepository.remove(sessionId, yearMonth)
     setTodaySessions(prev => prev.filter(s => s.id !== sessionId))
-  }, [todaySessions])
+  }, [yearMonth])
 
   const startTelework = useCallback(() => attendanceRepository.startTelework(), [])
 


### PR DESCRIPTION
監査の低・堅牢化バッチ。

- **dailyStore.getSessionOrder**: `JSON.parse` を try/catch + 型ガードで保護。localStorage 破損時に SessionList 初期化が落ちて画面全体が描画不能になるのを防ぐ。
- **holidays**: `response.ok` チェックと JSON 型検証を追加（404/500・壊れた応答での誤動作防止）。
- **createTray**: 既存 Tray を `destroy()` してから再生成（アイコン二重表示の防止）。
- **useSessions.remove**: `todaySessions` は当月に絞られているため `yearMonth` を直接使用。依存から `todaySessions` を外し不要な関数再生成を防ぐ。

## テスト
- dailyStore の破損/型不正ガードを4件追加
- typecheck パス / 全テスト 519 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)