### PR TITLE
docs: ダウンロード手順付きREADMEを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Juice
+
+作業セッションを時間区間として記録する macOS メニューバーアプリ。
+
+## ダウンロード
+
+お使いの Mac に合わせて DMG をダウンロードしてください。
+
+| Mac の種類 | ダウンロード |
+| --- | --- |
+| Apple Silicon（M1 以降） | [**Juice-1.0.0-arm64.dmg**](https://github.com/ryota-kanayama/juice/releases/download/v1.0.0/Juice-1.0.0-arm64.dmg) |
+| Intel Mac | [**Juice-1.0.0.dmg**](https://github.com/ryota-kanayama/juice/releases/download/v1.0.0/Juice-1.0.0.dmg) |
+
+> お使いの Mac の種類は、画面左上の  メニュー →「この Mac について」で確認できます。「チップ」が Apple M〜 なら Apple Silicon、「プロセッサ」が Intel なら Intel Mac です。
+
+すべてのバージョンは [リリース一覧](https://github.com/ryota-kanayama/juice/releases) から確認できます。
+
+## インストール
+
+1. ダウンロードした `.dmg` を開く
+2. **Juice** を `Applications` フォルダにドラッグ
+3. `Applications` から Juice を起動
+
+### ⚠️ 「開発元を確認できないため開けません」と出た場合
+
+このアプリは現在 **未署名** のため、初回起動時に警告が表示されます。次のどちらかで起動できます。
+
+- **方法A**: `Applications` 内の Juice を **右クリック →「開く」** を選択 →「開く」をクリック
+- **方法B**: ターミナルで以下を実行
+
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/Juice.app
+  ```
+
+一度起動すれば、2回目以降は通常どおりダブルクリックで開けます。
+
+## 開発
+
+```bash
+# 開発（ホットリロード）
+npm run dev
+
+# 型チェック
+npm run typecheck
+
+# テスト
+npm test
+
+# DMG をビルド（無署名）
+CSC_IDENTITY_AUTO_DISCOVERY=false npm run package
+```


### PR DESCRIPTION
## 概要
- ダウンロード用 README を新規追加
- Apple Silicon / Intel 別の直接ダウンロードリンク
- 未署名アプリの起動回避手順を記載