### PR TITLE
feat: Lambda の秘密を SSM Parameter Store(SecureString) へ移行（監査・低）

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -29,26 +29,38 @@ npm run build          # esbuild で dist/handler.js を生成
 
 cd terraform
 cp terraform.tfvars.example terraform.tfvars
-openssl rand -hex 32   # session_secret に使う値を生成
-# terraform.tfvars に実値を記入する:
-#   slack_client_id / slack_client_secret: 手順1で控えた値
+# terraform.tfvars に「秘密でない」設定だけ記入する:
+#   slack_client_id: 手順1で控えた値（Client ID は秘密ではない）
 #   allowed_team_id: ワークスペースの team ID
 #     （ブラウザで Slack を開いた URL app.slack.com/client/TXXXXXXX/...
 #      の T 始まりの部分）
-#   session_secret: 上で生成した値
-#   slack_bot_token / slack_channel_id: 既存 .env の
-#     MAIN_VITE_SLACK_BOT_TOKEN / MAIN_VITE_SLACK_CHANNEL_ID の値を移設
-#   attendance_api_url / attendance_api_key: 既存 .env の
-#     MAIN_VITE_ATTENDANCE_API_URL / MAIN_VITE_ATTENDANCE_API_KEY の値を移設
-#   whiteboard_api_url / whiteboard_api_key: 既存 .env の
-#     MAIN_VITE_WHITEBOARD_API_URL / MAIN_VITE_WHITEBOARD_API_KEY の値を移設
+#   slack_channel_id: 既存 .env の MAIN_VITE_SLACK_CHANNEL_ID
+#   attendance_api_url / whiteboard_api_url: 既存 .env の各 URL
+```
 
+秘密値は tfvars/tfstate に置かず、SSM Parameter Store(SecureString) に CLI で投入する
+（プレフィックスは既定 `/juice-proxy/`、`ssm_secret_prefix` で変更可）:
+
+```bash
+REGION=ap-northeast-1
+put() { aws ssm put-parameter --region "$REGION" --type SecureString --overwrite \
+  --name "/juice-proxy/$1" --value "$2"; }
+
+put SLACK_CLIENT_SECRET "手順1で控えた Client Secret"
+put SESSION_SECRET      "$(openssl rand -hex 32)"   # JWT の HS256 署名鍵
+put SLACK_BOT_TOKEN     "既存 .env の MAIN_VITE_SLACK_BOT_TOKEN"
+put ATTENDANCE_API_KEY  "既存 .env の MAIN_VITE_ATTENDANCE_API_KEY"
+put WHITEBOARD_API_KEY  "既存 .env の MAIN_VITE_WHITEBOARD_API_KEY"
+```
+
+```bash
 terraform init
 terraform apply        # 実行計画を確認して yes
 ```
 
-`terraform.tfvars` は秘密を含むため gitignore 済み。
-リージョンは既定で `ap-northeast-1`（変える場合は `region` 変数）。
+`terraform.tfvars` は gitignore 済み。秘密は SSM にのみ存在し、tfstate には載らない。
+SecureString は既定の AWS 管理キー `alias/aws/ssm` で暗号化される（追加料金なし）。
+リージョンは既定で `ap-northeast-1`（変える場合は `region` 変数と上記 `REGION`）。
 
 apply 完了時の Outputs に **function_url** が表示される。
 
@@ -103,9 +115,11 @@ open dist-release/mac-arm64/Juice.app
 - **コスト監視**: AWS Budgets で月 $5 のアラートを設定しておく
   （Console → Budgets → Create budget）
 - **コード更新**: `npm run build` → `terraform apply`
-- **キーローテーション**: `terraform.tfvars` を変更して `terraform apply`
-- **全セッション失効**: `session_secret` を変更して `terraform apply`
-- **全リソース削除**: `terraform destroy`
+- **キーローテーション**: SSM のパラメータを更新する（apply 不要、次のコールド起動で反映）
+  例: `aws ssm put-parameter --type SecureString --overwrite --name /juice-proxy/SLACK_BOT_TOKEN --value '新トークン'`
+- **全セッション失効**: `SESSION_SECRET` パラメータを新しい値に更新する（全 JWT が無効化される）
+  例: `aws ssm put-parameter --type SecureString --overwrite --name /juice-proxy/SESSION_SECRET --value "$(openssl rand -hex 32)"`
+- **全リソース削除**: `terraform destroy`（SSM パラメータは Terraform 管理外なので別途 `aws ssm delete-parameter` で削除）
 - **勤怠の登録名の自動解決**: サインイン時に Slack の `users.info` から
   旧ユーザー名（@ハンドル）を取得し勤怠 user_name に使う。
   スコープ変更後は既存サインイン者の再サインインが必要

--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -8,8 +8,383 @@
       "name": "juice-lambda",
       "version": "1.0.0",
       "devDependencies": {
+        "@aws-sdk/client-ssm": "^3.600.0",
         "@types/node": "^22.0.0",
         "esbuild": "^0.21.5"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1068.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1068.0.tgz",
+      "integrity": "sha512-Toui6G9ebQbjT5y6FgQxmokX8+231R+JPEEMA3Zf+Oa3ui1qf0XSknaaXvCWeoj4ru1SoL3kSAl8lZ4OrKGNSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.55",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz",
+      "integrity": "sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz",
+      "integrity": "sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz",
+      "integrity": "sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz",
+      "integrity": "sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/token-providers": "3.1066.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz",
+      "integrity": "sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz",
+      "integrity": "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.34",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz",
+      "integrity": "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1066.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz",
+      "integrity": "sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -403,6 +778,148 @@
         "node": ">=12"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.7.tgz",
+      "integrity": "sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.9.tgz",
+      "integrity": "sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.7.tgz",
+      "integrity": "sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
+      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.7.tgz",
+      "integrity": "sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.4.tgz",
+      "integrity": "sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
@@ -412,6 +929,26 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -452,12 +989,106 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     }
   }
 }

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "description": "Juice の認証・API プロキシ Lambda",
   "scripts": {
-    "build": "esbuild src/handler.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/handler.js"
+    "build": "esbuild src/handler.ts --bundle --platform=node --target=node22 --format=cjs --external:@aws-sdk/* --outfile=dist/handler.js"
   },
   "devDependencies": {
+    "@aws-sdk/client-ssm": "^3.600.0",
     "@types/node": "^22.0.0",
     "esbuild": "^0.21.5"
   }

--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -28,6 +28,17 @@ vi.mock('./whiteboardPost', async (importOriginal) => {
   return { ...mod, postWhiteboard: vi.fn() }
 })
 
+// 秘密値は SSM 取得をモックする（テストでは固定値を返す）
+vi.mock('./secrets', () => ({
+  loadSecrets: vi.fn().mockResolvedValue({
+    SLACK_CLIENT_SECRET: 'CSECRET',
+    SESSION_SECRET: 'test-secret',
+    SLACK_BOT_TOKEN: 'xoxb-test',
+    ATTENDANCE_API_KEY: 'AKEY',
+    WHITEBOARD_API_KEY: 'WKEY',
+  }),
+}))
+
 const STATE = 'a'.repeat(32)
 // /auth/callback には署名済み state が渡される（/auth/start が発行した形式）
 const SIGNED = signState(STATE, 'test-secret')

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -4,6 +4,7 @@ import { buildTeleworkMessage, parseSlackPostRequest, postToSlack } from './slac
 import { parseAttendanceRequest, postAttendance, resolveUserName } from './attendanceSend'
 import { postWhiteboard } from './whiteboardPost'
 import { signState, verifyState } from './stateSign'
+import { loadSecrets } from './secrets'
 
 interface FunctionUrlEvent {
   rawPath: string
@@ -41,10 +42,10 @@ function json(statusCode: number, data: unknown): FunctionUrlResponse {
   }
 }
 
-function bearerClaims(event: FunctionUrlEvent): ReturnType<typeof verifySessionJwt> {
+function bearerClaims(event: FunctionUrlEvent, sessionSecret: string): ReturnType<typeof verifySessionJwt> {
   const auth = event.headers.authorization ?? event.headers.Authorization ?? ''
   const match = auth.match(/^Bearer (.+)$/)
-  return match ? verifySessionJwt(match[1], env('SESSION_SECRET')) : null
+  return match ? verifySessionJwt(match[1], sessionSecret) : null
 }
 
 function rawBody(event: FunctionUrlEvent): string {
@@ -66,13 +67,15 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
   const path = event.rawPath
   const query = event.queryStringParameters ?? {}
   const redirectUri = `https://${event.requestContext.domainName}/auth/callback`
