### PR TITLE
feat: JWT の個別失効（ユーザー単位）を DynamoDB で実現（監査・低 / 方向A）

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -119,6 +119,14 @@ open dist-release/mac-arm64/Juice.app
   例: `aws ssm put-parameter --type SecureString --overwrite --name /juice-proxy/SLACK_BOT_TOKEN --value '新トークン'`
 - **全セッション失効**: `SESSION_SECRET` パラメータを新しい値に更新する（全 JWT が無効化される）
   例: `aws ssm put-parameter --type SecureString --overwrite --name /juice-proxy/SESSION_SECRET --value "$(openssl rand -hex 32)"`
+- **個別失効（退職者・紛失端末）**: `juice-revocations` テーブルに当該ユーザーの
+  失効時刻をセットする。これより前に発行された JWT が即座に無効化される
+  （本人は再サインインで復帰可。sub は Slack の user ID = U 始まり）:
+  ```bash
+  NOW=$(date +%s); TTL=$((NOW + 90*24*60*60))  # ttl で 90 日後に自動削除
+  aws dynamodb put-item --region ap-northeast-1 --table-name juice-revocations \
+    --item "{\"sub\":{\"S\":\"U0XXXXXXX\"},\"revokedBefore\":{\"N\":\"$NOW\"},\"ttl\":{\"N\":\"$TTL\"}}"
+  ```
 - **全リソース削除**: `terraform destroy`（SSM パラメータは Terraform 管理外なので別途 `aws ssm delete-parameter` で削除）
 - **勤怠の登録名の自動解決**: サインイン時に Slack の `users.info` から
   旧ユーザー名（@ハンドル）を取得し勤怠 user_name に使う。

--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -8,6 +8,7 @@
       "name": "juice-lambda",
       "version": "1.0.0",
       "devDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1068.0",
         "@aws-sdk/client-ssm": "^3.600.0",
         "@types/node": "^22.0.0",
         "esbuild": "^0.21.5"
@@ -79,6 +80,30 @@
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1068.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1068.0.tgz",
+      "integrity": "sha512-DOMUWnLSFHaRC0EixpWMnrQcQaV08P5rzAUdRTEkx72NaDRF0Q6+3QdtqX8ocyHfySzwMwOE9/vHRmhNvWHl/g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.55",
+        "@aws-sdk/dynamodb-codec": "^3.973.20",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
@@ -270,6 +295,53 @@
       "dependencies": {
         "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.20.tgz",
+      "integrity": "sha512-SFfxiqVgWeIe+RsJJNAMD//2IfehT4bLpGyNJRB0MgHmOIJtdcfMnR1k7KYyaHokSoQVdncVa9O9DIGa4eqcwg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.7.tgz",
+      "integrity": "sha512-LkwS3ZOUNL5kHzmz3dDx8lE3HOhZmf2VGjbJ/tMUZJYWWl3J0RJTZM7RFz1MLt06WDVvlShcAjY/RzhYlqLL7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.18.tgz",
+      "integrity": "sha512-1vKJt/6MBB/MBMRM3qzCMdW70syJY8u2DH+dq7yCnPn7wVJmyeAzAa/sK1lIbbYh8BVLbM5FspsT4zbe885gOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.7",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -1027,6 +1099,23 @@
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -7,6 +7,7 @@
     "build": "esbuild src/handler.ts --bundle --platform=node --target=node22 --format=cjs --external:@aws-sdk/* --outfile=dist/handler.js"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1068.0",
     "@aws-sdk/client-ssm": "^3.600.0",
     "@types/node": "^22.0.0",
     "esbuild": "^0.21.5"

--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { handler } from './handler'
 import { issueSessionJwt } from './sessionJwt'
 import { signState, verifyState } from './stateSign'
+import { isRevoked } from './revocations'
 import * as slackOidc from './slackOidc'
 import * as slackPost from './slackPost'
 import * as attendanceSend from './attendanceSend'
@@ -38,6 +39,9 @@ vi.mock('./secrets', () => ({
     WHITEBOARD_API_KEY: 'WKEY',
   }),
 }))
