### PR TITLE
feat: ハンバーガーメニューを Slack アカウントアバターに変更

### DIFF
--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -113,6 +113,7 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
         team: identity.teamId,
         email: identity.email,
         handle: identity.handle,
+        picture: identity.picture,
       },
       secrets.SESSION_SECRET
     )

--- a/lambda/src/sessionJwt.test.ts
+++ b/lambda/src/sessionJwt.test.ts
@@ -86,4 +86,18 @@ describe('sessionJwt', () => {
     expect(claims).not.toBeNull()
     expect(claims!.handle).toBeUndefined()
   })
+
+  it('picture 付きで発行したトークンは picture を返す', () => {
+    const token = issueSessionJwt(
+      { sub: 'U1', name: 'a', team: 'T1', picture: 'https://slack.test/a.png' }, SECRET, NOW
+    )
+    expect(verifySessionJwt(token, SECRET, NOW)!.picture).toBe('https://slack.test/a.png')
+  })
+
+  it('picture 無しで発行した旧トークンも検証できる（picture は undefined）', () => {
+    const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T1' }, SECRET, NOW)
+    const claims = verifySessionJwt(token, SECRET, NOW)
+    expect(claims).not.toBeNull()
+    expect(claims!.picture).toBeUndefined()
+  })
 })

--- a/lambda/src/sessionJwt.ts
+++ b/lambda/src/sessionJwt.ts
@@ -8,6 +8,8 @@ export interface SessionClaims {
   email?: string
   /** Slack 旧ユーザー名（@ハンドル）。users.info から取得。古い認可では undefined */
   handle?: string
+  /** プロフィール画像URL。古いトークンでは undefined */
+  picture?: string
   iat: number
   exp: number
 }
@@ -22,7 +24,14 @@ function hmac(input: string, secret: string): Buffer {
 
 /** HS256 のセッション JWT を発行する */
 export function issueSessionJwt(
-  identity: { sub: string; name: string; team: string; email?: string; handle?: string },
+  identity: {
+    sub: string
+    name: string
+    team: string
+    email?: string
+    handle?: string
+    picture?: string
+  },
   secret: string,
   now: number = nowSec()
 ): string {

--- a/lambda/src/slackOidc.test.ts
+++ b/lambda/src/slackOidc.test.ts
@@ -64,6 +64,30 @@ describe('fetchSlackIdentity', () => {
     })
   })
 
