### PR TITLE
refactor: preload の片方向イベント購読を off（解除関数返却）方式へ（監査・低）

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,11 +9,12 @@ function invoke<C extends IpcChannel>(channel: C, arg: IpcArg<C>): Promise<IpcRe
 }
 
 // 片方向イベント（main → renderer）の購読。
-// 注意: removeAllListeners で上書きするため 1 チャンネルにつき購読者は 1 つ。
-// 複数コンポーネントから同一イベントを購読する場合は off 方式への変更が必要。
-function on<E extends IpcEventName>(event: E, callback: (payload: IpcEventPayload<E>) => void): void {
-  ipcRenderer.removeAllListeners(event)
-  ipcRenderer.on(event, (_, payload: IpcEventPayload<E>) => callback(payload))
+// リスナーを1つずつ登録し、解除関数を返す。複数コンポーネントからの購読が可能で、
+// 各購読者は unmount 時に自分のリスナーだけを解除できる。
+function on<E extends IpcEventName>(event: E, callback: (payload: IpcEventPayload<E>) => void): () => void {
+  const listener = (_: unknown, payload: IpcEventPayload<E>): void => callback(payload)
+  ipcRenderer.on(event, listener)
+  return () => { ipcRenderer.removeListener(event, listener) }
 }
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/src/renderer/src/components/Settings/AccountSection.test.tsx
+++ b/src/renderer/src/components/Settings/AccountSection.test.tsx
@@ -7,7 +7,7 @@ const api = {
   getAuthStatus: vi.fn(),
   signInWithSlack: vi.fn().mockResolvedValue(undefined),
   signOutSlack: vi.fn().mockResolvedValue(undefined),
-  onAuthChanged: vi.fn(),
+  onAuthChanged: vi.fn((_cb: (status: { signedIn: boolean; name?: string }) => void) => () => {}),
 }
 
 beforeEach(() => {

--- a/src/renderer/src/components/Setup/SetupView.test.tsx
+++ b/src/renderer/src/components/Setup/SetupView.test.tsx
@@ -6,12 +6,12 @@ import { SetupView } from './SetupView'
 const api = {
   getTheme: vi.fn().mockResolvedValue('milk'),
   setTheme: vi.fn().mockResolvedValue(undefined),
-  onThemeChanged: vi.fn(),
+  onThemeChanged: vi.fn(() => () => {}),
   completeSetup: vi.fn().mockResolvedValue(undefined),
   getAuthStatus: vi.fn(),
   signInWithSlack: vi.fn().mockResolvedValue(undefined),
   signOutSlack: vi.fn().mockResolvedValue(undefined),
-  onAuthChanged: vi.fn(),
+  onAuthChanged: vi.fn(() => () => {}),
 }
 
 beforeEach(() => {

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -17,7 +17,7 @@ interface ElectronAPI {
   // settings: theme / notifications
   getTheme: () => Promise<string>
   setTheme: (themeId: string) => Promise<void>
-  onThemeChanged: (callback: (themeId: string) => void) => void
+  onThemeChanged: (callback: (themeId: string) => void) => () => void
   getIdleSettings: () => Promise<ToggleSettings>
   setIdleSettings: (enabled: boolean, minutes: number) => Promise<void>
   getElapsedSettings: () => Promise<ToggleSettings>
@@ -48,7 +48,7 @@ interface ElectronAPI {
   signInWithSlack: () => Promise<void>
   getAuthStatus: () => Promise<AuthStatus>
   signOutSlack: () => Promise<void>
-  onAuthChanged: (callback: (status: AuthStatus) => void) => void
+  onAuthChanged: (callback: (status: AuthStatus) => void) => () => void
 
   // misc
   completeSetup: () => Promise<void>

--- a/src/renderer/src/hooks/useAuthStatus.ts
+++ b/src/renderer/src/hooks/useAuthStatus.ts
@@ -8,8 +8,8 @@ export function useAuthStatus() {
   useEffect(() => {
     let alive = true
     window.electronAPI.getAuthStatus().then((s) => { if (alive) setStatus(s) })
-    window.electronAPI.onAuthChanged(setStatus)
-    return () => { alive = false }
+    const off = window.electronAPI.onAuthChanged(setStatus)
+    return () => { alive = false; off() }
   }, [])
 
   return {

--- a/src/renderer/src/hooks/useSettings.ts
+++ b/src/renderer/src/hooks/useSettings.ts
@@ -34,8 +34,8 @@ export function useSettings(): SettingsState {
   const [slackProjectName, setSlackProjectName] = useState('')
 
   useEffect(() => {
+    const offThemeChanged = settingsRepository.onThemeChanged(setActiveThemeId)
     settingsRepository.getTheme().then(setActiveThemeId)
-    settingsRepository.onThemeChanged(setActiveThemeId)
     settingsRepository.getIdle().then(({ enabled, minutes }) => {
       setIdleEnabled(enabled)
       setIdleMinutes(minutes)
@@ -54,6 +54,7 @@ export function useSettings(): SettingsState {
       setSlackProjectCode(projectCode)
       setSlackProjectName(projectName)
     })
+    return offThemeChanged
   }, [])
 
   return {

--- a/src/renderer/src/hooks/useSetup.ts
+++ b/src/renderer/src/hooks/useSetup.ts
@@ -15,7 +15,7 @@ export function useSetup(): SetupState {
 
   useEffect(() => {
     settingsRepository.getTheme().then(setActiveThemeId)
-    settingsRepository.onThemeChanged(setActiveThemeId)
+    return settingsRepository.onThemeChanged(setActiveThemeId)
   }, [])
 
   return {

--- a/src/renderer/src/repositories/settingsRepository.ts
+++ b/src/renderer/src/repositories/settingsRepository.ts
@@ -7,8 +7,8 @@ export const settingsRepository = {
   setTheme(themeId: string): Promise<void> {
     return window.electronAPI.setTheme(themeId)
   },
-  onThemeChanged(callback: (themeId: string) => void): void {
-    window.electronAPI.onThemeChanged(callback)
+  onThemeChanged(callback: (themeId: string) => void): () => void {
+    return window.electronAPI.onThemeChanged(callback)
   },
 
   getIdle(): Promise<{ enabled: boolean; minutes: number }> {


### PR DESCRIPTION
監査の低・preload 購読契約の改善。

`removeAllListeners` 方式（1チャンネル1購読・解除不可）をやめ、リスナーを1つずつ登録して解除関数を返す方式へ。複数コンポーネントから同一イベントを購読でき、各購読者が unmount 時に自分のリスナーだけを解除できる（将来の取りこぼし・リーク防止）。現状バグは出ていない予防的改善。

- `preload` `on`: `removeListener` ベースに変更し `() => void` を返す
- `env.d.ts` / `settingsRepository`: 戻り値型を `() => void` に
- `useAuthStatus` / `useSetup` / `useSettings`: useEffect の cleanup で購読解除
- テストの `onAuthChanged`/`onThemeChanged` モックが解除関数を返すよう更新

## テスト
- typecheck パス / 全テスト 519 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)