### PR TITLE
feat: 週次分析モーダルを追加（カレンダー日付詳細フッターのダブルクリック）

### DIFF
--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -81,6 +81,10 @@ export function registerIpcHandlers(
   handle('settings:getBreakBehaviorSettings', () => settingsStore.getBreakBehaviorSettings())
   handle('settings:setBreakBehaviorSettings', (_, { behavior }) => settingsStore.setBreakBehaviorSettings(behavior))
 
+  // settings: analysis
+  handle('settings:getMainProjectCode', () => settingsStore.getMainProjectCode())
+  handle('settings:setMainProjectCode', (_, code) => settingsStore.setMainProjectCode(code))
+
   // timer signals
   handle('timer:started', () => {
     onTimerStarted(settingsStore)

--- a/src/main/settingsStore.test.ts
+++ b/src/main/settingsStore.test.ts
@@ -159,9 +159,6 @@ describe('mainProjectCode', () => {
   let dir: string
 
   beforeEach(async () => {
-    const { mkdtemp } = await import('fs/promises')
-    const { tmpdir } = await import('os')
-    const { join } = await import('path')
     dir = await mkdtemp(join(tmpdir(), 'settings-mainproj-'))
     store = new SettingsStore(dir)
   })

--- a/src/main/settingsStore.test.ts
+++ b/src/main/settingsStore.test.ts
@@ -154,6 +154,38 @@ describe('SettingsStore', () => {
   })
 })
 
+describe('mainProjectCode', () => {
+  let store: SettingsStore
+  let dir: string
+
+  beforeEach(async () => {
+    const { mkdtemp } = await import('fs/promises')
+    const { tmpdir } = await import('os')
+    const { join } = await import('path')
+    dir = await mkdtemp(join(tmpdir(), 'settings-mainproj-'))
+    store = new SettingsStore(dir)
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('未設定時は空文字を返す', async () => {
+    expect(await store.getMainProjectCode()).toBe('')
+  })
+
+  it('設定・取得できる', async () => {
+    await store.setMainProjectCode('PROJ-001')
+    expect(await store.getMainProjectCode()).toBe('PROJ-001')
+  })
+
+  it('空文字に戻せる', async () => {
+    await store.setMainProjectCode('PROJ-001')
+    await store.setMainProjectCode('')
+    expect(await store.getMainProjectCode()).toBe('')
+  })
+})
+
 describe('SettingsStore — 未知キーの掃除', () => {
   let dir: string
   let store: SettingsStore

--- a/src/main/settingsStore.ts
+++ b/src/main/settingsStore.ts
@@ -12,6 +12,7 @@ interface Settings {
   setupCompleted: boolean
   whiteboardEnabled: boolean
   breakBehavior: 'stop' | 'pause'
+  mainProjectCode: string
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -24,6 +25,7 @@ const DEFAULT_SETTINGS: Settings = {
   setupCompleted: false,
   whiteboardEnabled: false,
   breakBehavior: 'stop',
+  mainProjectCode: '',
 }
 
 export class SettingsStore {
@@ -98,6 +100,7 @@ export class SettingsStore {
         setupCompleted: parsed.setupCompleted ?? DEFAULT_SETTINGS.setupCompleted,
         whiteboardEnabled: parsed.whiteboardEnabled ?? DEFAULT_SETTINGS.whiteboardEnabled,
         breakBehavior: (parsed.breakBehavior === 'pause' ? 'pause' : 'stop'),
+        mainProjectCode: parsed.mainProjectCode ?? DEFAULT_SETTINGS.mainProjectCode,
       }
     }
     try {
@@ -189,5 +192,14 @@ export class SettingsStore {
 
   async setBreakBehaviorSettings(behavior: 'stop' | 'pause'): Promise<void> {
     await this.update(s => ({ ...s, breakBehavior: behavior }))
+  }
+
+  async getMainProjectCode(): Promise<string> {
+    const s = await this.readAll()
+    return s.mainProjectCode
+  }
+
+  async setMainProjectCode(code: string): Promise<void> {
+    await this.update(s => ({ ...s, mainProjectCode: code }))
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -49,6 +49,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setWhiteboardSettings: (enabled: boolean) => invoke('settings:setWhiteboardSettings', { enabled }),
   getBreakBehaviorSettings: () => invoke('settings:getBreakBehaviorSettings', undefined),
   setBreakBehaviorSettings: (behavior: 'stop' | 'pause') => invoke('settings:setBreakBehaviorSettings', { behavior }),
+  getMainProjectCode: () => invoke('settings:getMainProjectCode', undefined),
+  setMainProjectCode: (code: string) => invoke('settings:setMainProjectCode', code),
 
   // timer signals
   timerStarted: () => invoke('timer:started', undefined),

--- a/src/renderer/src/components/Calendar/CalendarPage.tsx
+++ b/src/renderer/src/components/Calendar/CalendarPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import type { Session } from '../../types/session'
 import { useCalendar } from '../../hooks/useCalendar'
 import { useSuggestions } from '../../hooks/useSuggestions'
 import { useDailyData } from '../../daily/DailyDataContext'
 import { MonthView } from './MonthView'
 import { DayDetail } from './DayDetail'
+import { WeeklyAnalysisModal } from './WeeklyAnalysisModal'
 
 interface Props {
   todaySessions?: Session[]
@@ -15,6 +16,7 @@ export function CalendarPage({ todaySessions = [], today }: Props) {
   const cal = useCalendar()
   const suggestions = useSuggestions(todaySessions, today)
   const daily = useDailyData()
+  const [analysisDate, setAnalysisDate] = useState<string | null>(null)
 
   const yearMonth = `${cal.year}-${String(cal.month).padStart(2, '0')}`
   useEffect(() => { daily.ensureMonth(yearMonth) }, [yearMonth, daily])
@@ -31,6 +33,7 @@ export function CalendarPage({ todaySessions = [], today }: Props) {
           onUpdate={cal.updateSession}
           onBack={() => cal.selectDate(null)}
           suggestions={suggestions}
+          onOpenAnalysis={() => setAnalysisDate(cal.selectedDate)}
         />
       ) : (
         <MonthView
@@ -44,6 +47,10 @@ export function CalendarPage({ todaySessions = [], today }: Props) {
           onNextMonth={cal.nextMonth}
         />
       )}
+      <WeeklyAnalysisModal
+        date={analysisDate}
+        onClose={() => setAnalysisDate(null)}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/Calendar/DayDetail.tsx
+++ b/src/renderer/src/components/Calendar/DayDetail.tsx
@@ -19,11 +19,12 @@ interface Props {
   onUpdate?: (session: Session) => Promise<void>
   onBack?: () => void
   suggestions?: Suggestions
+  onOpenAnalysis?: () => void
 }
 
 const EMPTY_FORM: SessionFormValues = { name: '', projectCode: '', workCategory: '', totalTime: '' }
 
-export function DayDetail({ date, sessions, sessionOrder = null, onUpdate, onBack, suggestions = EMPTY_SUGGESTIONS }: Props) {
+export function DayDetail({ date, sessions, sessionOrder = null, onUpdate, onBack, suggestions = EMPTY_SUGGESTIONS, onOpenAnalysis }: Props) {
   // 編集ダイアログ。開くたびに対象セッションの値で初期化する
   const [editTargetId, setEditTargetId] = useState<string | null>(null)
   const [editDraft, setEditDraft] = useState<SessionFormValues>(EMPTY_FORM)
@@ -127,10 +128,17 @@ export function DayDetail({ date, sessions, sessionOrder = null, onUpdate, onBac
 
       <PageIndicator totalPages={totalPages} currentPage={page} onChangePage={changePage} />
 
-      <Card className="mb-2 mt-2 shrink-0 border-[var(--glass-border)] bg-[var(--glass-bg)] text-[var(--text-secondary)]">
-        <CardContent className="flex items-center justify-end px-3 py-2 text-right text-[11px]">
+      <Card
+        className={`mb-2 mt-2 shrink-0 border-[var(--glass-border)] bg-[var(--glass-bg)] text-[var(--text-secondary)]${onOpenAnalysis ? ' cursor-pointer' : ''}`}
+        onDoubleClick={onOpenAnalysis}
+        title={onOpenAnalysis ? 'ダブルクリックで週次分析を表示' : undefined}
+      >
+        <CardContent className="flex items-center justify-between px-3 py-2 text-[11px]">
+          {onOpenAnalysis && (
+            <span className="text-[var(--text-muted)]">ダブルクリックで週次分析を開く</span>
+          )}
           {sessions.length > 0 && (
-            <span>注いだ時間: <strong>{totalMinutes}分</strong></span>
+            <span className="ml-auto text-right">注いだ時間: <strong>{totalMinutes}分</strong></span>
           )}
         </CardContent>
       </Card>

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -16,63 +16,63 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
 
   return (
     <Dialog open={date !== null} onOpenChange={open => { if (!open) onClose() }}>
-      <DialogContent className="w-[296px] gap-2 p-4" aria-describedby={undefined}>
-        <DialogTitle className="text-[13px] font-bold leading-tight">
+      <DialogContent className="w-[306px] gap-2 p-4" aria-describedby={undefined}>
+        <DialogTitle className="text-[14px] font-bold leading-tight">
           週次分析{analysis ? ` — ${analysis.weekLabel}` : ''}
         </DialogTitle>
 
         {loading || !analysis ? (
-          <p className="py-3 text-center text-[11px] text-muted-foreground">読み込み中…</p>
+          <p className="py-3 text-center text-[12px] text-muted-foreground">読み込み中…</p>
         ) : (
-          <table className="w-full border-collapse text-[11px]">
+          <table className="w-full border-collapse text-[12px]">
             <thead>
               <tr>
-                <th className="pb-1 text-left text-[10px] font-medium text-muted-foreground"></th>
+                <th className="pb-1.5 text-left text-[11px] font-medium text-muted-foreground"></th>
                 {analysis.days.map(d => (
-                  <th key={d.date} className="pb-1 w-[38px] text-center text-[10px] font-medium text-muted-foreground">
+                  <th key={d.date} className="pb-1.5 w-[38px] text-center text-[11px] font-medium text-muted-foreground">
                     {d.dayLabel}
                   </th>
                 ))}
-                <th className="pb-1 w-[38px] text-center text-[10px] font-medium text-muted-foreground">平均</th>
+                <th className="pb-1.5 w-[38px] text-center text-[11px] font-medium text-muted-foreground">平均</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               <tr>
-                <td className="py-[5px] text-muted-foreground whitespace-nowrap">所定(分)</td>
+                <td className="py-1.5 text-muted-foreground whitespace-nowrap">所定(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.scheduledMinutes}</td>
+                  <td key={d.date} className="py-1.5 text-center tabular-nums">{d.scheduledMinutes}</td>
                 ))}
-                <td className="py-[5px] text-center text-muted-foreground">—</td>
+                <td className="py-1.5 text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-[5px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
+                <td className="py-1.5 text-muted-foreground whitespace-nowrap">実稼働(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums">{fmt(d.actualMinutes)}</td>
+                  <td key={d.date} className="py-1.5 text-center tabular-nums">{fmt(d.actualMinutes)}</td>
                 ))}
-                <td className="py-[5px] text-center text-muted-foreground">—</td>
+                <td className="py-1.5 text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-[5px] text-muted-foreground whitespace-nowrap">PJ外(分)</td>
+                <td className="py-1.5 text-muted-foreground whitespace-nowrap">PJ外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.nonProjectMinutes}</td>
+                  <td key={d.date} className="py-1.5 text-center tabular-nums">{d.nonProjectMinutes}</td>
                 ))}
-                <td className="py-[5px] text-center text-muted-foreground">—</td>
+                <td className="py-1.5 text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-[5px] text-muted-foreground whitespace-nowrap">想定外(分)</td>
+                <td className="py-1.5 text-muted-foreground whitespace-nowrap">想定外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.unexpectedMinutes}</td>
+                  <td key={d.date} className="py-1.5 text-center tabular-nums">{d.unexpectedMinutes}</td>
                 ))}
-                <td className="py-[5px] text-center text-muted-foreground">—</td>
+                <td className="py-1.5 text-center text-muted-foreground">—</td>
               </tr>
               <tr className="font-semibold">
-                <td className="py-[5px] whitespace-nowrap">稼働率</td>
+                <td className="py-1.5 whitespace-nowrap">稼働率</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums text-[var(--accent)]">
+                  <td key={d.date} className="py-1.5 text-center tabular-nums text-[var(--accent)]">
                     {fmt(d.utilizationRate, '%')}
                   </td>
                 ))}
-                <td className="py-[5px] text-center tabular-nums text-[var(--accent)]">
+                <td className="py-1.5 text-center tabular-nums text-[var(--accent)]">
                   {fmt(analysis.weeklyAvgUtilization, '%')}
                 </td>
               </tr>

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -16,63 +16,63 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
 
   return (
     <Dialog open={date !== null} onOpenChange={open => { if (!open) onClose() }}>
-      <DialogContent className="w-[296px]" aria-describedby={undefined}>
-        <DialogTitle className="text-[13px] font-bold">
+      <DialogContent className="w-[296px] gap-2 p-4" aria-describedby={undefined}>
+        <DialogTitle className="text-[12px] font-bold leading-tight">
           週次分析{analysis ? ` — ${analysis.weekLabel}` : ''}
         </DialogTitle>
 
         {loading || !analysis ? (
-          <p className="py-4 text-center text-[12px] text-muted-foreground">読み込み中…</p>
+          <p className="py-3 text-center text-[11px] text-muted-foreground">読み込み中…</p>
         ) : (
-          <table className="w-full border-collapse text-[11px]">
+          <table className="w-full border-collapse">
             <thead>
               <tr>
-                <th className="pb-1.5 pr-2 text-left text-[10px] font-medium text-muted-foreground"></th>
+                <th className="pb-1 text-left text-[9px] font-medium text-muted-foreground"></th>
                 {analysis.days.map(d => (
-                  <th key={d.date} className="px-1 pb-1.5 text-center text-[10px] font-medium text-muted-foreground">
+                  <th key={d.date} className="pb-1 text-center text-[9px] font-medium text-muted-foreground w-[38px]">
                     {d.dayLabel}
                   </th>
                 ))}
-                <th className="px-1 pb-1.5 text-center text-[10px] font-medium text-muted-foreground">週平均</th>
+                <th className="pb-1 text-center text-[9px] font-medium text-muted-foreground w-[38px]">平均</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               <tr>
-                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">所定 (m)</td>
+                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">所定(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{d.scheduledMinutes}</td>
+                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{d.scheduledMinutes}</td>
                 ))}
-                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">実稼働 (m)</td>
+                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{fmt(d.actualMinutes)}</td>
+                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{fmt(d.actualMinutes)}</td>
                 ))}
-                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">PJ外 (m)</td>
+                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">PJ外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{d.nonProjectMinutes}</td>
+                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{d.nonProjectMinutes}</td>
                 ))}