+  it('profile の image_192 をアバターURL(picture)として返す', async () => {
+    mockFetchSequence([
+      { ok: true, authed_user: { id: 'U123', access_token: 'xoxp-test' }, team: { id: 'T999' } },
+      {
+        ok: true,
+        user: {
+          name: 'kanayama',
+          real_name: '金山 良太',
+          profile: { email: 'kanayama@jsl.co.jp', image_192: 'https://slack.test/avatar_192.png' },
+        },
+      },
+    ])
+    const result = await fetchSlackIdentity(OPTS)
+    expect(result).toMatchObject({ picture: 'https://slack.test/avatar_192.png' })
+  })
+
+  it('image_192 が無ければ image_72 をアバターURLに使う', async () => {
+    mockFetchSequence([
+      { ok: true, authed_user: { id: 'U123', access_token: 'xoxp-test' }, team: { id: 'T999' } },
+      { ok: true, user: { name: 'kanayama', profile: { image_72: 'https://slack.test/avatar_72.png' } } },
+    ])
+    expect(await fetchSlackIdentity(OPTS)).toMatchObject({ picture: 'https://slack.test/avatar_72.png' })
+  })
+
   it('oauth.v2.access 失敗時は error を返す', async () => {
     mockFetchSequence([{ ok: false, error: 'invalid_code' }])
     expect(await fetchSlackIdentity(OPTS)).toEqual({ error: 'oauth: invalid_code' })

--- a/lambda/src/slackOidc.ts
+++ b/lambda/src/slackOidc.ts
@@ -8,6 +8,8 @@ export interface SlackIdentity {
   email?: string
   /** Slack 旧ユーザー名（@ハンドル）= users.info の name。勤怠照合に使う */
   handle?: string
+  /** プロフィール画像URL（image_192 優先、無ければ image_72）。取得できなければ undefined */
+  picture?: string
 }
 
 export interface SlackOidcError {
@@ -38,7 +40,11 @@ interface OAuthAccessResponse {
 
 interface UsersInfoResponse {
   ok: boolean
-  user?: { name?: string; real_name?: string; profile?: { email?: string } }
+  user?: {
+    name?: string
+    real_name?: string
+    profile?: { email?: string; image_192?: string; image_72?: string }
+  }
   error?: string
 }
 
@@ -90,6 +96,7 @@ export async function fetchSlackIdentity(opts: {
       teamId,
       email: u.profile?.email,
       handle: u.name,
+      picture: u.profile?.image_192 || u.profile?.image_72,
     }
   } catch (e) {
     return { error: `network: ${e instanceof Error ? e.message : 'unknown'}` }

--- a/src/main/auth/authStore.test.ts
+++ b/src/main/auth/authStore.test.ts
@@ -55,6 +55,16 @@ describe('AuthStore', () => {
     expect(status.expiresAt).toBe(new Date(FUTURE * 1000).toISOString())
   })
 
+  it('getStatus が JWT payload の picture を avatarUrl として返す', async () => {
+    await store.saveToken(fakeJwt({ name: '金山', picture: 'https://slack.test/a.png', exp: FUTURE }))
+    expect((await store.getStatus()).avatarUrl).toBe('https://slack.test/a.png')
+  })
+
+  it('picture が無い旧トークンは avatarUrl が undefined', async () => {
+    await store.saveToken(fakeJwt({ name: '金山', exp: FUTURE }))
+    expect((await store.getStatus()).avatarUrl).toBeUndefined()
+  })
+
   it('期限切れトークンは signedIn: false', async () => {
     await store.saveToken(fakeJwt({ name: 'x', exp: PAST }))
     expect(await store.getStatus()).toEqual({ signedIn: false })

--- a/src/main/auth/authStore.ts
+++ b/src/main/auth/authStore.ts
@@ -43,6 +43,7 @@ export class AuthStore {
       return {
         signedIn: true,
         name: typeof payload.name === 'string' ? payload.name : undefined,
+        avatarUrl: typeof payload.picture === 'string' ? payload.picture : undefined,
         expiresAt: new Date(payload.exp * 1000).toISOString(),
       }
     } catch {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: https://*.slack-edge.com https://secure.gravatar.com"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/renderer/src/App.module.css
+++ b/src/renderer/src/App.module.css
@@ -37,10 +37,62 @@
   -webkit-app-region: no-drag;
 }
 
-/* ハンバーガーメニュー */
+/* アカウントメニュー */
 .menuWrapper {
   position: relative;
   -webkit-app-region: no-drag;
+}
+
+.avatarImg {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  display: block;
+}
+
+/* ドロップダウン内アカウントセクション */
+.menuAccount {
+  padding: 12px 16px 10px;
+}
+
+.menuAccountName {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.menuAccountMeta {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.menuAccountAction {
+  margin-top: 8px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--bg-hover);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--text-primary);
+  transition: var(--transition-smooth);
+}
+
+.menuAccountAction:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.menuDivider {
+  height: 1px;
+  background: var(--glass-border);
 }
 
 .menuPopup {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,8 +14,9 @@ import { WorkStartOverlay } from './components/Popover/WorkStartOverlay'
 import { useWorkday } from './hooks/useWorkday'
 import { useSuggestions } from './hooks/useSuggestions'
 import { windowRepository } from './repositories/windowRepository'
-import { Menu, Timer, Calendar, Xmark, OpenNewWindow, SendDiagonal } from 'iconoir-react'
+import { User, Timer, Calendar, Xmark, OpenNewWindow, SendDiagonal } from 'iconoir-react'
 import { Button } from '@/components/ui/button'
+import { useAuthStatus } from './hooks/useAuthStatus'
 
 type Page = 'timer' | 'calendar' | 'attendance'
 
@@ -33,10 +34,27 @@ export default function App() {
   return <PopoverView />
 }
 
+/** トリガー用のアバター。画像があれば表示し、無い・読み込み失敗時は人型アイコンにフォールバック */
+function AccountAvatar({ avatarUrl, name }: { avatarUrl?: string; name?: string }) {
+  const [failed, setFailed] = useState(false)
+  if (avatarUrl && !failed) {
+    return (
+      <img
+        className={styles.avatarImg}
+        src={avatarUrl}
+        alt={name ?? 'アカウント'}
+        onError={() => setFailed(true)}
+      />
+    )
+  }
+  return <User width={16} height={16} />
+}
+
 function PopoverView() {
   const [currentPage, setCurrentPage] = useState<Page>('timer')
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  const { status, signIn, signOut } = useAuthStatus()
 
   const sessions = useSessions()
 
@@ -58,11 +76,46 @@ function PopoverView() {
         </Button>
         <span className={styles.logo}>juice</span>
         <div className={styles.menuWrapper} ref={menuRef}>
-          <Button variant="ghost" size="icon" aria-label="メニュー" className="[-webkit-app-region:no-drag]" onClick={() => setMenuOpen(p => !p)}>
-            <Menu width={16} height={16} />
+          <Button variant="ghost" size="icon" aria-label="アカウント" className="[-webkit-app-region:no-drag]" onClick={() => setMenuOpen(p => !p)}>
+            <AccountAvatar avatarUrl={status.avatarUrl} name={status.name} />
           </Button>
           {menuOpen && (
             <div className={styles.menuPopup}>
+              <div className={styles.menuAccount}>
+                {status.signedIn ? (
+                  <>
+                    <p className={styles.menuAccountName}>{status.name}</p>
+                    {status.expiresAt && (
+                      <p className={styles.menuAccountMeta}>
+                        有効期限: {new Date(status.expiresAt).toLocaleDateString('ja-JP')}
+                      </p>
+                    )}
+                    <button
+                      className={styles.menuAccountAction}
+                      onClick={() => {
+                        setMenuOpen(false)
+                        signOut()
+                      }}
+                    >
+                      サインアウト
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <p className={styles.menuAccountName}>未サインイン</p>
+                    <button
+                      className={styles.menuAccountAction}
+                      onClick={() => {
+                        setMenuOpen(false)
+                        signIn()
+                      }}
+                    >
+                      Slack でサインイン
+                    </button>
+                  </>
+                )}
+              </div>
+              <div className={styles.menuDivider} />
               <button
                 className={styles.menuItem}
                 onClick={() => {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -30,6 +30,8 @@ export interface PomodoroSettings {
 export interface AuthStatus {
   signedIn: boolean
   name?: string
+  /** Slack プロフィール画像URL。古いトークン・未取得時は undefined */
+  avatarUrl?: string
   /** ISO 8601。signedIn が true のときのみ */
   expiresAt?: string
 }


### PR DESCRIPTION
## 概要
ヘッダーのハンバーガーメニューを Slack アカウントアバターアイコンに変更。

## やったこと
- メニューアイコン → Slack プロフィール画像（未取得/読込失敗時は人型アイコンにフォールバック）
- Lambda → JWT → AuthStatus にアバターURL(`picture`)を追加（**Lambda デプロイ済み**）
- ドロップダウンにアカウント情報（表示名・有効期限・サインイン/アウト）を追加し、既存 JSL リンクは維持
- CSP に `img-src`（slack-edge / gravatar）を追加（無いと外部画像がブロックされる）

## 注意
既存ログインユーザーは再サインインでアバターが反映される（旧トークンに `picture` が無いため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)