### PR TITLE
test: useSessions テスト追加 + ErrorBoundary 導入

### DIFF
--- a/src/renderer/src/components/ErrorBoundary.test.tsx
+++ b/src/renderer/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ErrorBoundary } from './ErrorBoundary'
+
+function BrokenComponent(): never {
+  throw new Error('テストエラー')
+}
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('通常時は children をそのまま描画する', () => {
+    render(<ErrorBoundary><p>正常コンテンツ</p></ErrorBoundary>)
+    expect(screen.getByText('正常コンテンツ')).toBeInTheDocument()
+  })
+
+  it('children がエラーを投げると fallback UI を表示する', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<ErrorBoundary><BrokenComponent /></ErrorBoundary>)
+    expect(screen.getByText(/予期しないエラー/)).toBeInTheDocument()
+  })
+
+  it('fallback UI に再読み込みボタンがある', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<ErrorBoundary><BrokenComponent /></ErrorBoundary>)
+    expect(screen.getByRole('button', { name: /再読み込み/ })).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('ErrorBoundary caught:', error, info.componentStack)
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (error) {
+      return (
+        <div style={{ padding: '24px', textAlign: 'center', color: 'var(--text-muted)' }}>
+          <p style={{ marginBottom: '12px' }}>予期しないエラーが発生しました</p>
+          <details style={{ marginBottom: '12px', textAlign: 'left', fontSize: '11px' }}>
+            <summary style={{ cursor: 'pointer' }}>{error.message}</summary>
+            <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>{error.stack}</pre>
+          </details>
+          <button onClick={() => window.location.reload()}>再読み込み</button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/renderer/src/hooks/useSessions.test.ts
+++ b/src/renderer/src/hooks/useSessions.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useSessions } from './useSessions'
+import type { Session } from '../types/session'
+
+const TODAY = '2026-06-17'
+const YEAR_MONTH = '2026-06'
+
+const getSessions = vi.fn()
+const updateSession = vi.fn().mockResolvedValue(undefined)
+const deleteSession = vi.fn().mockResolvedValue(undefined)
+const teleworkStart = vi.fn().mockResolvedValue(undefined)
+
+vi.stubGlobal('electronAPI', {
+  getSessions,
+  updateSession,
+  deleteSession,
+  teleworkStart,
+})
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 's1',
+    taskId: 's1',
+    name: 'テスト作業',
+    projectCode: '',
+    workCategory: '',
+    times: [],
+    date: TODAY,
+    color: '#ffffff',
+    totalTime: 30,
+    ...overrides,
+  }
+}
+
+describe('useSessions', () => {
+  beforeEach(() => {
+    // Date.now() だけ偽造。setTimeout/setInterval は残して waitFor が動くようにする。
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(2026, 5, 17, 12, 0, 0))
+    getSessions.mockResolvedValue([])
+    updateSession.mockClear()
+    deleteSession.mockClear()
+    teleworkStart.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('初期ロードで today のセッションだけを読み込む', async () => {
+    const todaySession = makeSession({ id: 's1', date: TODAY })
+    const otherSession = makeSession({ id: 's2', date: '2026-06-16' })
+    getSessions.mockResolvedValue([todaySession, otherSession])
+
+    const { result } = renderHook(() => useSessions())
+
+    await waitFor(() => expect(result.current.todaySessions).toHaveLength(1))
+    expect(result.current.todaySessions[0].id).toBe('s1')
+    expect(result.current.today).toBe(TODAY)
+    expect(getSessions).toHaveBeenCalledWith(YEAR_MONTH)
+  })
+
+  it('upsertToday は既存セッションを置き換える', async () => {
+    const original = makeSession()
+    getSessions.mockResolvedValue([original])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.todaySessions).toHaveLength(1))
+
+    const updated = { ...original, name: '更新後' }
+    act(() => { result.current.upsertToday(updated) })
+
+    expect(result.current.todaySessions).toHaveLength(1)
+    expect(result.current.todaySessions[0].name).toBe('更新後')
+  })
+
+  it('upsertToday は存在しない id なら末尾に追加する', async () => {
+    getSessions.mockResolvedValue([makeSession()])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.todaySessions).toHaveLength(1))
+
+    const newSession = makeSession({ id: 's-new', name: '新規' })
+    act(() => { result.current.upsertToday(newSession) })
+
+    expect(result.current.todaySessions).toHaveLength(2)
+    expect(result.current.todaySessions[1].id).toBe('s-new')
+  })
+
+  it('applyStartMore は対象セッションに稼働中区間を追加する', async () => {
+    const session = makeSession({ times: [] })
+    getSessions.mockResolvedValue([session])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.todaySessions).toHaveLength(1))
+
+    act(() => { result.current.applyStartMore(session) })
+
+    expect(result.current.todaySessions[0].times).toHaveLength(1)
+    expect(result.current.todaySessions[0].times[0].endTime).toBeNull()
+  })
+
+  it('update は稼働中区間がなければ updateSession を呼んで state を更新する', async () => {
+    const session = makeSession({
+      times: [{ startTime: '2026-06-17T09:00:00', endTime: '2026-06-17T09:30:00' }],
+    })
+    getSessions.mockResolvedValue([session])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.todaySessions).toHaveLength(1))
+
+    const updated = { ...session, name: '更新後' }
+    await act(async () => { await result.current.update(updated) })
+
+    expect(updateSession).toHaveBeenCalledWith(updated)
+    expect(result.current.todaySessions[0].name).toBe('更新後')
+  })
+
+  it('update は稼働中区間があれば updateSession を呼ばずに state だけ更新する', async () => {
+    const session = makeSession({
+      times: [{ startTime: '2026-06-17T09:00:00', endTime: null }],
+    })
+    getSessions.mockResolvedValue([session])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.todaySessions).toHaveLength(1))
+
+    const updated = { ...session, name: '更新後' }
+    await act(async () => { await result.current.update(updated) })
+
+    expect(updateSession).not.toHaveBeenCalled()
+    expect(result.current.todaySessions[0].name).toBe('更新後')
+  })
+
+  it('add は新規セッションを保存して todaySessions に追加する', async () => {
+    getSessions.mockResolvedValue([])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.today).toBe(TODAY))
+
+    await act(async () => {
+      await result.current.add({
+        name: '手動追加',
+        projectCode: 'PROJ',
+        workCategory: '開発',
+        totalTime: '45',
+      })
+    })
+
+    expect(updateSession).toHaveBeenCalledOnce()
+    expect(result.current.todaySessions).toHaveLength(1)
+    expect(result.current.todaySessions[0].name).toBe('手動追加')
+    expect(result.current.todaySessions[0].totalTime).toBe(45)
+  })
+
+  it('remove は deleteSession を呼んで todaySessions から除去する', async () => {
+    const session = makeSession()
+    getSessions.mockResolvedValue([session])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.todaySessions).toHaveLength(1))
+
+    await act(async () => { await result.current.remove('s1') })
+
+    expect(deleteSession).toHaveBeenCalledWith('s1', YEAR_MONTH)
+    expect(result.current.todaySessions).toHaveLength(0)
+  })
+
+  it('startTelework は teleworkStart を呼ぶ', async () => {
+    getSessions.mockResolvedValue([])
+
+    const { result } = renderHook(() => useSessions())
+    await waitFor(() => expect(result.current.today).toBe(TODAY))
+
+    await act(async () => { await result.current.startTelework() })
+
+    expect(teleworkStart).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { migrateLegacyDailyData } from './daily/migrateLegacy'
 import { dailyRepository } from './repositories/dailyRepository'
 import { settingsRepository } from './repositories/settingsRepository'
@@ -23,7 +24,9 @@ async function bootstrap(): Promise<void> {
 
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </React.StrictMode>
   )
 }


### PR DESCRIPTION
## 変更内容

- `useSessions.test.ts` を新規追加（9ケース）
  - 初期ロード・upsertToday・applyStartMore・update・add・remove・startTelework を網羅
- `ErrorBoundary.tsx` を新規追加
  - renderer 内で未捕捉エラーが発生しても画面全体がクラッシュしないよう保護
  - 「再読み込み」ボタン付き fallback UI を表示
- `main.tsx` で `<App />` を `<ErrorBoundary>` で包む

## テスト

- 533 tests / 43 files — 全グリーン
- 型チェックエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)