### PR TITLE
refactor: ウィンドウ生成の共通化と SessionList の D&D ロジック抽出（監査・低）

### DIFF
--- a/src/main/windows/popover.ts
+++ b/src/main/windows/popover.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow } from 'electron'
-import { join } from 'path'
 import { broadcastThemeOnLoad } from './themeBroadcast'
+import { sharedWebPreferences, loadRenderer } from './shared'
 import type { SettingsStore } from '../settingsStore'
 
 // ポップオーバー画面の state はこのモジュールに閉じ込める。
@@ -24,11 +24,7 @@ function createPopoverWindow(settingsStore: SettingsStore): BrowserWindow {
     transparent: true,
     vibrancy: 'hud',
     visualEffectState: 'active',
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
+    webPreferences: sharedWebPreferences,
   })
 
   win.setAlwaysOnTop(true, 'pop-up-menu')
@@ -48,12 +44,7 @@ function createPopoverWindow(settingsStore: SettingsStore): BrowserWindow {
     if (!moved) win.hide()
   })
 
-  if (process.env['NODE_ENV'] === 'development') {
-    win.loadURL('http://localhost:5174/')
-  } else {
-    win.loadFile(join(__dirname, '../renderer/index.html'))
-  }
-
+  loadRenderer(win)
   broadcastThemeOnLoad(win, settingsStore)
   return win
 }

--- a/src/main/windows/settings.ts
+++ b/src/main/windows/settings.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow } from 'electron'
-import { join } from 'path'
 import { broadcastThemeOnLoad } from './themeBroadcast'
+import { sharedWebPreferences, loadRenderer } from './shared'
 import type { SettingsStore } from '../settingsStore'
 
 let settingsWindow: BrowserWindow | null = null
@@ -16,20 +16,11 @@ export function createSettingsWindow(settingsStore: SettingsStore): void {
     height: 500,
     resizable: false,
     title: 'Juice 設定',
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
+    webPreferences: sharedWebPreferences,
   })
 
   broadcastThemeOnLoad(settingsWindow, settingsStore)
-
-  if (process.env['NODE_ENV'] === 'development') {
-    settingsWindow.loadURL('http://localhost:5174/#settings')
-  } else {
-    settingsWindow.loadFile(join(__dirname, '../renderer/index.html'), { hash: 'settings' })
-  }
+  loadRenderer(settingsWindow, 'settings')
 
   settingsWindow.on('closed', () => {
     settingsWindow = null

--- a/src/main/windows/setup.ts
+++ b/src/main/windows/setup.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, screen } from 'electron'
-import { join } from 'path'
 import { broadcastThemeOnLoad } from './themeBroadcast'
+import { sharedWebPreferences, loadRenderer } from './shared'
 import type { SettingsStore } from '../settingsStore'
 
 let setupWindow: BrowserWindow | null = null
@@ -21,20 +21,11 @@ export function createSetupWindow(settingsStore: SettingsStore): void {
     y: Math.round((screenH - winH) / 2),
     resizable: false,
     title: 'Juice — セットアップ',
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
+    webPreferences: sharedWebPreferences,
   })
 
   broadcastThemeOnLoad(setupWindow, settingsStore)