-                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">想定外 (m)</td>
+                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">想定外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{d.unexpectedMinutes}</td>
+                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{d.unexpectedMinutes}</td>
                 ))}
-                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
               </tr>
               <tr className="font-semibold">
-                <td className="py-1.5 pr-2 text-[10px] text-foreground whitespace-nowrap">稼働率</td>
+                <td className="py-1 text-[9px] text-foreground whitespace-nowrap">稼働率</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums text-[var(--accent)]">
+                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums text-[var(--accent)]">
                     {fmt(d.utilizationRate, '%')}
                   </td>
                 ))}
-                <td className="px-1 py-1.5 text-center tabular-nums text-[var(--accent)]">
+                <td className="py-1 text-center text-[10px] tabular-nums text-[var(--accent)]">
                   {fmt(analysis.weeklyAvgUtilization, '%')}
                 </td>
               </tr>

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -1,0 +1,87 @@
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { useWeeklyAnalysis } from '../../hooks/useWeeklyAnalysis'
+
+interface Props {
+  date: string | null
+  onClose: () => void
+}
+
+function fmt(value: number | null, suffix = ''): string {
+  if (value === null) return '—'
+  return `${value}${suffix}`
+}
+
+export function WeeklyAnalysisModal({ date, onClose }: Props) {
+  const { analysis, loading } = useWeeklyAnalysis(date)
+
+  return (
+    <Dialog open={date !== null} onOpenChange={open => { if (!open) onClose() }}>
+      <DialogContent className="max-w-[560px]" aria-describedby={undefined}>
+        <DialogTitle className="text-[14px] font-bold">
+          週次分析{analysis ? ` — ${analysis.weekLabel}` : ''}
+        </DialogTitle>
+
+        {loading || !analysis ? (
+          <p className="py-4 text-center text-[13px] text-muted-foreground">読み込み中…</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-[12px]">
+              <thead>
+                <tr>
+                  <th className="py-1.5 pr-3 text-left text-[11px] font-medium text-muted-foreground"></th>
+                  {analysis.days.map(d => (
+                    <th key={d.date} className="px-2 py-1.5 text-center text-[11px] font-medium text-muted-foreground">
+                      {d.dayLabel}
+                    </th>
+                  ))}
+                  <th className="px-2 py-1.5 text-center text-[11px] font-medium text-muted-foreground">週平均</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                <tr>
+                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">所定稼働時間 (m)</td>
+                  {analysis.days.map(d => (
+                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{d.scheduledMinutes}</td>
+                  ))}
+                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">実稼働時間 (m)</td>
+                  {analysis.days.map(d => (
+                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{fmt(d.actualMinutes)}</td>
+                  ))}
+                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">PJ外作業 (m)</td>
+                  {analysis.days.map(d => (
+                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{d.nonProjectMinutes}</td>
+                  ))}
+                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">想定外作業 (m)</td>
+                  {analysis.days.map(d => (
+                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{d.unexpectedMinutes}</td>
+                  ))}
+                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
+                </tr>
+                <tr className="font-semibold">
+                  <td className="py-2 pr-3 text-[11px] text-foreground whitespace-nowrap">稼働率</td>
+                  {analysis.days.map(d => (
+                    <td key={d.date} className="px-2 py-2 text-center tabular-nums text-[var(--accent)]">
+                      {fmt(d.utilizationRate, '%')}
+                    </td>
+                  ))}
+                  <td className="px-2 py-2 text-center tabular-nums text-[var(--accent)]">
+                    {fmt(analysis.weeklyAvgUtilization, '%')}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -16,63 +16,63 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
 
   return (
     <Dialog open={date !== null} onOpenChange={open => { if (!open) onClose() }}>
-      <DialogContent className="w-[306px] gap-2 p-4" aria-describedby={undefined}>
-        <DialogTitle className="text-[14px] font-bold leading-tight">
+      <DialogContent className="w-[296px] gap-2 p-4" aria-describedby={undefined}>
+        <DialogTitle className="text-[13px] font-bold leading-tight">
           週次分析{analysis ? ` — ${analysis.weekLabel}` : ''}
         </DialogTitle>
 
         {loading || !analysis ? (
-          <p className="py-3 text-center text-[12px] text-muted-foreground">読み込み中…</p>
+          <p className="py-3 text-center text-[11px] text-muted-foreground">読み込み中…</p>
         ) : (
-          <table className="w-full border-collapse text-[12px]">
+          <table className="w-full border-collapse text-[11px]">
             <thead>
               <tr>
-                <th className="pb-1.5 text-left text-[11px] font-medium text-muted-foreground"></th>
+                <th className="pb-1 text-left text-[10px] font-medium text-muted-foreground"></th>
                 {analysis.days.map(d => (
-                  <th key={d.date} className="pb-1.5 w-[38px] text-center text-[11px] font-medium text-muted-foreground">
+                  <th key={d.date} className="pb-1 w-[38px] text-center text-[10px] font-medium text-muted-foreground">
                     {d.dayLabel}
                   </th>
                 ))}
-                <th className="pb-1.5 w-[38px] text-center text-[11px] font-medium text-muted-foreground">平均</th>
+                <th className="pb-1 w-[38px] text-center text-[10px] font-medium text-muted-foreground">平均</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               <tr>
-                <td className="py-1.5 text-muted-foreground whitespace-nowrap">所定(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">所定(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1.5 text-center tabular-nums">{d.scheduledMinutes}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.scheduledMinutes}</td>
                 ))}
-                <td className="py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1.5 text-muted-foreground whitespace-nowrap">実稼働(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1.5 text-center tabular-nums">{fmt(d.actualMinutes)}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{fmt(d.actualMinutes)}</td>
                 ))}
-                <td className="py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1.5 text-muted-foreground whitespace-nowrap">PJ外(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">PJ外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1.5 text-center tabular-nums">{d.nonProjectMinutes}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.nonProjectMinutes}</td>
                 ))}
