### PR TITLE
refactor: useTimerSession フックで TimerPage の橋渡し責務を分離

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,9 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import { TimerForm } from './components/Popover/TimerForm'
 import { ActiveTimer } from './components/Popover/ActiveTimer'
 import { SessionList } from './components/Popover/SessionList'
-import { useTimer } from './hooks/useTimer'
 import { useSessions, type SessionsState } from './hooks/useSessions'
-import type { Session } from './types/session'
+import { useTimerSession } from './hooks/useTimerSession'
 import styles from './App.module.css'
 import { AttendanceReport } from './components/Popover/AttendanceReport'
 import { SettingsView } from './components/Settings/SettingsView'
@@ -175,109 +174,64 @@ function PopoverView() {
 }
 
 export function TimerPage({ sessions }: { sessions: SessionsState }) {
-  const { isRunning, elapsedSeconds, baseSeconds, fillSeconds, activeColor, activeSessionId, start, startMore, stop, cancel, adjustStartTime } = useTimer()
-  const workday = useWorkday(sessions.today)
-  const suggestions = useSuggestions(sessions.todaySessions, sessions.today)
-  const [activeTimerName, setActiveTimerName] = useState('')
-  const [activeTimerProjectCode, setActiveTimerProjectCode] = useState('')
-  const [activeTimerWorkCategory, setActiveTimerWorkCategory] = useState('')
-  const [midnightSession, setMidnightSession] = useState<Session | null>(null)
-  const [stopError, setStopError] = useState(false)
-
-  const handleStart = (name: string, projectCode = '', workCategory = ''): void => {
-    setActiveTimerName(name)
-    setActiveTimerProjectCode(projectCode)
-    setActiveTimerWorkCategory(workCategory)
-    start(name)
-  }
-
-  const handleStartMore = (session: Session): void => {
-    setActiveTimerName(session.name)
-    setActiveTimerProjectCode(session.projectCode)
-    setActiveTimerWorkCategory(session.workCategory)
-    sessions.applyStartMore(session)
-    startMore(session)
-  }
-
-  const handleStop = async (projectCode: string, workCategory: string): Promise<void> => {
-    let result: Session | null
-    try {
-      result = await stop({ projectCode, workCategory })
-    } catch (err) {
-      // 保存に失敗してもタイマーは継続している（計測データは保持）。再試行を促す。
-      console.error('セッションの保存に失敗しました:', err)
-      setStopError(true)
-      return
-    }
-    if (!result) return
-    setStopError(false)
-    // 日付を跨いだ場合はリストに追加せず通知バナーを表示
-    if (result.date !== sessions.today) {
-      setMidnightSession(result)
-      return
-    }
-    sessions.upsertToday(result)
-  }
-
-  const handleDelete = async (sessionId: string): Promise<void> => {
-    if (sessionId === activeSessionId) cancel()
-    await sessions.remove(sessionId)
-  }
+  const ts = useTimerSession(sessions)
+  const workday = useWorkday(ts.today)
+  const suggestions = useSuggestions(ts.todaySessions, ts.today)
 
   return (
     <div className={styles.timerPage}>
-      {midnightSession && (
+      {ts.midnightSession && (
         <div className={styles.midnightBanner}>
-          <span>「{midnightSession.name}」を {midnightSession.date} として保存しました</span>
-          <button onClick={() => setMidnightSession(null)}><Xmark width={14} height={14} /></button>
+          <span>「{ts.midnightSession.name}」を {ts.midnightSession.date} として保存しました</span>
+          <button onClick={ts.dismissMidnightSession}><Xmark width={14} height={14} /></button>
         </div>
       )}
 
-      {stopError && (
+      {ts.stopError && (
         <div className={styles.midnightBanner}>
           <span>保存に失敗しました。タイマーは継続中です。もう一度停止してください</span>
-          <button onClick={() => setStopError(false)}><Xmark width={14} height={14} /></button>
+          <button onClick={ts.dismissStopError}><Xmark width={14} height={14} /></button>
         </div>
       )}
 
-      {isRunning ? (
+      {ts.isRunning ? (
         /* 稼働時: ActiveTimerのみ */
         <div className={styles.runningLayout}>
           <ActiveTimer
-            name={activeTimerName}
-            elapsedSeconds={elapsedSeconds}
-            baseSeconds={baseSeconds}
-            fillSeconds={fillSeconds}
-            color={activeColor}
-            initialProjectCode={activeTimerProjectCode}
-            initialWorkCategory={activeTimerWorkCategory}
+            name={ts.activeTimerName}
+            elapsedSeconds={ts.elapsedSeconds}
+            baseSeconds={ts.baseSeconds}
+            fillSeconds={ts.fillSeconds}
+            color={ts.activeColor}
+            initialProjectCode={ts.activeTimerProjectCode}
+            initialWorkCategory={ts.activeTimerWorkCategory}
             projectCodeSuggestions={suggestions.projectCodes}
             workCategorySuggestions={suggestions.workCategories}
-            onStop={handleStop}
+            onStop={ts.stop}
           />
         </div>
       ) : !workday.workStart ? (
         /* 業務開始前: オーバーレイで覆う */
         <div className={styles.idleContent}>
           <WorkStartOverlay
-            date={sessions.today}
+            date={ts.today}
             onStart={workday.startWork}
-            onTeleworkStart={sessions.startTelework}
+            onTeleworkStart={ts.startTelework}
           />
         </div>
       ) : (
         /* 待機時: スクロール可能なコンテナ */
         <div className={styles.idleContent}>
-          <TimerForm onStart={handleStart} nameSuggestions={suggestions.names} />
+          <TimerForm onStart={ts.start} nameSuggestions={suggestions.names} />
           <SessionList
-            sessions={sessions.todaySessions}
-            today={sessions.today}
-            isRunning={isRunning}
-            onUpdate={sessions.update}
-            onStartMore={handleStartMore}
-            onDelete={handleDelete}
-            onAdjustStartTime={ms => adjustStartTime(new Date(ms))}
-            onAdd={sessions.add}
+            sessions={ts.todaySessions}
+            today={ts.today}
+            isRunning={ts.isRunning}
+            onUpdate={ts.update}
+            onStartMore={ts.startMore}
+            onDelete={ts.remove}
+            onAdjustStartTime={ms => ts.adjustStartTime(new Date(ms))}
+            onAdd={ts.add}
             workStart={workday.workStart}
             workEnd={workday.workEnd}
             onWorkEnd={workday.endWork}

--- a/src/renderer/src/hooks/useTimerSession.test.ts
+++ b/src/renderer/src/hooks/useTimerSession.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTimerSession } from './useTimerSession'
+import type { SessionsState } from './useSessions'
+import type { Session } from '../types/session'
+
+vi.mock('./useTimer')
+import { useTimer } from './useTimer'
+
+const TODAY = '2026-06-17'
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 's1', taskId: 's1', name: 'テスト作業',
+    projectCode: 'PROJ', workCategory: '開発',
+    times: [], date: TODAY, color: '#fff', totalTime: 30,
+    ...overrides,
+  }
+}
+
+const mockTimerStart = vi.fn()
+const mockTimerStartMore = vi.fn()
+const mockTimerStop = vi.fn()
+const mockTimerCancel = vi.fn()
+const mockTimerAdjustStartTime = vi.fn()
+
+function makeTimerMock(overrides = {}) {
+  return {
+    isRunning: false,
+    elapsedSeconds: 0,
+    baseSeconds: 0,
+    fillSeconds: 1500,
+    activeColor: '#fff',
+    activeSessionId: null as string | null,
+    start: mockTimerStart,
+    startMore: mockTimerStartMore,
+    stop: mockTimerStop,
+    cancel: mockTimerCancel,
+    adjustStartTime: mockTimerAdjustStartTime,
+    ...overrides,
+  }
+}
+
+const mockUpsertToday = vi.fn()
+const mockApplyStartMore = vi.fn()
+const mockRemove = vi.fn().mockResolvedValue(undefined)
+const mockUpdate = vi.fn().mockResolvedValue(undefined)
+const mockAdd = vi.fn().mockResolvedValue(undefined)
+const mockStartTelework = vi.fn().mockResolvedValue(undefined)
+
+const mockSessions: SessionsState = {
+  today: TODAY,
+  todaySessions: [],
+  upsertToday: mockUpsertToday,
+  applyStartMore: mockApplyStartMore,
+  update: mockUpdate,
+  add: mockAdd,
+  remove: mockRemove,
+  startTelework: mockStartTelework,
+}
+
+describe('useTimerSession', () => {
+  beforeEach(() => {
+    vi.mocked(useTimer).mockReturnValue(makeTimerMock())
+    mockTimerStart.mockClear()
+    mockTimerStartMore.mockClear()
+    mockTimerStop.mockReset()
+    mockTimerCancel.mockClear()
+    mockUpsertToday.mockClear()
+    mockApplyStartMore.mockClear()
+    mockRemove.mockClear()
+  })
+
+  it('start は activeTimerName を更新して timerStart を呼ぶ', () => {
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    act(() => { result.current.start('テスト', 'PROJ', '開発') })
+    expect(result.current.activeTimerName).toBe('テスト')
+    expect(result.current.activeTimerProjectCode).toBe('PROJ')
+    expect(mockTimerStart).toHaveBeenCalledWith('テスト')
+  })
+
+  it('startMore は activeTimerName を更新して applyStartMore と timerStartMore を呼ぶ', () => {
+    const session = makeSession()
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    act(() => { result.current.startMore(session) })
+    expect(result.current.activeTimerName).toBe(session.name)
+    expect(mockApplyStartMore).toHaveBeenCalledWith(session)
+    expect(mockTimerStartMore).toHaveBeenCalledWith(session)
+  })
+
+  it('stop 正常系: upsertToday を呼んで stopError が false のまま', async () => {
+    const session = makeSession({ date: TODAY })
+    mockTimerStop.mockResolvedValue(session)
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    await act(async () => { await result.current.stop('PROJ', '開発') })
+    expect(mockUpsertToday).toHaveBeenCalledWith(session)
+    expect(result.current.stopError).toBe(false)
+    expect(result.current.midnightSession).toBeNull()
+  })
+
+  it('stop 日付跨ぎ: upsertToday を呼ばず midnightSession がセットされる', async () => {
+    const session = makeSession({ date: '2026-06-16' })
+    mockTimerStop.mockResolvedValue(session)
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    await act(async () => { await result.current.stop('PROJ', '開発') })
+    expect(mockUpsertToday).not.toHaveBeenCalled()
+    expect(result.current.midnightSession).toEqual(session)
+  })
+
+  it('stop 保存失敗: stopError が true になる', async () => {
+    mockTimerStop.mockRejectedValue(new Error('save failed'))
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    await act(async () => { await result.current.stop('PROJ', '開発') })
+    expect(result.current.stopError).toBe(true)
+    expect(mockUpsertToday).not.toHaveBeenCalled()
+  })
+
+  it('remove 稼働中セッション: cancel を呼んでから remove を呼ぶ', async () => {
+    vi.mocked(useTimer).mockReturnValue(makeTimerMock({ activeSessionId: 's1' }))
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    await act(async () => { await result.current.remove('s1') })
+    expect(mockTimerCancel).toHaveBeenCalled()
+    expect(mockRemove).toHaveBeenCalledWith('s1')
+  })
+
+  it('remove 停止中セッション: cancel を呼ばずに remove のみ', async () => {
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    await act(async () => { await result.current.remove('s1') })
+    expect(mockTimerCancel).not.toHaveBeenCalled()
+    expect(mockRemove).toHaveBeenCalledWith('s1')
+  })
+
+  it('dismissMidnightSession で midnightSession が null になる', async () => {
+    const session = makeSession({ date: '2026-06-16' })
+    mockTimerStop.mockResolvedValue(session)
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    await act(async () => { await result.current.stop('PROJ', '開発') })
+    expect(result.current.midnightSession).not.toBeNull()
+    act(() => { result.current.dismissMidnightSession() })
+    expect(result.current.midnightSession).toBeNull()
+  })
+
+  it('dismissStopError で stopError が false になる', async () => {
+    mockTimerStop.mockRejectedValue(new Error('save failed'))
+    const { result } = renderHook(() => useTimerSession(mockSessions))
+    await act(async () => { await result.current.stop('PROJ', '開発') })
+    expect(result.current.stopError).toBe(true)
+    act(() => { result.current.dismissStopError() })
+    expect(result.current.stopError).toBe(false)
+  })
+})

--- a/src/renderer/src/hooks/useTimerSession.ts
+++ b/src/renderer/src/hooks/useTimerSession.ts
@@ -1,0 +1,100 @@
+import { useState, useCallback } from 'react'
+import { useTimer } from './useTimer'
+import type { SessionsState } from './useSessions'
+import type { Session } from '../types/session'
+
+export interface TimerSessionState {
+  isRunning: boolean
+  elapsedSeconds: number
+  baseSeconds: number
+  fillSeconds: number
+  activeColor: string
+  activeSessionId: string | null
+  activeTimerName: string
+  activeTimerProjectCode: string
+  activeTimerWorkCategory: string
+  today: string
+  todaySessions: Session[]
+  midnightSession: Session | null
+  stopError: boolean
+  start: (name: string, projectCode?: string, workCategory?: string) => void
+  startMore: (session: Session) => void
+  stop: (projectCode: string, workCategory: string) => Promise<void>
+  cancel: () => void
+  adjustStartTime: (date: Date) => void
+  update: (session: Session) => Promise<void>
+  add: (params: { name: string; projectCode: string; workCategory: string; totalTime: string }) => Promise<void>
+  remove: (sessionId: string) => Promise<void>
+  startTelework: () => Promise<void>
+  dismissMidnightSession: () => void
+  dismissStopError: () => void
+}
+
+export function useTimerSession(sessions: SessionsState): TimerSessionState {
+  const timer = useTimer()
+  const [activeTimerName, setActiveTimerName] = useState('')
+  const [activeTimerProjectCode, setActiveTimerProjectCode] = useState('')
+  const [activeTimerWorkCategory, setActiveTimerWorkCategory] = useState('')
+  const [midnightSession, setMidnightSession] = useState<Session | null>(null)
+  const [stopError, setStopError] = useState(false)
+
+  const start = useCallback((name: string, projectCode = '', workCategory = ''): void => {
+    setActiveTimerName(name)
+    setActiveTimerProjectCode(projectCode)
+    setActiveTimerWorkCategory(workCategory)
+    timer.start(name)
+  }, [timer])
+
+  const startMore = useCallback((session: Session): void => {
+    setActiveTimerName(session.name)
+    setActiveTimerProjectCode(session.projectCode)
+    setActiveTimerWorkCategory(session.workCategory)
+    sessions.applyStartMore(session)
+    timer.startMore(session)
+  }, [timer, sessions])
+
+  const stop = useCallback(async (projectCode: string, workCategory: string): Promise<void> => {
+    let result: Session | null
+    try {
+      result = await timer.stop({ projectCode, workCategory })
+    } catch (err) {
+      console.error('セッションの保存に失敗しました:', err)
+      setStopError(true)
+      return
+    }
+    if (!result) return
+    setStopError(false)
+    if (result.date !== sessions.today) {
+      setMidnightSession(result)
+      return
+    }
+    sessions.upsertToday(result)
+  }, [timer, sessions])
+
+  const remove = useCallback(async (sessionId: string): Promise<void> => {
+    if (sessionId === timer.activeSessionId) timer.cancel()
+    await sessions.remove(sessionId)
+  }, [timer, sessions])
+
+  return {
+    ...timer,
+    activeTimerName,
+    activeTimerProjectCode,
+    activeTimerWorkCategory,
+    today: sessions.today,
+    todaySessions: sessions.todaySessions,
+    midnightSession,
+    stopError,
+    start,
+    startMore,
+    stop,
+    cancel: timer.cancel,
+    adjustStartTime: timer.adjustStartTime,
+    update: sessions.update,
+    add: sessions.add,
+    remove,
+    startTelework: sessions.startTelework,
+    dismissMidnightSession: () => setMidnightSession(null),
+    dismissStopError: () => setStopError(false),
+  }
+}


### PR DESCRIPTION
## 変更内容

- `useTimerSession` フックを新設（`src/renderer/src/hooks/useTimerSession.ts`）
- `TimerPage` に散在していた橋渡しロジックを移動
  - `activeTimerName / activeTimerProjectCode / activeTimerWorkCategory` の state 管理
  - `midnightSession`（日付跨ぎ通知）の state 管理
  - `stopError`（保存失敗通知）の state 管理
  - `handleStart / handleStartMore / handleStop / handleDelete` ハンドラ 4本
- `TimerPage` はレイアウト専業に、`useSessions` は `PopoverView` 単一インスタンスを維持
- テスト 9件追加（TDD で RED → GREEN）

🤖 Generated with [Claude Code](https://claude.com/claude-code)