-
-  if (process.env['NODE_ENV'] === 'development') {
-    setupWindow.loadURL('http://localhost:5174/#setup')
-  } else {
-    setupWindow.loadFile(join(__dirname, '../renderer/index.html'), { hash: 'setup' })
-  }
+  loadRenderer(setupWindow, 'setup')
 
   setupWindow.on('closed', async () => {
     setupWindow = null

--- a/src/main/windows/shared.ts
+++ b/src/main/windows/shared.ts
@@ -1,0 +1,21 @@
+import type { BrowserWindow } from 'electron'
+import { join } from 'path'
+
+/** 全ウィンドウ共通の webPreferences（preload パス・コンテキスト隔離設定）。 */
+export const sharedWebPreferences = {
+  preload: join(__dirname, '../preload/index.js'),
+  contextIsolation: true,
+  nodeIntegration: false,
+} as const
+
+/**
+ * レンダラーを読み込む。dev は Vite dev サーバ、prod はバンドル済み index.html。
+ * hash を渡すと該当ルート（#settings 等）を開く。
+ */
+export function loadRenderer(win: BrowserWindow, hash?: string): void {
+  if (process.env['NODE_ENV'] === 'development') {
+    win.loadURL(`http://localhost:5174/${hash ? `#${hash}` : ''}`)
+  } else {
+    win.loadFile(join(__dirname, '../renderer/index.html'), hash ? { hash } : undefined)
+  }
+}

--- a/src/renderer/src/components/Popover/SessionList.tsx
+++ b/src/renderer/src/components/Popover/SessionList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import type { Session } from '../../types/session'
 import { formatLocalDate, formatTimeFromDate, orderSessions } from '../../../../shared/sessionUtils'
 import { applySessionEdit } from '../../domain/session'
@@ -9,6 +9,7 @@ import { SessionFormDialog, type SessionFormValues } from './SessionFormDialog'
 import { useContextMenu } from '../../hooks/useContextMenu'
 import { useExpandedItem } from '../../hooks/useExpandedItem'
 import { usePagination } from '../../hooks/usePagination'
+import { useDragReorder } from '../../hooks/useDragReorder'
 import { EMPTY_SUGGESTIONS, type Suggestions } from '../../domain/suggestions'
 import { TimeField } from '@/components/ui/time-field'
 import { Button } from '@/components/ui/button'
@@ -78,93 +79,18 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
   const totalMinutes = sessions.reduce((acc, s) => acc + s.totalTime, 0)
   const { page, totalPages, pagedItems: pagedSessions, animKey, changePage } = usePagination(sortedSessions, 4)
 
-  // ドラッグ&ドロップ
-  const dragItemRef = useRef<string | null>(null)
-  const dragOverItemRef = useRef<string | null>(null)
-  const [dragOverId, setDragOverId] = useState<string | null>(null)
-  const listRef = useRef<HTMLUListElement | null>(null)
-  const pageChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const handleDragStart = (e: React.DragEvent, sessionId: string) => {
-    dragItemRef.current = sessionId
-    // 既定の copy 効果（緑のプラスマーク）を出さず移動として扱う
-    e.dataTransfer.effectAllowed = 'move'
-  }
-
-  const handleDragOver = (e: React.DragEvent, sessionId: string) => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = 'move'
-    dragOverItemRef.current = sessionId
-    setDragOverId(sessionId)
-  }
-
-  // ドラッグ中にリスト上端/下端付近でページ切り替え
-  const handleListDragOver = (e: React.DragEvent) => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = 'move'
-    if (!listRef.current || totalPages <= 1 || !dragItemRef.current) return
-
-    const rect = listRef.current.getBoundingClientRect()
-    const x = e.clientX
-    const edgeZone = 40 // px
-
-    const nearLeft = x - rect.left < edgeZone && page > 0
-    const nearRight = rect.right - x < edgeZone && page < totalPages - 1
-
-    if (nearLeft || nearRight) {
-      if (!pageChangeTimerRef.current) {
-        pageChangeTimerRef.current = setTimeout(() => {
-          pageChangeTimerRef.current = null
-          if (nearLeft) changePage(page - 1)
-          else if (nearRight) changePage(page + 1)
-        }, 400)
-      }
-    } else {
-      if (pageChangeTimerRef.current) {
-        clearTimeout(pageChangeTimerRef.current)
-        pageChangeTimerRef.current = null
-      }
-    }
-  }
-
-  // 並び替えを確定して D&D の状態をリセットする（drop と dragend のどちらが先でも一度だけ実行される）
-  const commitReorder = () => {
-    if (pageChangeTimerRef.current) {
-      clearTimeout(pageChangeTimerRef.current)
-      pageChangeTimerRef.current = null
-    }
-
-    const fromId = dragItemRef.current
-    const toId = dragOverItemRef.current
-    dragItemRef.current = null
-    dragOverItemRef.current = null
-    setDragOverId(null)
-
-    if (!fromId || !toId || fromId === toId) return
-
-    const currentOrder = sortedSessions.map(s => s.id)
-    const fromIdx = currentOrder.indexOf(fromId)
-    const toIdx = currentOrder.indexOf(toId)
-    if (fromIdx === -1 || toIdx === -1) return
-
-    currentOrder.splice(fromIdx, 1)
-    currentOrder.splice(toIdx, 0, fromId)
-
-    dailyStore.setSessionOrder(todayKey, currentOrder)
-    setCustomOrder(currentOrder)
-  }
-
-  // ページをまたぐ並び替えではドラッグ元の要素がアンマウントされ dragend が React に届かないため、
-  // ドロップ先（マウントされている側）で発火する drop で確定する
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault()
-    commitReorder()
-  }
-
-  const handleDragEnd = () => {
-    // 同一ページ内では drop の後に dragend も届くが、refs は消費済みなので二重確定しない
-    commitReorder()
-  }
+  // ドラッグ&ドロップ並び替え（ページ跨ぎ・drop/dragend の一度きり確定は hook 側で扱う）
+  const {
+    dragOverId, listRef,
+    handleDragStart, handleDragOver, handleListDragOver, handleDragLeave, handleDrop, handleDragEnd,
+  } = useDragReorder({
+    orderedIds: sortedSessions.map(s => s.id),
+    todayKey,
+    onReorder: setCustomOrder,
+    page,
+    totalPages,
+    changePage,
+  })
 
   const openAddDialog = () => {
     setAddDraft(EMPTY_FORM)
@@ -287,7 +213,7 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
               }}
               onDragStart={(e) => handleDragStart(e, session.id)}
               onDragOver={(e) => handleDragOver(e, session.id)}