-                <td className="py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1.5 text-muted-foreground whitespace-nowrap">想定外(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">想定外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1.5 text-center tabular-nums">{d.unexpectedMinutes}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.unexpectedMinutes}</td>
                 ))}
-                <td className="py-1.5 text-center text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr className="font-semibold">
-                <td className="py-1.5 whitespace-nowrap">稼働率</td>
+                <td className="py-[5px] whitespace-nowrap">稼働率</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1.5 text-center tabular-nums text-[var(--accent)]">
+                  <td key={d.date} className="py-[5px] text-center tabular-nums text-[var(--accent)]">
                     {fmt(d.utilizationRate, '%')}
                   </td>
                 ))}
-                <td className="py-1.5 text-center tabular-nums text-[var(--accent)]">
+                <td className="py-[5px] text-center tabular-nums text-[var(--accent)]">
                   {fmt(analysis.weeklyAvgUtilization, '%')}
                 </td>
               </tr>

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -17,7 +17,7 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
   return (
     <Dialog open={date !== null} onOpenChange={open => { if (!open) onClose() }}>
       <DialogContent className="w-[296px] gap-2 p-4" aria-describedby={undefined}>
-        <DialogTitle className="text-[12px] font-bold leading-tight">
+        <DialogTitle className="text-[13px] font-bold leading-tight">
           週次分析{analysis ? ` — ${analysis.weekLabel}` : ''}
         </DialogTitle>
 
@@ -27,52 +27,52 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
           <table className="w-full border-collapse">
             <thead>
               <tr>
-                <th className="pb-1 text-left text-[9px] font-medium text-muted-foreground"></th>
+                <th className="pb-1 text-left text-[10px] font-medium text-muted-foreground"></th>
                 {analysis.days.map(d => (
-                  <th key={d.date} className="pb-1 text-center text-[9px] font-medium text-muted-foreground w-[38px]">
+                  <th key={d.date} className="pb-1 text-center text-[10px] font-medium text-muted-foreground w-[38px]">
                     {d.dayLabel}
                   </th>
                 ))}
-                <th className="pb-1 text-center text-[9px] font-medium text-muted-foreground w-[38px]">平均</th>
+                <th className="pb-1 text-center text-[10px] font-medium text-muted-foreground w-[38px]">平均</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               <tr>
-                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">所定(分)</td>
+                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">所定(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{d.scheduledMinutes}</td>
+                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{d.scheduledMinutes}</td>
                 ))}
