### PR TITLE
fix: タイマー超過時に勤怠タスクが消える問題を修正・警告表示を追加

### DIFF
--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -4,7 +4,8 @@ import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
-import { Check, Copy, SendDiagonal } from 'iconoir-react'
+import { Check, Copy, SendDiagonal, WarningTriangle } from 'iconoir-react'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 
 interface Props {
   sessions: Session[]
@@ -15,7 +16,7 @@ const actionButton =
   'flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-[8px] border-0 p-[9px] text-[13px] font-semibold text-white transition-all hover:-translate-y-px'
 
 export function AttendanceReport({ sessions, today }: Props) {
-  const { breakMinutes, setBreakMinutes, text, canSend, copied, sending, sendResult, copy, send } =
+  const { breakMinutes, setBreakMinutes, text, overageMinutes, canSend, copied, sending, sendResult, copy, send } =
     useAttendanceReport(sessions, today)
 
   return (
@@ -42,27 +43,40 @@ export function AttendanceReport({ sessions, today }: Props) {
         >
           {copied ? <><Check width={14} height={14} /> コピーしました</> : <><Copy width={14} height={14} /> コピー</>}
         </Button>
-        <button
-          className={`${actionButton} disabled:transform-none disabled:cursor-not-allowed disabled:opacity-60 ${
-            sendResult === 'success'
-              ? 'bg-[linear-gradient(135deg,#26de81,#20c870)]'
-              : sendResult === 'auth' || sendResult === 'error'
-                ? 'bg-[linear-gradient(135deg,#ef4444,#dc2626)]'
-                : 'bg-[linear-gradient(135deg,#3b82f6,#2563eb)] shadow-[0_4px_12px_rgba(59,130,246,0.3)] hover:shadow-[0_6px_16px_rgba(59,130,246,0.4)]'
-          }`}
-          onClick={send}
-          disabled={sending || !canSend}
-        >
-          {sending
-            ? '送信中...'
-            : sendResult === 'success'
-              ? <><Check width={14} height={14} /> 送信しました</>
-              : sendResult === 'auth'
-                ? '認証が必要です'
-                : sendResult === 'error'
-                  ? '送信失敗'
-                  : <><SendDiagonal width={14} height={14} /> 送る</>}
-        </button>
+        <TooltipProvider delayDuration={450}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                className={`${actionButton} disabled:transform-none disabled:cursor-not-allowed disabled:opacity-60 ${
+                  overageMinutes !== null
+                    ? 'bg-[linear-gradient(135deg,#f59e0b,#d97706)]'
+                    : sendResult === 'success'
+                      ? 'bg-[linear-gradient(135deg,#26de81,#20c870)]'
+                      : sendResult === 'auth' || sendResult === 'error'
+                        ? 'bg-[linear-gradient(135deg,#ef4444,#dc2626)]'
+                        : 'bg-[linear-gradient(135deg,#3b82f6,#2563eb)] shadow-[0_4px_12px_rgba(59,130,246,0.3)] hover:shadow-[0_6px_16px_rgba(59,130,246,0.4)]'
+                }`}
+                onClick={send}
+                disabled={sending || !canSend || overageMinutes !== null}
+              >
+                {overageMinutes !== null
+                  ? <><WarningTriangle width={14} height={14} /> {overageMinutes}分超過</>
+                  : sending
+                    ? '送信中...'
+                    : sendResult === 'success'
+                      ? <><Check width={14} height={14} /> 送信しました</>
+                      : sendResult === 'auth'
+                        ? '認証が必要です'
+                        : sendResult === 'error'
+                          ? '送信失敗'
+                          : <><SendDiagonal width={14} height={14} /> 送る</>}
+              </button>
+            </TooltipTrigger>
+            {overageMinutes !== null && (
+              <TooltipContent>作業時間が実稼働時間を超過しています</TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
       </div>
     </Card>
   )

--- a/src/renderer/src/domain/attendance.test.ts
+++ b/src/renderer/src/domain/attendance.test.ts
@@ -20,8 +20,9 @@ describe('buildAttendanceText', () => {
     // 勤務: 08:37〜18:40 = 603分, 休憩60分 → 実労働543分
     // タイマー合計: 180分, 差分: 363分 → 180+363=543
     const sessions = [makeSession()]
-    const result = buildAttendanceText(sessions, '08:37', '18:40', 60)
-    expect(result).toBe('勤怠\n08:37 18:40 60\nZZ テスト作業 設計 543')
+    const { text, overageMinutes } = buildAttendanceText(sessions, '08:37', '18:40', 60)
+    expect(text).toBe('勤怠\n08:37 18:40 60\nZZ テスト作業 設計 543')
+    expect(overageMinutes).toBeNull()
   })
 
   it('複数タスクの場合、差分は最後のタスクにのみ加算される', () => {
@@ -31,49 +32,54 @@ describe('buildAttendanceText', () => {
       makeSession({ id: 'a', taskId: 't1', name: '社内MTG', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 180 }),
       makeSession({ id: 'b', taskId: 't2', name: '1on1', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 60 }),
     ]
-    const result = buildAttendanceText(sessions, '08:37', '18:40', 60)
-    expect(result).toBe('勤怠\n08:37 18:40 60\nZZ 社内MTG 打合せ 180\nZZ 1on1 打合せ 363')
+    const { text, overageMinutes } = buildAttendanceText(sessions, '08:37', '18:40', 60)
+    expect(text).toBe('勤怠\n08:37 18:40 60\nZZ 社内MTG 打合せ 180\nZZ 1on1 打合せ 363')
+    expect(overageMinutes).toBeNull()
   })
 
   it('タイマー合計が実労働時間と同じなら変化しない（差分0）', () => {
     // 勤務: 09:00〜12:00 = 180分, 休憩0分 → 実労働180分
     // タイマー合計: 180分, 差分: 0分
     const sessions = [makeSession()]
-    const result = buildAttendanceText(sessions, '09:00', '12:00', 0)
-    expect(result).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 180')
+    const { text, overageMinutes } = buildAttendanceText(sessions, '09:00', '12:00', 0)
+    expect(text).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 180')
+    expect(overageMinutes).toBeNull()
   })
 
-  it('タイマー合計が実労働時間を超える場合は最後のタスクから差し引いて合計を一致させる', () => {
+  it('タイマー合計が実労働時間を超える場合は自動調整せず overageMinutes を返す', () => {
     // 勤務: 09:00〜12:00 = 180分, 休憩0分 → 実労働180分
-    // タイマー合計: 200分, 差分: -20分 → 200-20=180
+    // タイマー合計: 200分, 超過: 20分
     const sessions = [makeSession({ totalTime: 200 })]
-    const result = buildAttendanceText(sessions, '09:00', '12:00', 0)
-    expect(result).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 180')
+    const { text, overageMinutes } = buildAttendanceText(sessions, '09:00', '12:00', 0)
+    expect(text).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 200')
+    expect(overageMinutes).toBe(20)
   })
 
-  it('マイナス差分が最後のタスクを超える場合は手前のタスクへ繰り越す', () => {
+  it('複数タスクで超過している場合もすべてのタスクがそのまま残る', () => {
     // 勤務: 09:00〜12:00 = 180分, 休憩30分 → 実労働150分
-    // タイマー合計: 180+60=240分, 差分: -90分
-    // 末尾 1on1(60) → 60-90=-30 で 0 にして除外、残り -30 を 社内MTG(180) へ → 150
+    // タイマー合計: 180+60=240分, 超過: 90分 → 全タスク維持
     const sessions = [
       makeSession({ id: 'a', taskId: 't1', name: '社内MTG', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 180 }),
       makeSession({ id: 'b', taskId: 't2', name: '1on1', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 60 }),
     ]
-    const result = buildAttendanceText(sessions, '09:00', '12:00', 30)
-    expect(result).toBe('勤怠\n09:00 12:00 30\nZZ 社内MTG 打合せ 150')
+    const { text, overageMinutes } = buildAttendanceText(sessions, '09:00', '12:00', 30)
+    expect(text).toBe('勤怠\n09:00 12:00 30\nZZ 社内MTG 打合せ 180\nZZ 1on1 打合せ 60')
+    expect(overageMinutes).toBe(90)
   })
 
   it('totalTimeが0のセッションはスキップする', () => {
     const sessions = [
       makeSession({ totalTime: 0 }),
     ]
-    const result = buildAttendanceText(sessions, '08:37', '18:40', 60)
-    expect(result).toBe('勤怠\n08:37 18:40 60')
+    const { text, overageMinutes } = buildAttendanceText(sessions, '08:37', '18:40', 60)
+    expect(text).toBe('勤怠\n08:37 18:40 60')
+    expect(overageMinutes).toBeNull()
   })
 
   it('workStart/workEndがnullの場合は差分加算しない', () => {
     const sessions = [makeSession()]
-    const result = buildAttendanceText(sessions, null, null, 60)
-    expect(result).toBe('勤怠\n  60\nZZ テスト作業 設計 180')
+    const { text, overageMinutes } = buildAttendanceText(sessions, null, null, 60)
+    expect(text).toBe('勤怠\n  60\nZZ テスト作業 設計 180')
+    expect(overageMinutes).toBeNull()
   })
 })

--- a/src/renderer/src/domain/attendance.ts
+++ b/src/renderer/src/domain/attendance.ts
@@ -14,13 +14,23 @@ export function isValidWorkTime(t: string | null): boolean {
   return !!t && /^\d{1,2}:\d{2}$/.test(t)
 }
 
+export interface AttendanceTextResult {
+  /** 勤怠システムへ送るテキスト */
+  text: string
+  /**
+   * タイマー合計が実労働時間を超えた分数。超過がなければ null。
+   * 超過時は自動調整せずこの値を警告として UI に表示する。
+   */
+  overageMinutes: number | null
+}
+
 /** 勤怠報告テキストを生成する */
 export function buildAttendanceText(
   sessions: Session[],
   workStart: string | null,
   workEnd: string | null,
   breakMinutes: number
-): string {
+): AttendanceTextResult {
   const map = new Map<string, { name: string; projectCode: string; workCategory: string; totalMinutes: number }>()
 
   for (const s of sessions) {
@@ -39,37 +49,33 @@ export function buildAttendanceText(
     }
   }
 
-  let groups = Array.from(map.values()).filter(g => g.totalMinutes > 0)
+  const groups = Array.from(map.values()).filter(g => g.totalMinutes > 0)
 
-  // 勤務時間から休憩を引いた実労働時間と、タイマー合計の差分を末尾のタスクから順に調整し、
-  // 報告合計を実労働時間に一致させる。
-  // - プラス差分（計測しきれなかった分）: 最後のタスクに加算
-  // - マイナス差分（タイマー超過）: 最後のタスクから差し引き、負になる分は手前へ繰り越す
+  let overageMinutes: number | null = null
+
+  // 勤務時間から休憩を引いた実労働時間とタイマー合計を比較する。
+  // - プラス差分（計測漏れ）: 最後のタスクに加算して合計を実労働時間に合わせる
+  // - マイナス差分（タイマー超過）: 自動調整せず overageMinutes として返す
   if (groups.length > 0 && workStart && workEnd) {
     const startMin = parseHHMM(workStart)
     const endMin = parseHHMM(workEnd)
     if (startMin != null && endMin != null) {
       const actualWorkMinutes = endMin - startMin - breakMinutes
       const timerTotal = groups.reduce((sum, g) => sum + g.totalMinutes, 0)
-      let diff = actualWorkMinutes - timerTotal
-      for (let i = groups.length - 1; i >= 0 && diff !== 0; i--) {
-        const adjusted = groups[i].totalMinutes + diff
-        if (adjusted >= 0) {
-          groups[i].totalMinutes = adjusted
-          diff = 0
-        } else {
-          // このタスクで吸収しきれないマイナス分を手前へ繰り越す
-          diff = adjusted
-          groups[i].totalMinutes = 0
-        }
+      const diff = actualWorkMinutes - timerTotal
+      if (diff > 0) {
+        groups[groups.length - 1].totalMinutes += diff
+      } else if (diff < 0) {
+        overageMinutes = -diff
       }
-      // 調整で 0 になったタスクは報告から除く
-      groups = groups.filter(g => g.totalMinutes > 0)
     }
   }
 
   const timeLine = `${workStart ?? ''} ${workEnd ?? ''} ${breakMinutes}`
   const taskLines = groups.map(g => `${g.projectCode} ${g.name} ${g.workCategory} ${g.totalMinutes}`)
 
-  return ['勤怠', timeLine, ...taskLines].join('\n')
+  return {
+    text: ['勤怠', timeLine, ...taskLines].join('\n'),
+    overageMinutes,
+  }
 }

--- a/src/renderer/src/hooks/useAttendanceReport.ts
+++ b/src/renderer/src/hooks/useAttendanceReport.ts
@@ -9,6 +9,8 @@ export interface AttendanceReportState {
   breakMinutes: number
   setBreakMinutes: (value: number) => void
   text: string
+  /** タイマー合計が実労働時間を超えた分数。超過なければ null */
+  overageMinutes: number | null
   canSend: boolean
   copied: boolean
   sending: boolean
@@ -31,7 +33,7 @@ export function useAttendanceReport(sessions: Session[], today: string): Attenda
   const workStart = day?.workStart ?? null
   const workEnd = day?.workEnd ?? null
   const orderedSessions = orderSessions(sessions, day?.sessionOrder ?? null)
-  const text = buildAttendanceText(orderedSessions, workStart, workEnd, breakMinutes)
+  const { text, overageMinutes } = buildAttendanceText(orderedSessions, workStart, workEnd, breakMinutes)
 
   const canSend = isValidWorkTime(workStart) && isValidWorkTime(workEnd) && sessions.length > 0
 
@@ -63,5 +65,5 @@ export function useAttendanceReport(sessions: Session[], today: string): Attenda
     }
   }
 
-  return { breakMinutes, setBreakMinutes, text, canSend, copied, sending, sendResult, copy, send }
+  return { breakMinutes, setBreakMinutes, text, overageMinutes, canSend, copied, sending, sendResult, copy, send }
 }


### PR DESCRIPTION
## Summary
- タイマー合計が実稼働時間を超える場合、末尾タスクを自動削除していたのを廃止
- 代わりに送るボタンを「⚠ X分超過」（アンバー色・disabled）に変更
- ホバーで「作業時間が実稼働時間を超過しています」のツールチップを表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)