### PR TITLE
ci: GitHub Actions を @v5 系へ更新 (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## 対応
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `node-version: 22` は安定性重視で継続

Node20 ランタイム廃止（2026-09-16）に伴う deprecation 警告を解消する。

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)