-                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
+                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
+                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{fmt(d.actualMinutes)}</td>
+                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{fmt(d.actualMinutes)}</td>
                 ))}
-                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
+                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">PJ外(分)</td>
+                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">PJ外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{d.nonProjectMinutes}</td>
+                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{d.nonProjectMinutes}</td>
                 ))}
-                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
+                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-1 text-[9px] text-muted-foreground whitespace-nowrap">想定外(分)</td>
+                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">想定外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums">{d.unexpectedMinutes}</td>
+                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{d.unexpectedMinutes}</td>
                 ))}
-                <td className="py-1 text-center text-[10px] text-muted-foreground">—</td>
+                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
               </tr>
               <tr className="font-semibold">
-                <td className="py-1 text-[9px] text-foreground whitespace-nowrap">稼働率</td>
+                <td className="py-[5px]text-[10px] text-foreground whitespace-nowrap">稼働率</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-1 text-center text-[10px] tabular-nums text-[var(--accent)]">
+                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums text-[var(--accent)]">
                     {fmt(d.utilizationRate, '%')}
                   </td>
                 ))}
-                <td className="py-1 text-center text-[10px] tabular-nums text-[var(--accent)]">
+                <td className="py-[5px]text-center text-[11px] tabular-nums text-[var(--accent)]">
                   {fmt(analysis.weeklyAvgUtilization, '%')}
                 </td>
               </tr>

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -16,70 +16,68 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
 
   return (
     <Dialog open={date !== null} onOpenChange={open => { if (!open) onClose() }}>
-      <DialogContent className="max-w-[560px]" aria-describedby={undefined}>
-        <DialogTitle className="text-[14px] font-bold">
+      <DialogContent className="w-[296px]" aria-describedby={undefined}>
+        <DialogTitle className="text-[13px] font-bold">
           週次分析{analysis ? ` — ${analysis.weekLabel}` : ''}
         </DialogTitle>
 
         {loading || !analysis ? (
-          <p className="py-4 text-center text-[13px] text-muted-foreground">読み込み中…</p>
+          <p className="py-4 text-center text-[12px] text-muted-foreground">読み込み中…</p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse text-[12px]">
-              <thead>
-                <tr>
-                  <th className="py-1.5 pr-3 text-left text-[11px] font-medium text-muted-foreground"></th>
-                  {analysis.days.map(d => (
-                    <th key={d.date} className="px-2 py-1.5 text-center text-[11px] font-medium text-muted-foreground">
-                      {d.dayLabel}
-                    </th>
-                  ))}
-                  <th className="px-2 py-1.5 text-center text-[11px] font-medium text-muted-foreground">週平均</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                <tr>
-                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">所定稼働時間 (m)</td>
-                  {analysis.days.map(d => (
-                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{d.scheduledMinutes}</td>
-                  ))}
-                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
-                </tr>
-                <tr>
-                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">実稼働時間 (m)</td>
-                  {analysis.days.map(d => (
-                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{fmt(d.actualMinutes)}</td>
-                  ))}
-                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
-                </tr>
-                <tr>
-                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">PJ外作業 (m)</td>
-                  {analysis.days.map(d => (
-                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{d.nonProjectMinutes}</td>
-                  ))}
-                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
-                </tr>
-                <tr>
-                  <td className="py-2 pr-3 text-[11px] text-muted-foreground whitespace-nowrap">想定外作業 (m)</td>
-                  {analysis.days.map(d => (
-                    <td key={d.date} className="px-2 py-2 text-center tabular-nums">{d.unexpectedMinutes}</td>
-                  ))}
-                  <td className="px-2 py-2 text-center text-muted-foreground">—</td>
-                </tr>
-                <tr className="font-semibold">
-                  <td className="py-2 pr-3 text-[11px] text-foreground whitespace-nowrap">稼働率</td>
-                  {analysis.days.map(d => (
-                    <td key={d.date} className="px-2 py-2 text-center tabular-nums text-[var(--accent)]">
-                      {fmt(d.utilizationRate, '%')}
-                    </td>
-                  ))}
-                  <td className="px-2 py-2 text-center tabular-nums text-[var(--accent)]">
-                    {fmt(analysis.weeklyAvgUtilization, '%')}
+          <table className="w-full border-collapse text-[11px]">
+            <thead>
+              <tr>
+                <th className="pb-1.5 pr-2 text-left text-[10px] font-medium text-muted-foreground"></th>
+                {analysis.days.map(d => (
+                  <th key={d.date} className="px-1 pb-1.5 text-center text-[10px] font-medium text-muted-foreground">
+                    {d.dayLabel}
+                  </th>
+                ))}
+                <th className="px-1 pb-1.5 text-center text-[10px] font-medium text-muted-foreground">週平均</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              <tr>
+                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">所定 (m)</td>
+                {analysis.days.map(d => (
+                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{d.scheduledMinutes}</td>
+                ))}
+                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+              </tr>
+              <tr>
+                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">実稼働 (m)</td>
+                {analysis.days.map(d => (
+                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{fmt(d.actualMinutes)}</td>
+                ))}
+                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+              </tr>
+              <tr>
+                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">PJ外 (m)</td>
+                {analysis.days.map(d => (
+                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{d.nonProjectMinutes}</td>
+                ))}
+                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+              </tr>
+              <tr>
+                <td className="py-1.5 pr-2 text-[10px] text-muted-foreground whitespace-nowrap">想定外 (m)</td>
+                {analysis.days.map(d => (
+                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums">{d.unexpectedMinutes}</td>
+                ))}
+                <td className="px-1 py-1.5 text-center text-muted-foreground">—</td>
+              </tr>
+              <tr className="font-semibold">
+                <td className="py-1.5 pr-2 text-[10px] text-foreground whitespace-nowrap">稼働率</td>
+                {analysis.days.map(d => (
+                  <td key={d.date} className="px-1 py-1.5 text-center tabular-nums text-[var(--accent)]">
+                    {fmt(d.utilizationRate, '%')}
                   </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+                ))}
+                <td className="px-1 py-1.5 text-center tabular-nums text-[var(--accent)]">
+                  {fmt(analysis.weeklyAvgUtilization, '%')}
+                </td>
+              </tr>
+            </tbody>
+          </table>
         )}
       </DialogContent>
     </Dialog>

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -24,55 +24,55 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
         {loading || !analysis ? (
           <p className="py-3 text-center text-[11px] text-muted-foreground">読み込み中…</p>
         ) : (
-          <table className="w-full border-collapse">
+          <table className="w-full border-collapse text-[11px]">
             <thead>
               <tr>
                 <th className="pb-1 text-left text-[10px] font-medium text-muted-foreground"></th>
                 {analysis.days.map(d => (
-                  <th key={d.date} className="pb-1 text-center text-[10px] font-medium text-muted-foreground w-[38px]">
+                  <th key={d.date} className="pb-1 w-[38px] text-center text-[10px] font-medium text-muted-foreground">
                     {d.dayLabel}
                   </th>
                 ))}
-                <th className="pb-1 text-center text-[10px] font-medium text-muted-foreground w-[38px]">平均</th>
+                <th className="pb-1 w-[38px] text-center text-[10px] font-medium text-muted-foreground">平均</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               <tr>
-                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">所定(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">所定(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{d.scheduledMinutes}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.scheduledMinutes}</td>
                 ))}