+
+// 失効チェックは既定で「失効なし」。失効ケースのテストでのみ true にする。
+vi.mock('./revocations', () => ({ isRevoked: vi.fn().mockResolvedValue(false) }))
 
 const STATE = 'a'.repeat(32)
 // /auth/callback には署名済み state が渡される（/auth/start が発行した形式）
@@ -77,6 +81,7 @@ beforeEach(() => {
   vi.mocked(slackPost.postToSlack).mockReset()
   vi.mocked(attendanceSend.postAttendance).mockReset()
   vi.mocked(whiteboardPost.postWhiteboard).mockReset()
+  vi.mocked(isRevoked).mockReset().mockResolvedValue(false)
 })
 
 describe('GET /auth/start', () => {
@@ -167,6 +172,14 @@ describe('GET /auth/me', () => {
     expect((await handler(makeEvent('/auth/me'))).statusCode).toBe(401)
     const res = await handler(makeEvent('/auth/me', {}, { authorization: 'Bearer xx.yy.zz' }))
     expect(res.statusCode).toBe(401)
+  })
+
+  it('失効済みユーザーの有効 JWT は 401（個別失効）', async () => {
+    vi.mocked(isRevoked).mockResolvedValue(true)
+    const token = issueSessionJwt({ sub: 'U123', name: '金山', team: 'T999' }, 'test-secret')
+    const res = await handler(makeEvent('/auth/me', {}, { authorization: `Bearer ${token}` }))
+    expect(res.statusCode).toBe(401)
+    expect(isRevoked).toHaveBeenCalledWith('U123', expect.any(Number))
   })
 })
 

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -1,5 +1,6 @@
 import { buildAuthorizeUrl, fetchSlackIdentity } from './slackOidc'
-import { issueSessionJwt, verifySessionJwt } from './sessionJwt'
+import { issueSessionJwt, verifySessionJwt, type SessionClaims } from './sessionJwt'
+import { isRevoked } from './revocations'
 import { buildTeleworkMessage, parseSlackPostRequest, postToSlack } from './slackPost'
 import { parseAttendanceRequest, postAttendance, resolveUserName } from './attendanceSend'
 import { postWhiteboard } from './whiteboardPost'
@@ -42,10 +43,15 @@ function json(statusCode: number, data: unknown): FunctionUrlResponse {
   }
 }
 
