### PR TITLE
fix: Electronウィンドウのナビゲーションガードとサンドボックスを追加

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -48,6 +48,21 @@ app.on('open-url', (event, url) => {
   handleAuthCallback(url, authStore).catch(err => logger.error('auth callback failed:', err))
 })
 
+// レンダラー発のナビゲーション・新規ウィンドウ生成を制限する多層防御。
+// 自バンドル(file://)と dev サーバ(localhost:5174)以外への遷移を弾き、
+// 外部 origin によるウィンドウ乗っ取りを防ぐ。外部リンクは shell:openUrl
+// （http/https 限定の openExternal）経由のみ許可する。
+app.on('web-contents-created', (_event, contents) => {
+  contents.on('will-navigate', (event, url) => {
+    const allowed = url.startsWith('http://localhost:5174') || url.startsWith('file://')
+    if (!allowed) {
+      event.preventDefault()
+      logger.warn('blocked navigation to:', url)
+    }
+  })
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }))
+})
+
 app.whenReady().then(async () => {
   // 開発時もDockにアプリアイコンを表示する（パッケージ版はバンドルの icns が使われる）
   const dockIcon = nativeImage.createFromPath(join(__dirname, '../../resources/icon.png'))

--- a/src/main/windows/shared.ts
+++ b/src/main/windows/shared.ts
@@ -6,6 +6,9 @@ export const sharedWebPreferences = {
   preload: join(__dirname, '../preload/index.js'),
   contextIsolation: true,
   nodeIntegration: false,
+  // レンダラーを OS から隔離する。preload は electron(contextBridge/ipcRenderer)
+  // のみ使用するためサンドボックス下でも動作する。
+  sandbox: true,
   // タイマーアプリにスペルチェックは不要。辞書の読み込み分のメモリを節約する。
   spellcheck: false,
 } as const


### PR DESCRIPTION
## 概要
リポジトリ全体のセキュリティ調査で検出した、Electron ウィンドウの多層防御不足に対応。

## 変更
- `will-navigate` / `setWindowOpenHandler` を全 webContents に設定し、レンダラー発の外部 origin への遷移・新規ウィンドウ生成を拒否（自バンドル `file://` と dev サーバ `localhost:5174` のみ許可）。外部リンクは従来どおり `shell:openUrl`（http/https 限定の openExternal）経由のみ。
- `sharedWebPreferences` に `sandbox: true` を明示。preload は electron のみ使用のためサンドボックス下でも動作。

## 検証
- `npm run typecheck` ✅
- `npm test` ✅ 599 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)