-                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{fmt(d.actualMinutes)}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{fmt(d.actualMinutes)}</td>
                 ))}
-                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">PJ外(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">PJ外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{d.nonProjectMinutes}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.nonProjectMinutes}</td>
                 ))}
-                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr>
-                <td className="py-[5px]text-[10px] text-muted-foreground whitespace-nowrap">想定外(分)</td>
+                <td className="py-[5px] text-muted-foreground whitespace-nowrap">想定外(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums">{d.unexpectedMinutes}</td>
+                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.unexpectedMinutes}</td>
                 ))}
-                <td className="py-[5px]text-center text-[11px] text-muted-foreground">—</td>
+                <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr className="font-semibold">
-                <td className="py-[5px]text-[10px] text-foreground whitespace-nowrap">稼働率</td>
+                <td className="py-[5px] whitespace-nowrap">稼働率</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px]text-center text-[11px] tabular-nums text-[var(--accent)]">
+                  <td key={d.date} className="py-[5px] text-center tabular-nums text-[var(--accent)]">
                     {fmt(d.utilizationRate, '%')}
                   </td>
                 ))}
-                <td className="py-[5px]text-center text-[11px] tabular-nums text-[var(--accent)]">
+                <td className="py-[5px] text-center tabular-nums text-[var(--accent)]">
                   {fmt(analysis.weeklyAvgUtilization, '%')}
                 </td>
               </tr>