-              onDragLeave={() => setDragOverId(null)}
+              onDragLeave={handleDragLeave}
               onDragEnd={handleDragEnd}
             >
               <span className="mt-[3px] h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: resolveJuiceColor(session.color) }} aria-hidden="true" />

--- a/src/renderer/src/hooks/useDragReorder.ts
+++ b/src/renderer/src/hooks/useDragReorder.ts
@@ -1,0 +1,124 @@
+import { useRef, useState, type DragEvent, type RefObject } from 'react'
+import { dailyStore } from '../dailyStore'
+
+interface Params {
+  /** 現在の表示順のセッションID配列 */
+  orderedIds: string[]
+  /** "YYYY-MM-DD"（順序の保存キー） */
+  todayKey: string
+  /** 並び替え確定時に新しい順序を通知する（customOrder の更新） */
+  onReorder: (order: string[]) => void
+  page: number
+  totalPages: number
+  changePage: (page: number) => void
+}
+
+interface DragReorder {
+  dragOverId: string | null
+  listRef: RefObject<HTMLUListElement | null>
+  handleDragStart: (e: DragEvent, sessionId: string) => void
+  handleDragOver: (e: DragEvent, sessionId: string) => void
+  handleListDragOver: (e: DragEvent) => void
+  handleDragLeave: () => void
+  handleDrop: (e: DragEvent) => void
+  handleDragEnd: () => void
+}
+
+/**
+ * セッションリストのドラッグ&ドロップ並び替え。
+ * ページをまたぐドラッグ（端部ホールドでページ切替）と、
+ * ドラッグ元がアンマウントされる場合でも drop / dragend のどちらか一度で確定する処理を扱う。
+ */
+export function useDragReorder({ orderedIds, todayKey, onReorder, page, totalPages, changePage }: Params): DragReorder {
+  const dragItemRef = useRef<string | null>(null)
+  const dragOverItemRef = useRef<string | null>(null)
+  const [dragOverId, setDragOverId] = useState<string | null>(null)
+  const listRef = useRef<HTMLUListElement | null>(null)
+  const pageChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleDragStart = (e: DragEvent, sessionId: string): void => {
+    dragItemRef.current = sessionId
+    // 既定の copy 効果（緑のプラスマーク）を出さず移動として扱う
+    e.dataTransfer.effectAllowed = 'move'
+  }
+
+  const handleDragOver = (e: DragEvent, sessionId: string): void => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    dragOverItemRef.current = sessionId
+    setDragOverId(sessionId)
+  }
+
+  // ドラッグ中にリスト上端/下端付近でページ切り替え
+  const handleListDragOver = (e: DragEvent): void => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    if (!listRef.current || totalPages <= 1 || !dragItemRef.current) return
+
+    const rect = listRef.current.getBoundingClientRect()
+    const x = e.clientX
+    const edgeZone = 40 // px
+
+    const nearLeft = x - rect.left < edgeZone && page > 0
+    const nearRight = rect.right - x < edgeZone && page < totalPages - 1
+
+    if (nearLeft || nearRight) {
+      if (!pageChangeTimerRef.current) {
+        pageChangeTimerRef.current = setTimeout(() => {
+          pageChangeTimerRef.current = null
+          if (nearLeft) changePage(page - 1)
+          else if (nearRight) changePage(page + 1)
+        }, 400)
+      }
+    } else {
+      if (pageChangeTimerRef.current) {
+        clearTimeout(pageChangeTimerRef.current)
+        pageChangeTimerRef.current = null
+      }
+    }
+  }
+
+  // 並び替えを確定して D&D の状態をリセットする（drop と dragend のどちらが先でも一度だけ実行される）
+  const commitReorder = (): void => {
+    if (pageChangeTimerRef.current) {
+      clearTimeout(pageChangeTimerRef.current)
+      pageChangeTimerRef.current = null
+    }
+
+    const fromId = dragItemRef.current
+    const toId = dragOverItemRef.current
+    dragItemRef.current = null
+    dragOverItemRef.current = null
+    setDragOverId(null)
+
+    if (!fromId || !toId || fromId === toId) return
+
+    const currentOrder = [...orderedIds]
+    const fromIdx = currentOrder.indexOf(fromId)
+    const toIdx = currentOrder.indexOf(toId)
+    if (fromIdx === -1 || toIdx === -1) return
+
+    currentOrder.splice(fromIdx, 1)
+    currentOrder.splice(toIdx, 0, fromId)
+
+    dailyStore.setSessionOrder(todayKey, currentOrder)
+    onReorder(currentOrder)
+  }
+
+  // ページをまたぐ並び替えではドラッグ元の要素がアンマウントされ dragend が React に届かないため、
+  // ドロップ先（マウントされている側）で発火する drop で確定する
+  const handleDrop = (e: DragEvent): void => {
+    e.preventDefault()
+    commitReorder()
+  }
+
+  // 同一ページ内では drop の後に dragend も届くが、refs は消費済みなので二重確定しない
+  const handleDragEnd = (): void => commitReorder()
+
+  const handleDragLeave = (): void => setDragOverId(null)
+
+  return {
+    dragOverId, listRef,
+    handleDragStart, handleDragOver, handleListDragOver, handleDragLeave, handleDrop, handleDragEnd,
+  }
+}


### PR DESCRIPTION
監査の低・リファクタバッチ。挙動は不変。

## ウィンドウ生成の共通化
- `windows/shared.ts` を追加。`popover`/`settings`/`setup` で重複していた `webPreferences`（preload・隔離設定）と dev/prod のロード分岐（`loadRenderer`）を共通化。

## SessionList の D&D 抽出
- ドラッグ&ドロップ並び替え（ページ跨ぎの端部ホールド切替、ドラッグ元アンマウント時の drop/dragend 一度きり確定）を `useDragReorder` フックへ抽出。SessionList の責務を縮小。

## 見送り
- **App.tsx の prop drilling**: 精査の結果、App→TimerPage→SessionList は中間の TimerPage が sessions/workday/suggestions を実際に使用しており純粋な drilling ではないため、context 化は利得が小さく回帰リスクが大きいと判断し今回は見送り。

## テスト
- typecheck パス / 全テスト 519 件パス（ページ跨ぎ並び替えテスト含む＝D&D 挙動の保持を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)