-function bearerClaims(event: FunctionUrlEvent, sessionSecret: string): ReturnType<typeof verifySessionJwt> {
+async function bearerClaims(event: FunctionUrlEvent, sessionSecret: string): Promise<SessionClaims | null> {
   const auth = event.headers.authorization ?? event.headers.Authorization ?? ''
   const match = auth.match(/^Bearer (.+)$/)
-  return match ? verifySessionJwt(match[1], sessionSecret) : null
+  if (!match) return null
+  const claims = verifySessionJwt(match[1], sessionSecret)
+  if (!claims) return null
+  // 失効チェックは JWT 検証成功後のみ行う（無効トークンの flood で DynamoDB を叩かせない）
+  if (await isRevoked(claims.sub, claims.iat)) return null
+  return claims
 }
 
 function rawBody(event: FunctionUrlEvent): string {
@@ -115,13 +121,13 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
   }
 
   if (path === '/auth/me') {
-    const claims = bearerClaims(event, secrets.SESSION_SECRET)
+    const claims = await bearerClaims(event, secrets.SESSION_SECRET)
     if (!claims) return json(401, { error: 'unauthorized' })
     return json(200, { sub: claims.sub, name: claims.name, team: claims.team, exp: claims.exp })
   }
 
   if (path === '/api/slack.post' && event.requestContext.http.method === 'POST') {
-    if (!bearerClaims(event, secrets.SESSION_SECRET)) return json(401, { error: 'unauthorized' })
+    if (!(await bearerClaims(event, secrets.SESSION_SECRET))) return json(401, { error: 'unauthorized' })
     const request = parseSlackPostRequest(rawBody(event))
     if (!request) return json(400, { error: 'bad request' })
     const result = await postToSlack(buildTeleworkMessage(request), {
@@ -136,7 +142,7 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
   }
 
   if (path === '/api/attendance.send' && event.requestContext.http.method === 'POST') {
-    const claims = bearerClaims(event, secrets.SESSION_SECRET)
+    const claims = await bearerClaims(event, secrets.SESSION_SECRET)
     if (!claims) return json(401, { error: 'unauthorized' })
     const request = parseAttendanceRequest(rawBody(event))
     if (!request) return json(400, { error: 'bad request' })
@@ -161,7 +167,7 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
     (path === '/api/whiteboard.telework' || path === '/api/whiteboard.leave') &&
     event.requestContext.http.method === 'POST'
   ) {
-    const claims = bearerClaims(event, secrets.SESSION_SECRET)
+    const claims = await bearerClaims(event, secrets.SESSION_SECRET)
     if (!claims) return json(401, { error: 'unauthorized' })
     // email クレームは Phase 2 以降のサインインでのみ付与される
     if (!claims.email) return json(401, { error: 'reauth_required' })

--- a/lambda/src/revocations.test.ts
+++ b/lambda/src/revocations.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockSend = vi.fn()
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: class { send = mockSend },
+  GetItemCommand: class { constructor(public input: unknown) {} },
+}))
+
+import { getRevokedBefore, isRevoked, _resetForTest } from './revocations'
+
+beforeEach(() => {
+  _resetForTest()
+  mockSend.mockReset()
+  process.env.REVOCATION_TABLE = 'juice-revocations'
+})
+
+afterEach(() => {
+  delete process.env.REVOCATION_TABLE
+})
+
+describe('getRevokedBefore', () => {
+  it('レコードがあれば revokedBefore を数値で返す', async () => {
+    mockSend.mockResolvedValue({ Item: { revokedBefore: { N: '1000' } } })
+    expect(await getRevokedBefore('U1')).toBe(1000)
+    const cmd = mockSend.mock.calls[0][0]
+    expect(cmd.input.Key).toEqual({ sub: { S: 'U1' } })
+  })
+
+  it('レコードが無ければ null', async () => {
+    mockSend.mockResolvedValue({})
+    expect(await getRevokedBefore('U1')).toBeNull()
+  })
+
+  it('テーブル未設定なら DynamoDB を呼ばず null（機能オフ）', async () => {
+    delete process.env.REVOCATION_TABLE
+    expect(await getRevokedBefore('U1')).toBeNull()
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+})
+
+describe('isRevoked', () => {
+  it('iat が revokedBefore より前なら失効', async () => {
+    mockSend.mockResolvedValue({ Item: { revokedBefore: { N: '1000' } } })
+    expect(await isRevoked('U1', 999)).toBe(true)
+  })
+
+  it('iat が revokedBefore 以降なら有効', async () => {
+    mockSend.mockResolvedValue({ Item: { revokedBefore: { N: '1000' } } })
+    expect(await isRevoked('U1', 1000)).toBe(false)
+    expect(await isRevoked('U1', 1001)).toBe(false)
+  })
+
+  it('失効レコードが無ければ有効', async () => {
+    mockSend.mockResolvedValue({})
+    expect(await isRevoked('U1', 1)).toBe(false)
+  })
+})

--- a/lambda/src/revocations.ts
+++ b/lambda/src/revocations.ts
@@ -1,0 +1,35 @@
+import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb'
+
+// JWT の個別失効。ステートレス JWT は単体で無効化できないため、
+// 「ユーザー(sub)ごとの失効時刻(revokedBefore)」を DynamoDB に持ち、
+// それより前に発行されたトークン(iat < revokedBefore)を拒否する。
+// 退職者・紛失端末は当該 sub の revokedBefore を現在時刻にセットすれば即停止できる。
+
+let client: DynamoDBClient | null = null
+
+/** 当該ユーザーの失効時刻(unix秒)を返す。レコードが無ければ null。 */
+export async function getRevokedBefore(sub: string): Promise<number | null> {
+  const table = process.env.REVOCATION_TABLE
+  // テーブル未設定なら失効機能は無効（後方互換・段階的導入のため）
+  if (!table) return null
+
+  client ??= new DynamoDBClient({})
+  const res = await client.send(new GetItemCommand({
+    TableName: table,
+    Key: { sub: { S: sub } },
+    ProjectionExpression: 'revokedBefore',
+  }))
+  const value = res.Item?.revokedBefore?.N
+  return value ? Number(value) : null
+}
+
+/** iat(発行時刻) のトークンが失効済みか。 */
+export async function isRevoked(sub: string, iat: number): Promise<boolean> {
+  const revokedBefore = await getRevokedBefore(sub)
+  return revokedBefore != null && iat < revokedBefore
+}
+
+/** テスト用: クライアントをリセットする。 */
+export function _resetForTest(): void {
+  client = null
+}

--- a/lambda/terraform/main.tf
+++ b/lambda/terraform/main.tf
@@ -66,8 +66,41 @@ resource "aws_lambda_function" "juice_proxy" {
       WHITEBOARD_API_URL        = var.whiteboard_api_url
       ATTENDANCE_USER_OVERRIDES = var.attendance_user_overrides
       SSM_SECRET_PREFIX         = var.ssm_secret_prefix
+      REVOCATION_TABLE          = aws_dynamodb_table.revocations.name
     }
   }
+}
+
+# JWT 個別失効テーブル: ユーザー(sub)ごとの失効時刻(revokedBefore)を持つ。
+# iat < revokedBefore のトークンを拒否する。退職者・紛失端末はこの sub を更新して即停止。
+resource "aws_dynamodb_table" "revocations" {
+  name         = "juice-revocations"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "sub"
+
+  attribute {
+    name = "sub"
+    type = "S"
+  }
+
+  # ttl 属性で古い失効レコードを自動削除（トークン最大有効期間の経過後）
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+}
+
+resource "aws_iam_role_policy" "dynamodb_revocations" {
+  name = "juice-proxy-dynamodb-revocations"
+  role = aws_iam_role.lambda.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["dynamodb:GetItem"]
+      Resource = aws_dynamodb_table.revocations.arn
+    }]
+  })
 }
 
 # 秘密パラメータ（SecureString）は Terraform 管理外（CLI で投入）。


