### PR TITLE
fix: ホワイトボード2段呼び出しの順序を attendance→magnet に変更

### DIFF
--- a/lambda/src/whiteboardPost.test.ts
+++ b/lambda/src/whiteboardPost.test.ts
@@ -15,39 +15,41 @@ function mockFetchSequence(responses: Array<{ ok: boolean; status?: number }>): 
 }
 
 describe('postWhiteboard', () => {
-  it('telework は magnet=2 と出勤=true を順に送る', async () => {
+  it('telework は 出勤打刻=true → magnet=2 を順に送る', async () => {
     const fetchMock = mockFetchSequence([{ ok: true }, { ok: true }])
     const result = await postWhiteboard('telework', EMAIL, OPTS)
     expect(result).toEqual({ ok: true })
-    const [magnetUrl, magnetInit] = fetchMock.mock.calls[0]
-    expect(magnetUrl).toBe('https://wb.test/api/magnet?apiKey=WBKEY')
-    expect(JSON.parse(magnetInit.body)).toEqual({ magnet_id: 2, email: EMAIL })
-    const [attUrl, attInit] = fetchMock.mock.calls[1]
+    // 1回目: 打刻（表示ステータスより先に確定させる）
+    const [attUrl, attInit] = fetchMock.mock.calls[0]
     expect(attUrl).toBe('https://wb.test/api/attendance?apiKey=WBKEY')
     const params = new URLSearchParams(String(attInit.body))
     expect(params.get('come_to_the_office')).toBe('true')
     expect(params.get('email')).toBe(EMAIL)
+    // 2回目: magnet（表示ステータス）
+    const [magnetUrl, magnetInit] = fetchMock.mock.calls[1]
+    expect(magnetUrl).toBe('https://wb.test/api/magnet?apiKey=WBKEY')
+    expect(JSON.parse(magnetInit.body)).toEqual({ magnet_id: 2, email: EMAIL })
   })
 
-  it('leave は magnet=3 と出勤=false を送る', async () => {
+  it('leave は 出勤打刻=false → magnet=3 を送る', async () => {
     const fetchMock = mockFetchSequence([{ ok: true }, { ok: true }])
     await postWhiteboard('leave', EMAIL, OPTS)
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body).magnet_id).toBe(3)
     expect(
-      new URLSearchParams(String(fetchMock.mock.calls[1][1].body)).get('come_to_the_office')
+      new URLSearchParams(String(fetchMock.mock.calls[0][1].body)).get('come_to_the_office')
     ).toBe('false')
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).magnet_id).toBe(3)
   })
 
-  it('magnet 失敗時は attendance を呼ばず error を返す', async () => {
-    const fetchMock = mockFetchSequence([{ ok: false, status: 500 }])
+  it('打刻失敗時は magnet を呼ばず error を返す', async () => {
+    const fetchMock = mockFetchSequence([{ ok: false, status: 502 }])
     const result = await postWhiteboard('telework', EMAIL, OPTS)
-    expect(result).toEqual({ error: 'magnet: 500' })
+    expect(result).toEqual({ error: 'attendance: 502' })
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('attendance 失敗は error を返す', async () => {
-    mockFetchSequence([{ ok: true }, { ok: false, status: 502 }])
-    expect(await postWhiteboard('telework', EMAIL, OPTS)).toEqual({ error: 'attendance: 502' })
+  it('magnet 失敗は error を返す（打刻は成功済みなので誤表示は残らない）', async () => {
+    mockFetchSequence([{ ok: true }, { ok: false, status: 500 }])
+    expect(await postWhiteboard('telework', EMAIL, OPTS)).toEqual({ error: 'magnet: 500' })
   })
 
   it('ネットワークエラーでも throw しない', async () => {

--- a/lambda/src/whiteboardPost.ts
+++ b/lambda/src/whiteboardPost.ts
@@ -7,8 +7,15 @@ const MAGNET_LEAVE = 3
 export type WhiteboardKind = 'telework' | 'leave'
 
 /**
- * ホワイトボードの状態を更新する（magnet → attendance の2段呼び出し）。
- * magnet 失敗時は attendance を呼ばない。失敗は {error}（throw しない）。
+ * ホワイトボードの状態を更新する（attendance → magnet の2段呼び出し）。
+ *
+ * 打刻（attendance）を先に確定させ、表示ステータス（magnet）を後に更新する。
+ * こうすると部分失敗しても誤表示が残らない:
+ *   - 打刻が失敗 → magnet を呼ばないので、表示は直前の正しい状態のまま
+ *   - magnet が失敗 → 打刻は記録済みで、表示は直前の正しい状態のまま
+ * （magnet を先にすると「テレワーク中なのに打刻なし」や、補償削除で
+ *   ボードから人が消える問題が起きるため、この順序にしている）
+ * 失敗は {error}（throw しない）。
  */
 export async function postWhiteboard(
   kind: WhiteboardKind,
@@ -18,14 +25,6 @@ export async function postWhiteboard(
   const magnetId = kind === 'telework' ? MAGNET_TELEWORK : MAGNET_LEAVE
   const comeToOffice = kind === 'telework'
   try {
-    const magnet = await fetch(`${opts.apiUrl}/api/magnet?apiKey=${opts.apiKey}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ magnet_id: magnetId, email }),
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    })
-    if (!magnet.ok) return { error: `magnet: ${magnet.status}` }
-
     const attendance = await fetch(`${opts.apiUrl}/api/attendance?apiKey=${opts.apiKey}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -33,6 +32,14 @@ export async function postWhiteboard(
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })
     if (!attendance.ok) return { error: `attendance: ${attendance.status}` }
+
+    const magnet = await fetch(`${opts.apiUrl}/api/magnet?apiKey=${opts.apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ magnet_id: magnetId, email }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+    if (!magnet.ok) return { error: `magnet: ${magnet.status}` }
     return { ok: true }
   } catch (e) {
     return { error: `network: ${e instanceof Error ? e.message : 'unknown'}` }


### PR DESCRIPTION
## 背景
`whiteboardPost.ts` の magnet → attendance の2段呼び出しが非アトミックで、部分失敗時に状態が不整合になりうる（監査・低）。

## 変更
呼び出し順を **attendance（打刻）→ magnet（表示ステータス）** に入れ替え。打刻を先に確定させることで部分失敗しても誤表示やボードからの消失が起きない。
- 打刻失敗 → magnet を呼ばず、表示は直前の正しい状態のまま
- magnet 失敗 → 打刻は記録済み、表示は直前の正しい状態のまま

補償削除（ロールバック）は不要なため不採用（magnet 先＋補償削除だと、その人がボードから一時的に消える副作用があった）。

## 確認
- packaged 版で実機確認: テレワークで magnet ステータスが正常に変化することを確認済み
- 全テスト通過 / typecheck / lint OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)