### PR TITLE
chore: dev/preview 前に Electron 本体バイナリの存在を保証

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "author": "kanayama",
   "homepage": ".",
   "scripts": {
+    "ensure-electron": "node scripts/ensure-electron.mjs",
+    "predev": "node scripts/ensure-electron.mjs",
     "dev": "env -u ELECTRON_RUN_AS_NODE electron-vite dev",
     "build": "electron-vite build",
+    "prepreview": "node scripts/ensure-electron.mjs",
     "preview": "env -u ELECTRON_RUN_AS_NODE electron-vite preview",
     "package": "electron-vite build && electron-builder --config electron-builder.yml",
     "test": "vitest run",

--- a/scripts/ensure-electron.mjs
+++ b/scripts/ensure-electron.mjs
@@ -1,0 +1,29 @@
+// dev / preview の前に Electron 本体バイナリが入っているか保証する。
+//
+// electron の postinstall（install.js）がダウンロード途中で失敗すると
+// node_modules/electron/dist と path.txt が欠け、electron-vite が
+// 「Error: Electron uninstall」で起動できなくなる。
+// install.js は冪等（インストール済みなら即 exit 0、欠けていれば取得）なので
+// 起動前に毎回呼んで自己修復する。
+import { existsSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+
+const installer = 'node_modules/electron/install.js'
+
+if (!existsSync(installer)) {
+  console.error(
+    '\n[ensure-electron] electron パッケージが見つかりません。`npm install` を実行してください。\n'
+  )
+  process.exit(1)
+}
+
+try {
+  execFileSync(process.execPath, [installer], { stdio: 'inherit' })
+} catch {
+  console.error(
+    '\n[ensure-electron] Electron 本体の取得に失敗しました。ネットワークを確認のうえ\n' +
+      '  node node_modules/electron/install.js\n' +
+      'を手動で実行してください。\n'
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
## 背景
electron の postinstall（バイナリDL）が中断/失敗すると `node_modules/electron/dist`・`path.txt` が欠け、`npm run dev` が `Error: Electron uninstall` で起動できなくなる。`npm install` をやり直しても既存パッケージの postinstall は再実行されないため直りにくい。

## 変更
- `scripts/ensure-electron.mjs` を追加。`install.js`（冪等）を呼んで欠損時のみ自己修復
- `predev` / `prepreview` に組み込み。起動前に自動実行（インストール済みなら ~0.2 秒で素通り）
- electron 未インストール時は `npm install` を促して停止

🤖 Generated with [Claude Code](https://claude.com/claude-code)