### PR DESCRIPTION
監査の低・別プロジェクト級②。JWT の **個別失効**（退職者・紛失端末を即停止）を最小構成で実現。前回ご相談の「セッション個別失効」案件。

## 仕組み（方向A: 自前JWT + 失効ストア）
- ステートレス JWT は単体で無効化できないため、**ユーザー(sub)ごとの失効時刻 `revokedBefore`** を DynamoDB に持つ。
- 各保護リクエストで JWT 検証成功後に「`iat < revokedBefore[sub]` なら 401」とする。
- 退職者・紛失端末は当該 sub の `revokedBefore` を現在時刻にセットすれば**即停止**（本人は再サインインで復帰可）。全員を巻き込む `SESSION_SECRET` ローテーションが不要に。

## 変更
- `lambda/src/revocations.ts`: sub の失効時刻を DynamoDB から引き iat と比較。`REVOCATION_TABLE` 未設定なら機能オフ（後方互換・段階導入）。
- `handler.ts`: `bearerClaims` を async 化し、**JWT 検証成功後のみ**失効チェック（無効トークンの flood で DynamoDB を叩かせない）。
- Terraform: `juice-revocations` テーブル（`PAY_PER_REQUEST`・`ttl` 自動削除）+ `dynamodb:GetItem` IAM + `REVOCATION_TABLE` env。
- README: 個別失効の運用コマンドを追記。

## コスト
DynamoDB オンデマンド。失効した人のレコードのみ・認証済みリクエストのみ GetItem → 実質無料枠。

## テスト
- `revocations` 単体6件 + handler の失効ケース1件
- typecheck / 全 530 件パス / `terraform validate` OK

## デプロイ
`npm run build` → `terraform apply`（DynamoDB テーブル新規作成 + Lambda 更新）。失効方法は README 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)