### PR TITLE
maint: Electron を 42.5.0 に追従 (#83)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.5.0",
         "dependency-cruiser": "^17.4.0",
-        "electron": "^42.4.0",
+        "electron": "^42.5.0",
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "eslint": "^8.56.0",
@@ -7080,9 +7080,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
-      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
+      "version": "42.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.5.0.tgz",
+      "integrity": "sha512-cYEKS9XFz+c9fAB4jI0x49yz1FFzB55r3q96wu9YkwwJMv7t9202IE/ltlgy6yitl/J4M7C8JQcmUqdzDvPl/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.5.0",
     "dependency-cruiser": "^17.4.0",
-    "electron": "^42.4.0",
+    "electron": "^42.5.0",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "eslint": "^8.56.0",


### PR DESCRIPTION
## 対応
- `electron` `^42.4.0` → `^42.5.0`（最新安定版）

major 42 が最新（43 未リリース）のため、major 42 系内の最新パッチへ追従。

## 検証
- typecheck / test(599) / lint / knip / build すべて green
- `npm audit` 0 件
- スモークテスト合格（42.5.0 バイナリでレンダラーがロードされクラッシュなし）

## 補足
- スモーク手順で `--user-data-dir` フラグが効かない点（アプリが userData を juice-dev に固定）が判明したため、ローカル手順書を修正済み（`docs/` は非追跡）。

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)