### PR TITLE
feat: Slack 認証コールバックを完了ページ化（タブが残る問題を緩和）

### DIFF
--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -106,17 +106,28 @@ describe('GET /auth/start', () => {
 })
 
 describe('GET /auth/callback', () => {
-  it('本人確認 OK なら JWT 付きで juice:// へ 302（state は元の nonce に戻る）', async () => {
+  it('本人確認 OK なら JWT 付きの完了ページを返す（deep link は元の nonce に戻る）', async () => {
     vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({
       sub: 'U123', name: '金山', teamId: 'T999',
     })
     const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: SIGNED }))
-    expect(res.statusCode).toBe(302)
-    const url = new URL(res.headers!.Location)
+    expect(res.statusCode).toBe(200)
+    expect(res.headers!['Content-Type']).toContain('text/html')
+    const url = new URL(res.body!.match(/juice:\/\/[^"]+/)![0])
     expect(url.protocol).toBe('juice:')
     // アプリが照合できるよう、署名前の nonce を返す
     expect(url.searchParams.get('state')).toBe(STATE)
     expect(url.searchParams.get('token')!.split('.')).toHaveLength(3)
+  })
+
+  it('完了ページは「タブを閉じてOK」案内とアプリを開くリンクを含む', async () => {
+    vi.mocked(slackOidc.fetchSlackIdentity).mockResolvedValue({
+      sub: 'U123', name: '金山', teamId: 'T999',
+    })
+    const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: SIGNED }))
+    expect(res.body).toContain('サインイン完了')
+    expect(res.body).toContain('このタブは閉じて')
+    expect(res.body).toContain('Juice を開く')
   })
 
   it('署名されていない（生の）state は 400 で拒否する', async () => {
@@ -153,7 +164,7 @@ describe('GET /auth/callback', () => {
       sub: 'U123', name: '金山', teamId: 'T999', handle: 'kanayama',
     })
     const res = await handler(makeEvent('/auth/callback', { code: 'C1', state: SIGNED }))
-    const url = new URL(res.headers!.Location)
+    const url = new URL(res.body!.match(/juice:\/\/[^"]+/)![0])
     const token = url.searchParams.get('token')!
     const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf-8'))
     expect(payload.handle).toBe('kanayama')

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -69,6 +69,24 @@ function errorPage(message: string): FunctionUrlResponse {
   }
 }
 
+/**
+ * サインイン完了ページ。deep link を自動発火してアプリに戻しつつ、
+ * 「このタブは閉じてOK」と案内する。外部ブラウザのタブはこちらから自動で
+ * 閉じられない（スクリプトで開いたタブではないため）ので明示する。
+ * token を含むため no-store。deep link の & は HTML エスケープしない
+ * （new URL でそのまま解釈できるようにする / 全ブラウザで動作）。
+ */
+function successPage(deepLink: string): FunctionUrlResponse {
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+    body: `<!doctype html><html lang="ja"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Juice サインイン完了</title></head><body style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;padding:2.5rem;text-align:center;color:#333"><h1 style="font-size:1.4rem;margin-bottom:.5rem">✅ サインイン完了</h1><p>Juice アプリに戻っています…</p><p style="color:#888;font-size:.9rem;margin-top:.75rem">自動で戻らない場合は下のボタンを押してください。<br>このタブは閉じて構いません。</p><p style="margin-top:1.5rem"><a href="${deepLink}" style="display:inline-block;padding:.6rem 1.4rem;background:#6b4eff;color:#fff;border-radius:8px;text-decoration:none;font-weight:600">Juice を開く</a></p><script>location.href=${JSON.stringify(deepLink)}</script></body></html>`,
+  }
+}
+
 export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlResponse> {
   const path = event.rawPath
   const query = event.queryStringParameters ?? {}
@@ -118,7 +136,7 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
       secrets.SESSION_SECRET
     )
     // アプリは自身が生成した nonce で照合するため、署名前の nonce を返す
-    return redirect(`juice://auth?token=${encodeURIComponent(token)}&state=${nonce}`)
+    return successPage(`juice://auth?token=${encodeURIComponent(token)}&state=${nonce}`)
   }
 
   if (path === '/auth/me') {


### PR DESCRIPTION
## 概要
サインイン後にブラウザのタブが残る件への対応。外部ブラウザのタブは仕様上こちらから自動で閉じられないため、コールバックを完了ページにして「閉じてOK」と明示する。

## やったこと
- `/auth/callback` を `juice://` への 302 から HTML 完了ページへ変更
- deep link を自動発火しつつ「このタブは閉じて構いません」と案内、手動で開くボタンも用意
- token を含むため `Cache-Control: no-store`

## デプロイ
Lambda は `terraform apply` で**デプロイ済み**（health: auth/start 302・auth/me 401 確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)