### PR TITLE
feat: 勤怠エリアに出勤・退勤・休憩のインライン編集を追加 (#3)

### DIFF
--- a/src/renderer/src/components/Popover/AttendanceReport.test.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { DailyDataProvider } from '../../daily/DailyDataContext'
+import { AttendanceReport } from './AttendanceReport'
+import type { Session } from '../../types/session'
+
+vi.mock('../../repositories/attendanceRepository', () => ({
+  attendanceRepository: { send: vi.fn().mockResolvedValue({ ok: true, status: 200, body: '{}' }) },
+}))
+
+vi.stubGlobal('electronAPI', {
+  getDailyMonth: vi.fn().mockResolvedValue({
+    version: 1,
+    days: {
+      '2026-06-12': { workStart: '09:00', workEnd: '18:00', breakMinutes: 60 },
+    },
+  }),
+  setDailyDay: vi.fn().mockResolvedValue(undefined),
+})
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <DailyDataProvider>{children}</DailyDataProvider>
+)
+
+function makeSession(): Session {
+  return {
+    id: '1', taskId: '1', name: '作業', projectCode: 'P', workCategory: 'C',
+    times: [{ startTime: '2026-06-12T10:00:00', endTime: '2026-06-12T11:00:00' }],
+    date: '2026-06-12', color: '#FF9500', totalTime: 60,
+  }
+}
+
+describe('AttendanceReport — 表示行', () => {
+  it('出勤・退勤・休憩が表示される', async () => {
+    render(<AttendanceReport sessions={[makeSession()]} today="2026-06-12" />, { wrapper })
+    expect(await screen.findByText('09:00')).toBeInTheDocument()
+    expect(screen.getByText('18:00')).toBeInTheDocument()
+    expect(screen.getByText('60分')).toBeInTheDocument()
+  })
+
+  it('出勤をダブルクリックするとダイアログが開く', async () => {
+    render(<AttendanceReport sessions={[makeSession()]} today="2026-06-12" />, { wrapper })
+    const startValue = await screen.findByText('09:00')
+    fireEvent.dblClick(startValue)
+    expect(await screen.findByText('出勤時刻')).toBeInTheDocument()
+  })
+
+  it('退勤をダブルクリックするとダイアログが開く', async () => {
+    render(<AttendanceReport sessions={[makeSession()]} today="2026-06-12" />, { wrapper })
+    const endValue = await screen.findByText('18:00')
+    fireEvent.dblClick(endValue)
+    expect(await screen.findByText('退勤時刻')).toBeInTheDocument()
+  })
+
+  it('休憩をダブルクリックするとダイアログが開く', async () => {
+    render(<AttendanceReport sessions={[makeSession()]} today="2026-06-12" />, { wrapper })
+    const breakValue = await screen.findByText('60分')
+    fireEvent.dblClick(breakValue)
+    expect(await screen.findByText('休憩時間')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -1,66 +1,126 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import type { Session } from '../../types/session'
 import { useAttendanceReport } from '../../hooks/useAttendanceReport'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { TimeField } from '@/components/ui/time-field'
 import { Check, Copy, SendDiagonal, WarningTriangle } from 'iconoir-react'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
+import { Dialog, DialogContent, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 
 interface Props {
   sessions: Session[]
   today: string
 }
 
+type EditField = 'workStart' | 'workEnd' | 'break'
+
 const actionButton =
   'flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-[8px] border-0 p-[9px] text-[13px] font-semibold text-white transition-all hover:-translate-y-px'
 
 export function AttendanceReport({ sessions, today }: Props) {
-  const { breakMinutes, setBreakMinutes, text, overageMinutes, canSend, copied, sending, sendResult, copy, send } =
-    useAttendanceReport(sessions, today)
+  const {
+    breakMinutes, setBreakMinutes,
+    workStart, setWorkStart,
+    workEnd, setWorkEnd,
+    text, overageMinutes, canSend, copied, sending, sendResult, copy, send,
+  } = useAttendanceReport(sessions, today)
 
-  // 入力フィールドはローカル文字列 state で管理し、blur / Enter で確定する。
-  // これにより途中入力（"4" → "45"）でカーソルが飛んだり値がリセットされるのを防ぐ。
-  const [inputValue, setInputValue] = useState(String(breakMinutes))
-  const inputFocusedRef = useRef(false)
+  const [editField, setEditField] = useState<EditField | null>(null)
+  const [dialogValue, setDialogValue] = useState('')
 
-  // 外部（自動計算）から breakMinutes が変わったときだけ inputValue に反映する
-  useEffect(() => {
-    if (!inputFocusedRef.current) {
-      setInputValue(String(breakMinutes))
+  function openDialog(field: EditField): void {
+    setEditField(field)
+    if (field === 'workStart') setDialogValue(workStart ?? '')
+    else if (field === 'workEnd') setDialogValue(workEnd ?? '')
+    else setDialogValue(String(breakMinutes))
+  }
+
+  function confirmDialog(): void {
+    if (editField === 'workStart') {
+      setWorkStart(dialogValue)
+    } else if (editField === 'workEnd') {
+      setWorkEnd(dialogValue)
+    } else if (editField === 'break') {
+      const n = parseInt(dialogValue, 10)
+      if (!isNaN(n) && n >= 0) setBreakMinutes(n)
     }
-  }, [breakMinutes])
-
-  function commitInput(raw: string): void {
-    const n = parseInt(raw, 10)
-    if (!isNaN(n) && n >= 0) {
-      setBreakMinutes(n)
-      setInputValue(String(n))
-    } else {
-      setInputValue(String(breakMinutes))
-    }
+    setEditField(null)
   }
 
   return (
     <Card className="flex min-h-0 flex-1 flex-col rounded-xl bg-[var(--glass-bg)] p-3 [backdrop-filter:blur(12px)]">
-      <div className="mb-3 flex items-center gap-2">
-        <Label htmlFor="break" className="text-xs text-muted-foreground">休憩</Label>
-        <Input
-          id="break"
-          type="text"
-          inputMode="numeric"
-          className="h-8 w-14 text-right text-[13px]"
-          value={inputValue}
-          onChange={e => setInputValue(e.target.value)}
-          onFocus={() => { inputFocusedRef.current = true }}
-          onBlur={() => {
-            inputFocusedRef.current = false
-            commitInput(inputValue)
-          }}
-          onKeyDown={e => { if (e.key === 'Enter') commitInput(inputValue) }}
-        />
-        <span className="text-xs text-muted-foreground">分</span>
+      <Dialog open={editField !== null} onOpenChange={open => { if (!open) setEditField(null) }}>
+        <DialogContent className="max-w-[220px]" aria-describedby={undefined}>
+          <DialogTitle>
+            {editField === 'workStart' ? '出勤時刻' : editField === 'workEnd' ? '退勤時刻' : '休憩時間'}
+          </DialogTitle>
+          <div onKeyDown={e => { if (e.key === 'Enter') confirmDialog() }}>
+            {editField === 'break' ? (
+              <div className="flex items-center gap-2">
+                <Input
+                  type="text"
+                  inputMode="numeric"
+                  className="h-11 w-full text-center text-xl"
+                  value={dialogValue}
+                  onChange={e => setDialogValue(e.target.value)}
+                  autoFocus
+                />
+                <span className="text-sm text-muted-foreground">分</span>
+              </div>
+            ) : (
+              <TimeField
+                aria-label={editField === 'workStart' ? '出勤時刻' : '退勤時刻'}
+                className="h-11 w-full justify-center text-xl"
+                value={dialogValue}
+                onChange={setDialogValue}
+                autoFocus
+              />
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditField(null)}>キャンセル</Button>
+            <Button onClick={confirmDialog}>確定</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <div className="mb-3 flex items-center justify-between rounded-[8px] border border-[var(--glass-border)] bg-[var(--glass-bg)] px-3 py-2 [backdrop-filter:blur(8px)]">
+        <div className="flex items-center gap-3">
+          <button
+            className="group flex cursor-pointer flex-col items-center gap-0.5 border-0 bg-transparent p-0"
+            onDoubleClick={() => openDialog('workStart')}
+            title="ダブルクリックで編集"
+          >
+            <span className="text-[10px] text-muted-foreground">出勤</span>
+            <span className={`text-[13px] font-semibold transition-colors group-hover:text-[var(--accent)] ${workStart ? 'text-foreground' : 'text-muted-foreground'}`}>
+              {workStart ?? '--:--'}
+            </span>
+          </button>
+          <span className="text-[13px] text-muted-foreground">〜</span>
+          <button
+            className="group flex cursor-pointer flex-col items-center gap-0.5 border-0 bg-transparent p-0"
+            onDoubleClick={() => openDialog('workEnd')}
+            title="ダブルクリックで編集"
+          >
+            <span className="text-[10px] text-muted-foreground">退勤</span>
+            <span className={`text-[13px] font-semibold transition-colors group-hover:text-[var(--accent)] ${workEnd ? 'text-foreground' : 'text-muted-foreground'}`}>
+              {workEnd ?? '--:--'}
+            </span>
+          </button>
+        </div>
+        <div className="h-4 w-px bg-border" />
+        <button
+          className="group flex cursor-pointer flex-col items-center gap-0.5 border-0 bg-transparent p-0"
+          onDoubleClick={() => openDialog('break')}
+          title="ダブルクリックで編集"
+        >
+          <span className="text-[10px] text-muted-foreground">休憩</span>
+          <span className="text-[13px] font-semibold text-foreground transition-colors group-hover:text-[var(--accent)]">
+            {breakMinutes}分
+          </span>
+        </button>
       </div>
 
       <pre className="mb-3 min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap rounded-[8px] border border-[var(--glass-border)] bg-[var(--glass-bg)] px-3 py-2.5 font-mono text-xs leading-[1.7] text-[var(--text-primary)] [backdrop-filter:blur(8px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">{text}</pre>

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { Session } from '../../types/session'
 import { useAttendanceReport } from '../../hooks/useAttendanceReport'
+import { isValidWorkTime } from '../../domain/attendance'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -39,9 +40,9 @@ export function AttendanceReport({ sessions, today }: Props) {
 
   function confirmDialog(): void {
     if (editField === 'workStart') {
-      setWorkStart(dialogValue)
+      if (isValidWorkTime(dialogValue)) setWorkStart(dialogValue)
     } else if (editField === 'workEnd') {
-      setWorkEnd(dialogValue)
+      if (isValidWorkTime(dialogValue)) setWorkEnd(dialogValue)
     } else if (editField === 'break') {
       const n = parseInt(dialogValue, 10)
       if (!isNaN(n) && n >= 0) setBreakMinutes(n)
@@ -54,7 +55,7 @@ export function AttendanceReport({ sessions, today }: Props) {
       <Dialog open={editField !== null} onOpenChange={open => { if (!open) setEditField(null) }}>
         <DialogContent className="max-w-[220px]" aria-describedby={undefined}>
           <DialogTitle>
-            {editField === 'workStart' ? '出勤時刻' : editField === 'workEnd' ? '退勤時刻' : '休憩時間'}
+            {editField === 'workStart' ? '出勤時刻' : editField === 'workEnd' ? '退勤時刻' : editField === 'break' ? '休憩時間' : ''}
           </DialogTitle>
           <div onKeyDown={e => { if (e.key === 'Enter') confirmDialog() }}>
             {editField === 'break' ? (

--- a/src/renderer/src/hooks/useAttendanceReport.test.tsx
+++ b/src/renderer/src/hooks/useAttendanceReport.test.tsx
@@ -92,3 +92,33 @@ describe('useAttendanceReport — 送信結果の分類', () => {
     }
   })
 })
+
+describe('useAttendanceReport — workStart/workEnd setter', () => {
+  it('setWorkStart が daily.setDay を workStart で呼ぶ', async () => {
+    const setDailyDay = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('electronAPI', {
+      getDailyMonth: vi.fn().mockResolvedValue({ version: 1, days: {} }),
+      setDailyDay,
+    })
+    const { result } = renderHook(
+      () => useAttendanceReport([makeSession()], '2026-06-12'),
+      { wrapper },
+    )
+    await act(async () => { result.current.setWorkStart('09:00') })
+    expect(setDailyDay).toHaveBeenCalledWith('2026-06-12', expect.objectContaining({ workStart: '09:00' }))
+  })
+
+  it('setWorkEnd が daily.setDay を workEnd で呼ぶ', async () => {
+    const setDailyDay = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('electronAPI', {
+      getDailyMonth: vi.fn().mockResolvedValue({ version: 1, days: {} }),
+      setDailyDay,
+    })
+    const { result } = renderHook(
+      () => useAttendanceReport([makeSession()], '2026-06-12'),
+      { wrapper },
+    )
+    await act(async () => { result.current.setWorkEnd('18:00') })
+    expect(setDailyDay).toHaveBeenCalledWith('2026-06-12', expect.objectContaining({ workEnd: '18:00' }))
+  })
+})

--- a/src/renderer/src/hooks/useAttendanceReport.ts
+++ b/src/renderer/src/hooks/useAttendanceReport.ts
@@ -8,6 +8,10 @@ import { attendanceRepository } from '../repositories/attendanceRepository'
 export interface AttendanceReportState {
   breakMinutes: number
   setBreakMinutes: (value: number) => void
+  workStart: string | null
+  setWorkStart: (time: string) => void
+  workEnd: string | null
+  setWorkEnd: (time: string) => void
   text: string
   /** タイマー合計が実労働時間を超えた分数。超過なければ null */
   overageMinutes: number | null
@@ -35,6 +39,14 @@ export function useAttendanceReport(sessions: Session[], today: string): Attenda
 
   const setBreakMinutes = (value: number): void => {
     void daily.setDay(today, { breakMinutes: value })
+  }
+
+  const setWorkStart = (time: string): void => {
+    void daily.setDay(today, { workStart: time })
+  }
+
+  const setWorkEnd = (time: string): void => {
+    void daily.setDay(today, { workEnd: time })
   }
 
   const [copied, setCopied] = useState(false)
@@ -74,5 +86,5 @@ export function useAttendanceReport(sessions: Session[], today: string): Attenda
     }
   }
 
-  return { breakMinutes, setBreakMinutes, text, overageMinutes, canSend, copied, sending, sendResult, copy, send }
+  return { breakMinutes, setBreakMinutes, workStart, setWorkStart, workEnd, setWorkEnd, text, overageMinutes, canSend, copied, sending, sendResult, copy, send }
 }


### PR DESCRIPTION
## 変更内容

- `AttendanceReport` の上部休憩入力欄を廃止し、出勤・退勤・休憩の3値を横並び表示行に変更
- 各値をダブルクリックするとダイアログが開き編集できる
- 出勤・退勤は `TimeField`、休憩は数値 input を使用
- `useAttendanceReport` フックに `workStart`/`workEnd` とそれぞれの setter を追加

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)