--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -68,11 +68,11 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
               <tr className="font-semibold">
                 <td className="py-[5px] whitespace-nowrap">稼働率</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums text-[var(--accent)]">
+                  <td key={d.date} className="py-[5px] text-center text-[9px] tabular-nums text-[var(--accent)]">
                     {fmt(d.utilizationRate, '%')}
                   </td>
                 ))}
-                <td className="py-[5px] text-center tabular-nums text-[var(--accent)]">
+                <td className="py-[5px] text-center text-[9px] tabular-nums text-[var(--accent)]">
                   {fmt(analysis.weeklyAvgUtilization, '%')}
                 </td>
               </tr>

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -15,12 +15,13 @@ import {
 } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-type Section = 'theme' | 'notification' | 'account'
+type Section = 'theme' | 'notification' | 'account' | 'analysis'
 
 const NAV_ITEMS: { id: Section; label: string }[] = [
   { id: 'theme', label: 'テーマ' },
   { id: 'notification', label: '通知' },
   { id: 'account', label: '連携' },
+  { id: 'analysis', label: '分析' },
 ]
 
 const heading = 'mb-2 mt-0 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground'
@@ -38,8 +39,8 @@ export function SettingsView() {
   const [activeSection, setActiveSection] = useState<Section>('theme')
   const {
     activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
-    whiteboardEnabled, breakBehavior,
-    setTheme, setIdle, setElapsed, setPomodoro, setWhiteboard, setBreakBehavior,
+    whiteboardEnabled, breakBehavior, mainProjectCode,
+    setTheme, setIdle, setElapsed, setPomodoro, setWhiteboard, setBreakBehavior, setMainProjectCode,
   } = useSettings()
 
   return (
@@ -220,6 +221,35 @@ export function SettingsView() {
                     id="whiteboard"
                     checked={whiteboardEnabled}
                     onCheckedChange={setWhiteboard}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          </>
+        )}
+
+        {/* ─── 分析 ─── */}
+        {activeSection === 'analysis' && (
+          <>
+            <h2 className={heading}>プロジェクト</h2>
+            <Card>
+              <CardContent className="p-0">
+                <div className="flex items-center justify-between gap-3 p-3.5">
+                  <div>
+                    <Label htmlFor="mainProjectCode" className="text-[13px] font-medium text-foreground">
+                      主プロジェクトコード
+                    </Label>
+                    <p className="mt-0.5 text-[11px] text-muted-foreground">
+                      週次分析でこのコード以外の作業を「PJ外作業」として集計します
+                    </p>
+                  </div>
+                  <input
+                    id="mainProjectCode"
+                    type="text"
+                    value={mainProjectCode}
+                    onChange={e => setMainProjectCode(e.target.value)}
+                    placeholder="例: PROJ-001"
+                    className="h-8 w-32 rounded-md border border-input bg-background px-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                   />
                 </div>
               </CardContent>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -36,6 +36,8 @@ interface ElectronAPI {
   setWhiteboardSettings: (enabled: boolean) => Promise<void>
   getBreakBehaviorSettings: () => Promise<BreakBehaviorSettings>
   setBreakBehaviorSettings: (behavior: 'stop' | 'pause') => Promise<void>
+  getMainProjectCode: () => Promise<string>
+  setMainProjectCode: (code: string) => Promise<void>
 
   // timer signals
   timerStarted: () => Promise<void>

--- a/src/renderer/src/hooks/useSettings.ts
+++ b/src/renderer/src/hooks/useSettings.ts
@@ -12,12 +12,14 @@ export interface SettingsState {
   pomodoroEnabled: boolean
   whiteboardEnabled: boolean
   breakBehavior: 'stop' | 'pause'
+  mainProjectCode: string
   setTheme: (themeId: string) => void
   setIdle: (enabled: boolean, minutes: number) => void
   setElapsed: (enabled: boolean, minutes: number) => void
   setPomodoro: (enabled: boolean) => void
   setWhiteboard: (enabled: boolean) => void
   setBreakBehavior: (b: 'stop' | 'pause') => void
+  setMainProjectCode: (code: string) => void
 }
 
 /** 設定画面のオーケストレーション。各設定の読み出し・即時反映・永続化を統括。 */
@@ -30,6 +32,7 @@ export function useSettings(): SettingsState {
   const [pomodoroEnabled, setPomodoroEnabled] = useState(false)
   const [whiteboardEnabled, setWhiteboardEnabled] = useState(false)
   const [breakBehavior, setBreakBehaviorState] = useState<'stop' | 'pause'>('stop')
+  const [mainProjectCode, setMainProjectCodeState] = useState('')
 
   useEffect(() => {
     const offThemeChanged = settingsRepository.onThemeChanged(setActiveThemeId)
@@ -49,12 +52,13 @@ export function useSettings(): SettingsState {
       setWhiteboardEnabled(enabled)
     })
     settingsRepository.getBreakBehavior().then(({ behavior }) => setBreakBehaviorState(behavior))
+    settingsRepository.getMainProjectCode().then(setMainProjectCodeState)
     return offThemeChanged
   }, [])
 
   return {
     activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
-    whiteboardEnabled, breakBehavior,
+    whiteboardEnabled, breakBehavior, mainProjectCode,
 
     setTheme: (themeId): void => {
       // 即時反映（IPC待ちなし）
@@ -83,6 +87,10 @@ export function useSettings(): SettingsState {
     setBreakBehavior: (b): void => {
       setBreakBehaviorState(b)
       settingsRepository.setBreakBehavior(b)
+    },
+    setMainProjectCode: (code): void => {
+      setMainProjectCodeState(code)
+      settingsRepository.setMainProjectCode(code)
     },
   }
 }

--- a/src/renderer/src/hooks/useWeeklyAnalysis.test.ts
+++ b/src/renderer/src/hooks/useWeeklyAnalysis.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { getWeekdays, calcActualMinutes, buildDayAnalysis } from './useWeeklyAnalysis'
+import type { Session } from '../types/session'
+import type { DayRecord } from '../../../shared/types'
+
+describe('getWeekdays', () => {
+  it('月曜日を含む日付の週の月〜金を返す', () => {
+    const days = getWeekdays('2026-06-22')  // 月曜
+    expect(days).toEqual(['2026-06-22', '2026-06-23', '2026-06-24', '2026-06-25', '2026-06-26'])
+  })
+
+  it('水曜日を含む日付の週の月〜金を返す', () => {
+    const days = getWeekdays('2026-06-24')  // 水曜
+    expect(days).toEqual(['2026-06-22', '2026-06-23', '2026-06-24', '2026-06-25', '2026-06-26'])
+  })
+
+  it('日曜日を含む日付の週の月〜金を返す（前週）', () => {
+    const days = getWeekdays('2026-06-28')  // 日曜
+    expect(days).toEqual(['2026-06-22', '2026-06-23', '2026-06-24', '2026-06-25', '2026-06-26'])
+  })
+
+  it('月末をまたぐ週を正しく返す', () => {
+    const days = getWeekdays('2026-06-30')  // 火曜
+    expect(days).toEqual(['2026-06-29', '2026-06-30', '2026-07-01', '2026-07-02', '2026-07-03'])
+  })
+})
+
+describe('calcActualMinutes', () => {
+  it('workStart と workEnd から breakMinutes を引いた分数を返す', () => {
+    const record: DayRecord = { workStart: '09:00', workEnd: '18:00', breakMinutes: 60 }
+    expect(calcActualMinutes(record)).toBe(480)
+  })
+
+  it('breakMinutes が未設定で breakStart/breakEnd がある場合は自動計算する', () => {
+    const record: DayRecord = { workStart: '09:00', workEnd: '18:00', breakStart: '12:00', breakEnd: '13:00' }
+    expect(calcActualMinutes(record)).toBe(480)
+  })
+
+  it('workStart が未入力の場合は null を返す', () => {
+    expect(calcActualMinutes({ workEnd: '18:00' })).toBeNull()
+  })
+
+  it('workEnd が未入力の場合は null を返す', () => {
+    expect(calcActualMinutes({ workStart: '09:00' })).toBeNull()
+  })
+
+  it('record が null の場合は null を返す', () => {
+    expect(calcActualMinutes(null)).toBeNull()
+  })
+})
+
+describe('buildDayAnalysis', () => {
+  const sessions: Session[] = [
+    {
+      id: '1', taskId: '1', name: '主PJ作業', projectCode: 'MAIN', workCategory: '開発',
+      times: [], date: '2026-06-23', color: '#FF9500', totalTime: 300,
+    },
+    {
+      id: '2', taskId: '2', name: 'PJ外作業', projectCode: 'OTHER', workCategory: '会議',
+      times: [], date: '2026-06-23', color: '#FF9500', totalTime: 90,
+    },
+    {
+      id: '3', taskId: '3', name: '想定外作業', projectCode: 'MAIN', workCategory: '想定外',
+      times: [], date: '2026-06-23', color: '#FF9500', totalTime: 30,
+    },
+  ]
+
+  it('各指標を正しく計算する', () => {
+    const record: DayRecord = { workStart: '09:00', workEnd: '18:00', breakMinutes: 60 }
+    const result = buildDayAnalysis('2026-06-23', '火', record, sessions, 'MAIN')
+    expect(result.scheduledMinutes).toBe(480)
+    expect(result.actualMinutes).toBe(480)
+    expect(result.nonProjectMinutes).toBe(90)   // projectCode !== 'MAIN'
+    expect(result.unexpectedMinutes).toBe(30)    // workCategory === '想定外'
+    expect(result.utilizationRate).toBe(100)     // 480/480*100
+  })
+
+  it('mainProjectCode が空のとき nonProjectMinutes は 0', () => {
+    const record: DayRecord = { workStart: '09:00', workEnd: '18:00', breakMinutes: 60 }
+    const result = buildDayAnalysis('2026-06-23', '火', record, sessions, '')
+    expect(result.nonProjectMinutes).toBe(0)
+  })
+
+  it('actualMinutes が null のとき utilizationRate も null', () => {
+    const result = buildDayAnalysis('2026-06-23', '火', null, sessions, 'MAIN')
+    expect(result.actualMinutes).toBeNull()
+    expect(result.utilizationRate).toBeNull()
+  })
+})

--- a/src/renderer/src/hooks/useWeeklyAnalysis.test.ts
+++ b/src/renderer/src/hooks/useWeeklyAnalysis.test.ts
@@ -47,6 +47,11 @@ describe('calcActualMinutes', () => {
   it('record が null の場合は null を返す', () => {
     expect(calcActualMinutes(null)).toBeNull()
   })
+
+  it('breakMinutes も breakStart/breakEnd も未設定の場合は休憩 0 分として計算する', () => {
+    const record: DayRecord = { workStart: '09:00', workEnd: '18:00' }
+    expect(calcActualMinutes(record)).toBe(540)
+  })
 })
 
 describe('buildDayAnalysis', () => {

--- a/src/renderer/src/hooks/useWeeklyAnalysis.ts
+++ b/src/renderer/src/hooks/useWeeklyAnalysis.ts
@@ -49,7 +49,11 @@ export function calcActualMinutes(record: DayRecord | null): number | null {
     return h * 60 + m
   }
   const totalMins = parseHHMM(record.workEnd) - parseHHMM(record.workStart)
-  const breakMins = record.breakMinutes ?? calcBreakMinutes(record.breakStart ?? null, record.breakEnd ?? null)
+  const breakMins = record.breakMinutes != null
+    ? record.breakMinutes
+    : (record.breakStart && record.breakEnd)
+      ? calcBreakMinutes(record.breakStart, record.breakEnd)
+      : 0
   return Math.max(0, totalMins - breakMins)
 }
 

--- a/src/renderer/src/hooks/useWeeklyAnalysis.ts
+++ b/src/renderer/src/hooks/useWeeklyAnalysis.ts
@@ -1,0 +1,121 @@
+import { useState, useEffect } from 'react'
+import type { Session } from '../types/session'
+import type { DayRecord } from '../../../shared/types'
+import { sessionRepository } from '../repositories/sessionRepository'
+import { settingsRepository } from '../repositories/settingsRepository'
+import { useDailyData } from '../daily/DailyDataContext'
+import { calcBreakMinutes } from '../domain/attendance'
+
+export interface DayAnalysis {
+  date: string
+  dayLabel: string
+  scheduledMinutes: number
+  actualMinutes: number | null
+  nonProjectMinutes: number
+  unexpectedMinutes: number
+  utilizationRate: number | null
+}
+
+export interface WeeklyAnalysis {
+  weekLabel: string
+  days: DayAnalysis[]
+  weeklyAvgUtilization: number | null
+}
+
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土']
+
+/** date を含む週の月〜金の "YYYY-MM-DD" 配列を返す（月曜始まり） */
+export function getWeekdays(date: string): string[] {
+  const d = new Date(`${date}T00:00:00`)
+  const dow = d.getDay()  // 0=日, 1=月, ...6=土
+  const diffToMonday = dow === 0 ? -6 : 1 - dow
+  const monday = new Date(d)
+  monday.setDate(d.getDate() + diffToMonday)
+  return Array.from({ length: 5 }, (_, i) => {
+    const day = new Date(monday)
+    day.setDate(monday.getDate() + i)
+    const y = day.getFullYear()
+    const m = String(day.getMonth() + 1).padStart(2, '0')
+    const dd = String(day.getDate()).padStart(2, '0')
+    return `${y}-${m}-${dd}`
+  })
+}
+
+/** DayRecord から実稼働時間（分）を算出。workStart/workEnd 未入力なら null */
+export function calcActualMinutes(record: DayRecord | null): number | null {
+  if (!record?.workStart || !record?.workEnd) return null
+  const parseHHMM = (t: string): number => {
+    const [h, m] = t.split(':').map(Number)
+    return h * 60 + m
+  }
+  const totalMins = parseHHMM(record.workEnd) - parseHHMM(record.workStart)
+  const breakMins = record.breakMinutes ?? calcBreakMinutes(record.breakStart ?? null, record.breakEnd ?? null)
+  return Math.max(0, totalMins - breakMins)
+}
+
+/** 1日分の分析データを計算する */
+export function buildDayAnalysis(
+  date: string,
+  dayLabel: string,
+  record: DayRecord | null,
+  sessions: Session[],
+  mainProjectCode: string,
+): DayAnalysis {
+  const actualMinutes = calcActualMinutes(record)
+  const nonProjectMinutes = mainProjectCode
+    ? sessions.filter(s => s.projectCode !== mainProjectCode).reduce((acc, s) => acc + s.totalTime, 0)
+    : 0
+  const unexpectedMinutes = sessions
+    .filter(s => s.workCategory === '想定外')
+    .reduce((acc, s) => acc + s.totalTime, 0)
+  const utilizationRate = actualMinutes !== null
+    ? Math.round(actualMinutes / 480 * 100)
+    : null
+  return { date, dayLabel, scheduledMinutes: 480, actualMinutes, nonProjectMinutes, unexpectedMinutes, utilizationRate }
+}
+
+/** 選択日を含む週の稼働分析データを返すフック */
+export function useWeeklyAnalysis(date: string | null): { analysis: WeeklyAnalysis | null; loading: boolean } {
+  const [analysis, setAnalysis] = useState<WeeklyAnalysis | null>(null)
+  const [loading, setLoading] = useState(false)
+  const daily = useDailyData()
+
+  useEffect(() => {
+    if (!date) { setAnalysis(null); return }
+
+    const weekdays = getWeekdays(date)
+    // 月またぎ対応：必要な月を重複なく収集
+    const months = [...new Set(weekdays.map(d => d.slice(0, 7)))]
+    months.forEach(ym => daily.ensureMonth(ym))
+
+    setLoading(true)
+    Promise.all([
+      ...months.map(ym => sessionRepository.list(ym)),
+      settingsRepository.getMainProjectCode(),
+    ]).then(results => {
+      const allSessions = (results.slice(0, months.length) as Session[][]).flat()
+      const mainProjectCode = results[months.length] as string
+
+      const days = weekdays.map(d => {
+        const dow = new Date(`${d}T00:00:00`).getDay()
+        const dayLabel = DAY_LABELS[dow]
+        const record = daily.getDay(d)
+        const daySessions = allSessions.filter(s => s.date === d)
+        return buildDayAnalysis(d, dayLabel, record, daySessions, mainProjectCode)
+      })
+
+      const validRates = days.map(d => d.utilizationRate).filter((r): r is number => r !== null)
+      const weeklyAvgUtilization = validRates.length > 0
+        ? Math.round(validRates.reduce((a, b) => a + b, 0) / validRates.length)
+        : null
+
+      const monday = weekdays[0]
+      const weekLabel = `${monday.slice(0, 4)}/${monday.slice(5, 7)}/${monday.slice(8, 10)} の週`
+
+      setAnalysis({ weekLabel, days, weeklyAvgUtilization })
+    }).finally(() => setLoading(false))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date])
+
+  return { analysis, loading }
+}

--- a/src/renderer/src/repositories/settingsRepository.ts
+++ b/src/renderer/src/repositories/settingsRepository.ts
@@ -46,6 +46,13 @@ export const settingsRepository = {
     return window.electronAPI.setBreakBehaviorSettings(behavior)
   },
 
+  getMainProjectCode(): Promise<string> {
+    return window.electronAPI.getMainProjectCode()
+  },
+  setMainProjectCode(code: string): Promise<void> {
+    return window.electronAPI.setMainProjectCode(code)
+  },
+
   completeSetup(): Promise<void> {
     return window.electronAPI.completeSetup()
   },

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -70,6 +70,10 @@ export interface IpcContract {
   'settings:getBreakBehaviorSettings': [void, BreakBehaviorSettings]
   'settings:setBreakBehaviorSettings': [{ behavior: 'stop' | 'pause' }, void]
 
+  // settings: analysis
+  'settings:getMainProjectCode': [void, string]
+  'settings:setMainProjectCode': [code: string, void]
+
   // timer signals
   'timer:started': [void, void]
   'timer:stopped': [void, void]


### PR DESCRIPTION
## Summary

- 設定画面に「主プロジェクトコード」入力欄を追加（分析セクション）
- `useWeeklyAnalysis` フックを実装（稼働率・PJ外・想定外の集計）
- カレンダー日付詳細のフッターをダブルクリックすると週次分析モーダルが開く
- 休憩未入力時の暗黙60分控除バグを修正

## Test plan

- [ ] 設定画面 → 分析タブで主プロジェクトコードを入力・保存できること
- [ ] カレンダーで日付を選択し、詳細フッターをダブルクリックすると週次分析モーダルが開くこと
- [ ] モーダルに当週の稼働率・PJ外・想定外が正しく表示されること
- [ ] `npm test` が全テスト通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)