### PR TITLE
feat: セットアップ画面にホワイトボード連携と主PJコード入力を追加

### DIFF
--- a/src/renderer/src/components/Setup/SetupView.test.tsx
+++ b/src/renderer/src/components/Setup/SetupView.test.tsx
@@ -12,11 +12,17 @@ const api = {
   signInWithSlack: vi.fn().mockResolvedValue(undefined),
   signOutSlack: vi.fn().mockResolvedValue(undefined),
   onAuthChanged: vi.fn(() => () => {}),
+  getWhiteboardSettings: vi.fn().mockResolvedValue({ enabled: false }),
+  setWhiteboardSettings: vi.fn().mockResolvedValue(undefined),
+  getMainProjectCode: vi.fn().mockResolvedValue(''),
+  setMainProjectCode: vi.fn().mockResolvedValue(undefined),
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
   api.getAuthStatus.mockResolvedValue({ signedIn: false })
+  api.getWhiteboardSettings.mockResolvedValue({ enabled: false })
+  api.getMainProjectCode.mockResolvedValue('')
   Object.assign(window, { electronAPI: api })
 })
 
@@ -38,10 +44,10 @@ describe('SetupView step2（サインイン）', () => {
     expect(api.signInWithSlack).toHaveBeenCalled()
   })
 
