### PR TITLE
fix: 勤怠テキスト生成時にタスク名の空白を全除去

### DIFF
--- a/src/renderer/src/domain/attendance.test.ts
+++ b/src/renderer/src/domain/attendance.test.ts
@@ -25,6 +25,12 @@ describe('buildAttendanceText', () => {
     expect(overageMinutes).toBeNull()
   })
 
+  it('名前の前後・中間の空白を全て除去して出力する', () => {
+    const sessions = [makeSession({ name: '  テ スト　作業  ' })]
+    const { text } = buildAttendanceText(sessions, '08:37', '18:40', 60)
+    expect(text).toBe('勤怠\n08:37 18:40 60\nZZ テスト作業 設計 543')
+  })
+
   it('複数タスクの場合、差分は最後のタスクにのみ加算される', () => {
     // 勤務: 08:37〜18:40 = 603分, 休憩60分 → 実労働543分
     // タイマー合計: 180+60=240分, 差分: 303分 → 最後のタスク: 60+303=363

--- a/src/renderer/src/domain/attendance.ts
+++ b/src/renderer/src/domain/attendance.ts
@@ -49,7 +49,7 @@ export function buildAttendanceText(
       existing.totalMinutes += minutes
     } else {
       map.set(key, {
-        name: s.name,
+        name: s.name.replace(/\s/g, ''),
         projectCode: s.projectCode ?? '',
         workCategory: s.workCategory ?? '',
         totalMinutes: minutes,


### PR DESCRIPTION
## 概要
勤怠画面の表示・送信時に、タスク名の空白を全除去する。

## 変更点
- `buildAttendanceText` で `name` の前後・中間の空白（全角スペース U+3000 含む）を `\s` で除去
- 表示と送信は同じ `text` を使うため1箇所で両対応
- 既存の保存データの空白も出力時にクリーンされる
- テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)