### PR TITLE
refactor: juice-timer を Juice に名称統一

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "juice-timer",
+  "name": "juice",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "juice-timer",
+      "name": "juice",
       "version": "1.0.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "juice-timer",
+  "name": "juice",
   "version": "1.0.0",
   "description": "macOS menu bar timer app",
   "main": "out/main/index.js",
@@ -73,7 +73,7 @@
     "vitest": "^4.0.18"
   },
   "build": {
-    "appId": "com.kanaami.juice-timer",
+    "appId": "com.kanaami.juice",
     "productName": "Juice",
     "mac": {
       "category": "public.app-category.productivity",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,7 @@ app.setPath(
   'userData',
   app.isPackaged
     ? join(os.homedir(), 'Library', 'Application Support', 'Juice')
-    : join(os.homedir(), 'Library', 'Application Support', 'juice-timer-dev')
+    : join(os.homedir(), 'Library', 'Application Support', 'juice-dev')
 )
 
 // 複数インスタンスの起動を防ぐ（プロダクション向け）
@@ -32,7 +32,7 @@ if (!app.requestSingleInstanceLock()) {
 process.on('SIGTERM', () => app.quit())
 process.on('SIGINT', () => app.quit())
 
-// 上で setPath('userData', ...) によって dev は juice-timer-dev、パッケージ版は Juice に分離済み。
+// 上で setPath('userData', ...) によって dev は juice-dev、パッケージ版は Juice に分離済み。
 // 全ストアで userData を使い、dev とパッケージ版のセッション・設定・認証データを一貫して分離する。
 const dataDir = app.getPath('userData')
 const sessionStore = new SessionStore(dataDir)


### PR DESCRIPTION
## 変更内容

- `package.json`: `name` を `juice-timer` → `juice`、`appId` を `com.kanaami.juice-timer` → `com.kanaami.juice`
- `package-lock.json`: `name` を同期
- `src/main/index.ts`: dev用データパスを `juice-timer-dev` → `juice-dev` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)