-  it('「あとで設定する」で step3 に進める', async () => {
+  it('「あとで設定する」で連携設定ステップに進める', async () => {
     await goToStep2()
     await userEvent.click(screen.getByRole('button', { name: 'あとで設定する' }))
-    expect(await screen.findByRole('button', { name: '完了' })).toBeInTheDocument()
+    expect(await screen.findByLabelText('主プロジェクトコード')).toBeInTheDocument()
   })
 
   it('サインイン済みなら名前と「次へ」が出る', async () => {
@@ -49,5 +55,38 @@ describe('SetupView step2（サインイン）', () => {
     await goToStep2()
     expect(await screen.findByText(/金山/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '次へ' })).toBeInTheDocument()
+  })
+})
+
+describe('SetupView step3（連携設定）', () => {
+  async function goToStep3() {
+    render(<SetupView />)
+    await userEvent.click(await screen.findByRole('button', { name: 'はじめる' }))
+    await userEvent.click(await screen.findByRole('button', { name: 'あとで設定する' }))
+    await screen.findByLabelText('主プロジェクトコード')
+  }
+
+  it('ホワイトボード連携トグルと主プロジェクトコード入力欄が出る', async () => {
+    await goToStep3()
+    expect(screen.getByRole('switch')).toBeInTheDocument()
+    expect(screen.getByLabelText('主プロジェクトコード')).toBeInTheDocument()
+  })
+
+  it('主プロジェクトコードを入力すると setMainProjectCode を呼ぶ', async () => {
+    await goToStep3()
+    await userEvent.type(screen.getByLabelText('主プロジェクトコード'), 'PROJ-001')
+    expect(api.setMainProjectCode).toHaveBeenLastCalledWith('PROJ-001')
+  })
+
+  it('ホワイトボード連携トグルで setWhiteboardSettings を呼ぶ', async () => {
+    await goToStep3()
+    await userEvent.click(screen.getByRole('switch'))
+    expect(api.setWhiteboardSettings).toHaveBeenCalledWith(true)
+  })
+
+  it('「次へ」でテーマ（完了）ステップに進める', async () => {
+    await goToStep3()
+    await userEvent.click(screen.getByRole('button', { name: '次へ' }))
+    expect(await screen.findByRole('button', { name: '完了' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/Setup/SetupView.tsx
+++ b/src/renderer/src/components/Setup/SetupView.tsx
@@ -5,11 +5,16 @@ import { useAuthStatus } from '../../hooks/useAuthStatus'
 import { ThemeGrid } from '../ThemeGrid/ThemeGrid'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 
-const TOTAL_STEPS = 3
+const TOTAL_STEPS = 4
 
 export function SetupView() {
-  const { activeThemeId, setTheme, complete } = useSetup()
+  const {
+    activeThemeId, setTheme, complete,
+    whiteboardEnabled, setWhiteboard, mainProjectCode, setMainProjectCode,
+  } = useSetup()
   const { status, signIn } = useAuthStatus()
   const [step, setStep] = useState(1)
 
@@ -45,9 +50,60 @@ export function SetupView() {
         </div>
       )}
 
-      {/* Step 3: テーマ選択 */}
+      {/* Step 3: 連携設定（ホワイトボード連携 + 主PJコード） */}
       {step === 3 && (
         <div className="flex flex-1 flex-col animate-fade-in" key="step3">
+          <h2 className="mb-1 text-[15px] font-semibold">連携設定</h2>
+          <p className="mb-4 text-[12px] text-muted-foreground">
+            ホワイトボード連携と主プロジェクトコードを設定します。あとから設定 &gt; 連携 / 分析でも変更できます。
+          </p>
+          <Card className="mb-3">
+            <CardContent className="p-0">
+              <div className="flex items-center justify-between gap-3 p-3.5">
+                <div>
+                  <Label htmlFor="whiteboard" className="text-[13px] font-medium text-foreground">
+                    ホワイトボード連携
+                  </Label>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    タイマー開始時に出勤 / 勤怠送信時に退勤
+                  </p>
+                </div>
+                <Switch
+                  id="whiteboard"
+                  checked={whiteboardEnabled}
+                  onCheckedChange={setWhiteboard}
+                />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-0">
+              <div className="flex items-center justify-between gap-3 p-3.5">
+                <div>
+                  <Label htmlFor="mainProjectCode" className="text-[13px] font-medium text-foreground">
+                    主プロジェクトコード
+                  </Label>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    週次分析でこのコード以外の作業を「PJ外作業」として集計します
+                  </p>
+                </div>
+                <input
+                  id="mainProjectCode"
+                  type="text"
+                  value={mainProjectCode}
+                  onChange={e => setMainProjectCode(e.target.value)}
+                  placeholder="例: PROJ-001"
+                  className="h-8 w-32 rounded-md border border-input bg-background px-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Step 4: テーマ選択 */}
+      {step === 4 && (
+        <div className="flex flex-1 flex-col animate-fade-in" key="step4">
           <div className="mb-5 text-center">
             <span className="mb-1 block text-[36px]">🧃</span>
             <h1 className="mb-1 mt-0 text-[18px] font-bold text-[var(--text-primary)]">テーマ</h1>
@@ -96,6 +152,9 @@ export function SetupView() {
             </Button>
           )}
           {step === 3 && (
+            <Button className="flex-1" onClick={() => setStep(4)}>次へ</Button>
+          )}
+          {step === 4 && (
             <Button className="flex-1" onClick={complete}>完了</Button>
           )}
         </div>

--- a/src/renderer/src/hooks/useSetup.ts
+++ b/src/renderer/src/hooks/useSetup.ts
@@ -6,15 +6,23 @@ import { DEFAULT_THEME_ID } from '../theme/themeParams'
 export interface SetupState {
   activeThemeId: string
   setTheme: (themeId: string) => void
+  whiteboardEnabled: boolean
+  setWhiteboard: (enabled: boolean) => void
+  mainProjectCode: string
+  setMainProjectCode: (code: string) => void
   complete: () => Promise<void>
 }
 
-/** セットアップウィザードのオーケストレーション。テーマ即時反映と完了処理を統括。 */
+/** セットアップウィザードのオーケストレーション。テーマ即時反映と連携設定の保存、完了処理を統括。 */
 export function useSetup(): SetupState {
   const [activeThemeId, setActiveThemeId] = useState(DEFAULT_THEME_ID)
+  const [whiteboardEnabled, setWhiteboardEnabled] = useState(false)
+  const [mainProjectCode, setMainProjectCodeState] = useState('')
 
   useEffect(() => {
     settingsRepository.getTheme().then(setActiveThemeId)
+    settingsRepository.getWhiteboard().then(w => setWhiteboardEnabled(w.enabled))
+    settingsRepository.getMainProjectCode().then(setMainProjectCodeState)
     return settingsRepository.onThemeChanged(setActiveThemeId)
   }, [])
 
@@ -25,6 +33,16 @@ export function useSetup(): SetupState {
       applyTheme(themeId)
       setActiveThemeId(themeId)
       settingsRepository.setTheme(themeId)
+    },
+    whiteboardEnabled,
+    setWhiteboard: (enabled): void => {
+      setWhiteboardEnabled(enabled)
+      settingsRepository.setWhiteboard(enabled)
+    },
+    mainProjectCode,
+    setMainProjectCode: (code): void => {
+      setMainProjectCodeState(code)
+      settingsRepository.setMainProjectCode(code)
     },
     complete: async (): Promise<void> => {
       await settingsRepository.completeSetup()


### PR DESCRIPTION
## 概要
初回セットアップウィザードに連携設定ステップを追加し、ホワイトボード連携と主プロジェクトコードを設定できるようにした。

## 変更点
- ウィザードを3→4ステップに拡張（welcome → Slack → **連携設定** → テーマ/完了）
- Step3「連携設定」: ホワイトボード連携トグル + 主プロジェクトコード入力
- `useSetup` に whiteboard / mainProjectCode の読み込み・保存を追加（既存の settingsRepository / IPC を利用）
- 主PJコードは任意（未入力でも完了可）
- テスト追加

## 補足
両設定とも永続化・IPC・SettingsView 側の入力UIは既存。今回は SetupView への入力UI追加のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)