### PR TITLE
chore: 廃止済みカレンダー別ウィンドウの残存参照を掃除

### DIFF
--- a/src/renderer/src/hooks/useTimer.test.ts
+++ b/src/renderer/src/hooks/useTimer.test.ts
@@ -10,7 +10,6 @@ vi.stubGlobal('electronAPI', {
   saveSession: mockSaveSession,
   updateSession: mockUpdateSession,
   getSessions: vi.fn().mockResolvedValue([]),
-  openCalendar: vi.fn().mockResolvedValue(undefined),
   resizeWindow: vi.fn().mockResolvedValue(undefined),
   openUrl: vi.fn().mockResolvedValue(undefined),
   hideWindow: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## やったこと

- CLAUDE.md から、既に存在しない `calendar:open` ハンドラ／`openCalendar` の記述を削除
- `useTimer.test.ts` から実APIに存在しない `openCalendar` モックを削除

実API（preload / main / env.d.ts / ipc.ts）に `openCalendar` は無く、テストモックとドキュメントだけが幽霊として残っていたため掃除。

## 確認

- typecheck / 全テスト（515件）通過
- 該当テスト useTimer.test.ts（25件）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)