### PR TITLE
fix: ビルドサイズ大幅削減とアイコン統一・メモリ調整

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -22,7 +22,7 @@ mac:
 dmg:
   title: Juice
 
-# ファイルを含める
+# ファイルを含める（デフォルトで全てを含み、以下のパターンで除外する）
 files:
   - '!**/.DS_Store'
   - '!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme}'
@@ -30,3 +30,15 @@ files:
   - '!**/node_modules/.bin'
   - '!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}'
   - '!**/._*'
+  # 実行に不要なディレクトリ・ファイルを除外（ビルドサイズ削減）
+  - '!lambda${/*}'        # AWS Lambda + Terraform プロバイダバイナリ（約810MB）
+  - '!docs${/*}'          # ドキュメント
+  - '!src${/*}'           # ソース（実行は out/ のビルド成果物を使う）
+  - '!**/*.map'           # ソースマップ
+  - '!**/*.tsbuildinfo'   # TypeScript インクリメンタルビルド情報
+  - '!CLAUDE.md'
+  - '!**/*.test.{ts,tsx}'
+  - '!.env'               # ビルド時に埋め込まれるため実行時は不要
+  - '!.superpowers${/*}'  # 開発ツールの作業ディレクトリ
+  - '!.claude${/*}'
+  - '!tsconfig*.json'

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "culori": "^4.0.2",
         "electron-log": "^5.4.4",
         "iconoir-react": "^7.11.0",
-        "lucide-react": "^1.17.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "tailwind-merge": "^3.6.0"
@@ -9736,15 +9735,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
-      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "culori": "^4.0.2",
     "electron-log": "^5.4.4",
     "iconoir-react": "^7.11.0",
-    "lucide-react": "^1.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwind-merge": "^3.6.0"

--- a/src/main/windows/shared.ts
+++ b/src/main/windows/shared.ts
@@ -6,6 +6,8 @@ export const sharedWebPreferences = {
   preload: join(__dirname, '../preload/index.js'),
   contextIsolation: true,
   nodeIntegration: false,
+  // タイマーアプリにスペルチェックは不要。辞書の読み込み分のメモリを節約する。
+  spellcheck: false,
 } as const
 
 /**

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import { Check, NavArrowDown, NavArrowUp } from "iconoir-react"
 
 import { cn } from "@/lib/utils"
 
@@ -24,7 +24,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <NavArrowDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -42,7 +42,7 @@ const SelectScrollUpButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronUp className="h-4 w-4" />
+    <NavArrowUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
@@ -59,7 +59,7 @@ const SelectScrollDownButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronDown className="h-4 w-4" />
+    <NavArrowDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
 ))
 SelectScrollDownButton.displayName =


### PR DESCRIPTION
## やったこと

- **不要ファイルをパッケージから除外**: `lambda/terraform` の AWS プロバイダバイナリ(約810MB)等が app.asar に混入していたため `electron-builder.yml` の `files:` で除外
  - app.asar: 870MB → 22MB / DMG(arm64): 272MB → 99MB
  - `.env` 等の開発用ファイル混入も除去
- **アイコンライブラリを iconoir-react に統一**: 1ファイルでしか使っていなかった lucide-react を削除
- **spellcheck 無効化**: タイマーアプリに不要なためメモリ節約

## 備考

メモリ最適化として `disableHardwareAcceleration()` も検証したが、macOS では GPU プロセスが消えず効果がなかったため不採用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)