+  // 秘密値は SSM から取得する（コールド時のみ実取得、以降はキャッシュ）
+  const secrets = await loadSecrets()
 
   if (path === '/auth/start') {
     const state = query.state ?? ''
     if (!STATE_PATTERN.test(state)) return errorPage('state パラメータが不正です。')
     // アプリの nonce に HMAC 署名と発行時刻を付けて Slack へ渡す。
     // /auth/callback で「自分が発行した state か・TTL 内か」を検証できるようにする。
-    const signedState = signState(state, env('SESSION_SECRET'))
+    const signedState = signState(state, secrets.SESSION_SECRET)
     return redirect(
       buildAuthorizeUrl({ clientId: env('SLACK_CLIENT_ID'), redirectUri, state: signedState })
     )
@@ -81,11 +84,11 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
   if (path === '/auth/callback') {
     const code = query.code ?? ''
     // 署名済み state を検証し、元の nonce を取り出す（署名不一致・期限切れは拒否）
-    const nonce = verifyState(query.state ?? '', env('SESSION_SECRET'))
+    const nonce = verifyState(query.state ?? '', secrets.SESSION_SECRET)
     if (!nonce || !code) return errorPage('パラメータが不足しています。')
     const identity = await fetchSlackIdentity({
       clientId: env('SLACK_CLIENT_ID'),
-      clientSecret: env('SLACK_CLIENT_SECRET'),
+      clientSecret: secrets.SLACK_CLIENT_SECRET,
       code,
       redirectUri,
     })
@@ -105,24 +108,24 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
         email: identity.email,
         handle: identity.handle,
       },
-      env('SESSION_SECRET')
+      secrets.SESSION_SECRET
     )
     // アプリは自身が生成した nonce で照合するため、署名前の nonce を返す
     return redirect(`juice://auth?token=${encodeURIComponent(token)}&state=${nonce}`)
   }
 
   if (path === '/auth/me') {
-    const claims = bearerClaims(event)
+    const claims = bearerClaims(event, secrets.SESSION_SECRET)
     if (!claims) return json(401, { error: 'unauthorized' })
     return json(200, { sub: claims.sub, name: claims.name, team: claims.team, exp: claims.exp })
   }
 
   if (path === '/api/slack.post' && event.requestContext.http.method === 'POST') {
-    if (!bearerClaims(event)) return json(401, { error: 'unauthorized' })
+    if (!bearerClaims(event, secrets.SESSION_SECRET)) return json(401, { error: 'unauthorized' })
     const request = parseSlackPostRequest(rawBody(event))
     if (!request) return json(400, { error: 'bad request' })
     const result = await postToSlack(buildTeleworkMessage(request), {
-      botToken: env('SLACK_BOT_TOKEN'),
+      botToken: secrets.SLACK_BOT_TOKEN,
       channelId: env('SLACK_CHANNEL_ID'),
     })
     if ('error' in result) {
@@ -133,14 +136,14 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
   }
 
   if (path === '/api/attendance.send' && event.requestContext.http.method === 'POST') {
-    const claims = bearerClaims(event)
+    const claims = bearerClaims(event, secrets.SESSION_SECRET)
     if (!claims) return json(401, { error: 'unauthorized' })
     const request = parseAttendanceRequest(rawBody(event))
     if (!request) return json(400, { error: 'bad request' })
     const userName = resolveUserName(claims, process.env.ATTENDANCE_USER_OVERRIDES ?? '{}')
     const result = await postAttendance(userName, request.text, {
       apiUrl: env('ATTENDANCE_API_URL'),
-      apiKey: env('ATTENDANCE_API_KEY'),
+      apiKey: secrets.ATTENDANCE_API_KEY,
     })
     if ('error' in result) {
       console.error('attendance.send failed:', result.error)
@@ -158,14 +161,14 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
     (path === '/api/whiteboard.telework' || path === '/api/whiteboard.leave') &&
     event.requestContext.http.method === 'POST'
   ) {
-    const claims = bearerClaims(event)
+    const claims = bearerClaims(event, secrets.SESSION_SECRET)
     if (!claims) return json(401, { error: 'unauthorized' })
     // email クレームは Phase 2 以降のサインインでのみ付与される
     if (!claims.email) return json(401, { error: 'reauth_required' })
     const kind = path === '/api/whiteboard.telework' ? 'telework' : 'leave'
     const result = await postWhiteboard(kind, claims.email, {
       apiUrl: env('WHITEBOARD_API_URL'),
-      apiKey: env('WHITEBOARD_API_KEY'),
+      apiKey: secrets.WHITEBOARD_API_KEY,
     })
     if ('error' in result) {
       console.error('whiteboard failed:', result.error)

--- a/lambda/src/secrets.test.ts
+++ b/lambda/src/secrets.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockSend = vi.fn()
+vi.mock('@aws-sdk/client-ssm', () => ({
+  SSMClient: class { send = mockSend },
+  GetParametersCommand: class { constructor(public input: unknown) {} },
+}))
+
+import { loadSecrets, _resetForTest } from './secrets'
+
+const PREFIX = '/juice-proxy/'
+const PARAMS = [
+  { Name: `${PREFIX}SLACK_CLIENT_SECRET`, Value: 'cs' },
+  { Name: `${PREFIX}SESSION_SECRET`, Value: 'ss' },
+  { Name: `${PREFIX}SLACK_BOT_TOKEN`, Value: 'bt' },
+  { Name: `${PREFIX}ATTENDANCE_API_KEY`, Value: 'ak' },
+  { Name: `${PREFIX}WHITEBOARD_API_KEY`, Value: 'wk' },
+]
+
+beforeEach(() => {
+  _resetForTest()
+  mockSend.mockReset()
+  process.env.SSM_SECRET_PREFIX = PREFIX
+})
+
+afterEach(() => {
+  delete process.env.SSM_SECRET_PREFIX
+})
+
+describe('loadSecrets', () => {
+  it('SSM から5つの秘密を取得し、WithDecryption 付きで全名を要求する', async () => {
+    mockSend.mockResolvedValue({ Parameters: PARAMS })
+    const secrets = await loadSecrets()
+    expect(secrets).toEqual({
+      SLACK_CLIENT_SECRET: 'cs', SESSION_SECRET: 'ss', SLACK_BOT_TOKEN: 'bt',
+      ATTENDANCE_API_KEY: 'ak', WHITEBOARD_API_KEY: 'wk',
+    })
+    const cmd = mockSend.mock.calls[0][0]
+    expect(cmd.input.WithDecryption).toBe(true)
+    expect(cmd.input.Names).toContain(`${PREFIX}SESSION_SECRET`)
+    expect(cmd.input.Names).toHaveLength(5)
+  })
+
+  it('同一コンテナ内ではキャッシュし、2回目は SSM を呼ばない', async () => {
+    mockSend.mockResolvedValue({ Parameters: PARAMS })
+    await loadSecrets()
+    await loadSecrets()
+    expect(mockSend).toHaveBeenCalledTimes(1)
+  })
+
+  it('取得できないパラメータがあれば throw する', async () => {
+    mockSend.mockResolvedValue({ Parameters: PARAMS.slice(0, 4) }) // WHITEBOARD_API_KEY 欠落
+    await expect(loadSecrets()).rejects.toThrow('WHITEBOARD_API_KEY')
+  })
+
+  it('SSM_SECRET_PREFIX 未設定なら throw する', async () => {
+    delete process.env.SSM_SECRET_PREFIX
+    await expect(loadSecrets()).rejects.toThrow('SSM_SECRET_PREFIX')
+  })
+})

--- a/lambda/src/secrets.ts
+++ b/lambda/src/secrets.ts
@@ -1,0 +1,52 @@
+import { SSMClient, GetParametersCommand } from '@aws-sdk/client-ssm'
+
+// 秘密値は環境変数や tfstate に置かず、SSM Parameter Store(SecureString) から
+// 起動時(コールド時)に取得してキャッシュする。パラメータは Terraform 管理外
+// （CLI で投入）で、Lambda は名前のプレフィックスだけを env から知る。
+
+export interface Secrets {
+  SLACK_CLIENT_SECRET: string
+  SESSION_SECRET: string
+  SLACK_BOT_TOKEN: string
+  ATTENDANCE_API_KEY: string
+  WHITEBOARD_API_KEY: string
+}
+
+const SECRET_KEYS: (keyof Secrets)[] = [
+  'SLACK_CLIENT_SECRET',
+  'SESSION_SECRET',
+  'SLACK_BOT_TOKEN',
+  'ATTENDANCE_API_KEY',
+  'WHITEBOARD_API_KEY',
+]
+
+let cached: Secrets | null = null
+let client: SSMClient | null = null
+
+/** SSM から秘密値を取得する（同一コンテナ内ではキャッシュを再利用）。 */
+export async function loadSecrets(): Promise<Secrets> {
+  if (cached) return cached
+
+  const prefix = process.env.SSM_SECRET_PREFIX
+  if (!prefix) throw new Error('環境変数 SSM_SECRET_PREFIX が未設定')
+
+  client ??= new SSMClient({})
+  const names = SECRET_KEYS.map(k => `${prefix}${k}`)
+  const res = await client.send(new GetParametersCommand({ Names: names, WithDecryption: true }))
+
+  const byName = new Map((res.Parameters ?? []).map(p => [p.Name, p.Value]))
+  const out = {} as Secrets
+  for (const k of SECRET_KEYS) {
+    const value = byName.get(`${prefix}${k}`)
+    if (!value) throw new Error(`SSM パラメータが取得できません: ${prefix}${k}`)
+    out[k] = value
+  }
+  cached = out
+  return out
+}
+
+/** テスト用: キャッシュをリセットする。 */
+export function _resetForTest(): void {
+  cached = null
+  client = null
+}

--- a/lambda/terraform/main.tf
+++ b/lambda/terraform/main.tf
@@ -55,21 +55,47 @@ resource "aws_lambda_function" "juice_proxy" {
   # アカウント上限自体が flood 時の頭打ちとして機能する。
   # 上限引き上げを申請した場合は reserved_concurrent_executions = 5 を復活させること。
 
+  # 秘密値は環境変数に置かず SSM Parameter Store(SecureString) から実行時に取得する。
+  # ここには秘密でない設定と、秘密パラメータ名のプレフィックスのみを置く。
   environment {
     variables = {
       SLACK_CLIENT_ID           = var.slack_client_id
-      SLACK_CLIENT_SECRET       = var.slack_client_secret
       ALLOWED_TEAM_ID           = var.allowed_team_id
-      SESSION_SECRET            = var.session_secret
-      SLACK_BOT_TOKEN           = var.slack_bot_token
       SLACK_CHANNEL_ID          = var.slack_channel_id
       ATTENDANCE_API_URL        = var.attendance_api_url
-      ATTENDANCE_API_KEY        = var.attendance_api_key
       WHITEBOARD_API_URL        = var.whiteboard_api_url
-      WHITEBOARD_API_KEY        = var.whiteboard_api_key
       ATTENDANCE_USER_OVERRIDES = var.attendance_user_overrides
+      SSM_SECRET_PREFIX         = var.ssm_secret_prefix
     }
   }
+}
+
+# 秘密パラメータ（SecureString）は Terraform 管理外（CLI で投入）。
+# ここでは取得・復号の権限のみを付与し、値は state に載せない。
+data "aws_caller_identity" "current" {}
+
+data "aws_kms_alias" "ssm" {
+  name = "alias/aws/ssm"
+}
+
+resource "aws_iam_role_policy" "ssm_secrets" {
+  name = "juice-proxy-ssm-secrets"
+  role = aws_iam_role.lambda.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameters", "ssm:GetParameter"]
+        Resource = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_secret_prefix}*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = data.aws_kms_alias.ssm.target_key_arn
+      }
+    ]
+  })
 }
 
 resource "aws_lambda_function_url" "juice_proxy" {

--- a/lambda/terraform/terraform.tfvars.example
+++ b/lambda/terraform/terraform.tfvars.example
@@ -1,14 +1,14 @@
 # terraform.tfvars にコピーして実値を記入する（terraform.tfvars は gitignore 済み）
-slack_client_id     = "1234567890.1234567890123"
-slack_client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-allowed_team_id     = "TXXXXXXXX"
-session_secret      = "openssl rand -hex 32 の出力をここに"
-slack_bot_token     = "xoxb-..."
-slack_channel_id    = "CXXXXXXXX"
-attendance_api_url  = "https://example.com/api/receive_slack_post"
-attendance_api_key  = "xxxxxxxx"
-whiteboard_api_url  = "https://example.com"
-whiteboard_api_key  = "xxxxxxxx"
+#
+# 秘密値（SLACK_CLIENT_SECRET / SESSION_SECRET / SLACK_BOT_TOKEN /
+# ATTENDANCE_API_KEY / WHITEBOARD_API_KEY）はここには書かない。
+# SSM Parameter Store(SecureString) に CLI で投入する（README 参照）。tfstate に載せない。
+slack_client_id    = "1234567890.1234567890123"
+allowed_team_id    = "TXXXXXXXX"
+slack_channel_id   = "CXXXXXXXX"
+attendance_api_url = "https://example.com/api/receive_slack_post"
+whiteboard_api_url = "https://example.com"
+# ssm_secret_prefix は省略可（デフォルト "/juice-proxy/"）。
 # attendance_user_overrides は省略可（デフォルト "{}"）。
 # 勤怠の登録名が Slack の氏名と違う人が出たときだけ設定する:
 # attendance_user_overrides = "{\"U0XXXXXXX\":\"kanayama\"}"

--- a/lambda/terraform/variables.tf
+++ b/lambda/terraform/variables.tf
@@ -10,27 +10,9 @@ variable "slack_client_id" {
   sensitive   = true
 }
 
-variable "slack_client_secret" {
-  description = "Slack アプリの Client Secret"
-  type        = string
-  sensitive   = true
-}
-
 variable "allowed_team_id" {
   description = "許可する Slack ワークスペースの team ID（T 始まり）"
   type        = string
-}
-
-variable "session_secret" {
-  description = "セッション JWT の HS256 署名鍵（openssl rand -hex 32 で生成）"
-  type        = string
-  sensitive   = true
-}
-
-variable "slack_bot_token" {
-  description = "Slack 投稿用 Bot トークン（既存 bot のものを .env から移設）"
-  type        = string
-  sensitive   = true
 }
 
 variable "slack_channel_id" {
@@ -43,25 +25,19 @@ variable "attendance_api_url" {
   type        = string
 }
 
-variable "attendance_api_key" {
-  description = "勤怠 API キー（.env から移設）"
-  type        = string
-  sensitive   = true
-}
-
 variable "whiteboard_api_url" {
   description = "ホワイトボード API の URL（.env から移設）"
   type        = string
-}
-
-variable "whiteboard_api_key" {
-  description = "ホワイトボード API キー（.env から移設）"
-  type        = string
-  sensitive   = true
 }
 
 variable "attendance_user_overrides" {
   description = "勤怠 user_name の対応表（Slack user ID → 勤怠登録名の JSON。空で開始しエラーが出た人だけ追加する）"
   type        = string
   default     = "{}"
+}
+
+variable "ssm_secret_prefix" {
+  description = "秘密パラメータ（SecureString）名のプレフィックス。末尾は / にする。例: /juice-proxy/"
+  type        = string
+  default     = "/juice-proxy/"
 }


### PR DESCRIPTION
監査の低・別プロジェクト級①。秘密を **Lambda 環境変数・tfstate の平文から完全排除**し、SSM Parameter Store(SecureString) にアウトオブバンド管理（CLI 投入・Terraform 管理外）。**無料**（SSM Standard + AWS 管理キー `aws/ssm`）。

## 変更
- `lambda/src/secrets.ts`: 5つの秘密を SSM から起動時に取得しキャッシュ（`SLACK_CLIENT_SECRET`/`SESSION_SECRET`/`SLACK_BOT_TOKEN`/`ATTENDANCE_API_KEY`/`WHITEBOARD_API_KEY`）。
- `handler.ts`: `env()` ではなく `loadSecrets()` の値を使用。非秘密（client_id・team_id・URL 等）は env のまま。
- esbuild: `@aws-sdk/*` を external（Lambda ランタイム同梱）。
- Terraform: 秘密を環境変数から削除、`SSM_SECRET_PREFIX` 追加、`ssm:GetParameters` + `kms:Decrypt` の IAM ポリシー付与。**秘密値は state に載らない**。
- README / tfvars.example を SSM 方式に更新。

## テスト
- `secrets` 単体4件（SSM 取得・キャッシュ・欠落 throw・prefix 未設定）＋ handler は loadSecrets をモック
- typecheck / 全テスト 523 件パス / lambda build / `terraform validate` OK

## ⚠️ デプロイ手順（順序重要）
新コードは起動時に SSM を読むため、**先にパラメータを投入してから apply**:

1. SSM にパラメータ投入（既定 prefix `/juice-proxy/`）:
   ```bash
   REGION=ap-northeast-1
   put() { aws ssm put-parameter --region $REGION --type SecureString --overwrite --name "/juice-proxy/$1" --value "$2"; }
   put SLACK_CLIENT_SECRET "<現値>"
   put SESSION_SECRET      "<現値（既存と同じ値にすれば全員の再サインイン不要）>"
   put SLACK_BOT_TOKEN     "<現値>"
   put ATTENDANCE_API_KEY  "<現値>"
   put WHITEBOARD_API_KEY  "<現値>"
   ```
2. `lambda/terraform/terraform.tfvars` から上記5つの秘密行を削除。
3. `cd lambda && npm run build && cd terraform && terraform apply`。

※ 既存の `SESSION_SECRET` と同じ値を投入すれば、発行済み JWT はそのまま有効（再サインイン不要）。値を変えると全員再サインイン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)