### PR TITLE
fix: 存在しないeslintルールのdisableコメントを削除

### DIFF
--- a/src/renderer/src/hooks/useWeeklyAnalysis.ts
+++ b/src/renderer/src/hooks/useWeeklyAnalysis.ts
@@ -118,7 +118,6 @@ export function useWeeklyAnalysis(date: string | null): { analysis: WeeklyAnalys
 
       setAnalysis({ weekLabel, days, weeklyAvgUtilization })
     }).finally(() => setLoading(false))
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [date])
 
   return { analysis, loading }


### PR DESCRIPTION
## 概要
CI の lint が失敗していたため修正。

## 原因
`eslint-plugin-react-hooks` が未導入のプロジェクトで、`useWeeklyAnalysis.ts` に `// eslint-disable-next-line react-hooks/exhaustive-deps` が記述されており、「ルール定義が見つからない」エラーになっていた（PR #59 で混入）。

## 変更点
- 無効なルールに対する disable コメントを削除（ルール自体が存在しないため副作用なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)