### PR TITLE
feat: 使用ガイドを追加 (#67 Part B)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { SettingsView } from './components/Settings/SettingsView'
 import { SetupView } from './components/Setup/SetupView'
 import { CalendarPage } from './components/Calendar/CalendarPage'
 import { WorkStartOverlay } from './components/Popover/WorkStartOverlay'
+import { UsageGuideButton } from './components/UsageGuide/UsageGuideButton'
 import { useWorkday } from './hooks/useWorkday'
 import { useSuggestions } from './hooks/useSuggestions'
 import { useBreak } from './hooks/useBreak'
@@ -77,7 +78,9 @@ function PopoverView() {
           <Xmark width={16} height={16} />
         </Button>
         <span className={styles.logo}>juice</span>
-        <div className={styles.menuWrapper} ref={menuRef}>
+        <div className="flex items-center gap-0.5">
+          <UsageGuideButton />
+          <div className={styles.menuWrapper} ref={menuRef}>
           <Button variant="ghost" size="icon" aria-label="アカウント" className="[-webkit-app-region:no-drag]" onClick={() => setMenuOpen(p => !p)}>
             <AccountAvatar avatarUrl={status.avatarUrl} name={status.name} />
           </Button>
@@ -129,6 +132,7 @@ function PopoverView() {
               </button>
             </div>
           )}
+          </div>
         </div>
       </header>
 

--- a/src/renderer/src/components/Setup/SetupView.test.tsx
+++ b/src/renderer/src/components/Setup/SetupView.test.tsx
@@ -84,9 +84,19 @@ describe('SetupView step3（連携設定）', () => {
     expect(api.setWhiteboardSettings).toHaveBeenCalledWith(true)
   })
 
-  it('「次へ」でテーマ（完了）ステップに進める', async () => {
+  it('「次へ」でテーマステップに進める', async () => {
     await goToStep3()
     await userEvent.click(screen.getByRole('button', { name: '次へ' }))
-    expect(await screen.findByRole('button', { name: '完了' })).toBeInTheDocument()
+    expect(await screen.findByText('お好みのテーマを選んでください')).toBeInTheDocument()
+  })
+
+  it('テーマの「次へ」で操作の基本（完了）ステップに進める', async () => {
+    await goToStep3()
+    await userEvent.click(screen.getByRole('button', { name: '次へ' }))
+    await screen.findByText('お好みのテーマを選んでください')
+    await userEvent.click(screen.getByRole('button', { name: '次へ' }))
+    expect(await screen.findByText('操作の基本')).toBeInTheDocument()
+    expect(screen.getByText('記録を編集')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '完了' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/Setup/SetupView.test.tsx
+++ b/src/renderer/src/components/Setup/SetupView.test.tsx
@@ -96,7 +96,7 @@ describe('SetupView step3（連携設定）', () => {
     await screen.findByText('お好みのテーマを選んでください')
     await userEvent.click(screen.getByRole('button', { name: '次へ' }))
     expect(await screen.findByText('操作の基本')).toBeInTheDocument()
-    expect(screen.getByText('記録を編集')).toBeInTheDocument()
+    expect(screen.getByText('作業を始める')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '完了' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/Setup/SetupView.tsx
+++ b/src/renderer/src/components/Setup/SetupView.tsx
@@ -127,11 +127,7 @@ export function SetupView() {
       {step === 5 && (
         <div className="flex flex-1 flex-col animate-fade-in" key="step5">
           <h2 className="mb-3 text-[15px] font-semibold">操作の基本</h2>
-          <Card>
-            <CardContent className="p-4">
-              <UsageGuide />
-            </CardContent>
-          </Card>
+          <UsageGuide />
         </div>
       )}
 

--- a/src/renderer/src/components/Setup/SetupView.tsx
+++ b/src/renderer/src/components/Setup/SetupView.tsx
@@ -7,8 +7,9 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { UsageGuide } from '../UsageGuide/UsageGuide'
 
-const TOTAL_STEPS = 4
+const TOTAL_STEPS = 5
 
 export function SetupView() {
   const {
@@ -122,6 +123,18 @@ export function SetupView() {
         </div>
       )}
 
+      {/* Step 5: 操作の基本 */}
+      {step === 5 && (
+        <div className="flex flex-1 flex-col animate-fade-in" key="step5">
+          <h2 className="mb-3 text-[15px] font-semibold">操作の基本</h2>
+          <Card>
+            <CardContent className="p-4">
+              <UsageGuide />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
       {/* フッター: インジケーター + ボタン */}
       <div className="mt-auto flex shrink-0 flex-col gap-3">
         <div className="flex justify-center gap-1.5">
@@ -155,6 +168,9 @@ export function SetupView() {
             <Button className="flex-1" onClick={() => setStep(4)}>次へ</Button>
           )}
           {step === 4 && (
+            <Button className="flex-1" onClick={() => setStep(5)}>次へ</Button>
+          )}
+          {step === 5 && (
             <Button className="flex-1" onClick={complete}>完了</Button>
           )}
         </div>

--- a/src/renderer/src/components/UsageGuide/UsageGuide.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuide.test.tsx
@@ -1,13 +1,33 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { UsageGuide } from './UsageGuide'
 
 describe('UsageGuide', () => {
-  it('主要な操作項目を表示する', () => {
+  it('最初は先頭の項目だけを表示する', () => {
     render(<UsageGuide />)
+    expect(screen.getByText('作業を始める')).toBeInTheDocument()
+    expect(screen.queryByText('記録を編集')).not.toBeInTheDocument()
+  })
+
+  it('「次の項目へ」で次の項目に進む', async () => {
+    const user = userEvent.setup()
+    render(<UsageGuide />)
+    await user.click(screen.getByRole('button', { name: '次の項目へ' }))
     expect(screen.getByText('記録を編集')).toBeInTheDocument()
-    expect(screen.getByText('追加・削除')).toBeInTheDocument()
-    expect(screen.getByText('並び替え')).toBeInTheDocument()
-    expect(screen.getAllByText(/ダブルクリック/).length).toBeGreaterThan(0)
+    expect(screen.queryByText('作業を始める')).not.toBeInTheDocument()
+  })
+
+  it('「前の項目へ」で前の項目に戻る', async () => {
+    const user = userEvent.setup()
+    render(<UsageGuide />)
+    await user.click(screen.getByRole('button', { name: '次の項目へ' }))
+    await user.click(screen.getByRole('button', { name: '前の項目へ' }))
+    expect(screen.getByText('作業を始める')).toBeInTheDocument()
+  })
+
+  it('先頭では「前の項目へ」が無効', () => {
+    render(<UsageGuide />)
+    expect(screen.getByRole('button', { name: '前の項目へ' })).toBeDisabled()
   })
 })

--- a/src/renderer/src/components/UsageGuide/UsageGuide.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuide.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { UsageGuide } from './UsageGuide'
+
+describe('UsageGuide', () => {
+  it('主要な操作項目を表示する', () => {
+    render(<UsageGuide />)
+    expect(screen.getByText('記録を編集')).toBeInTheDocument()
+    expect(screen.getByText('追加・削除')).toBeInTheDocument()
+    expect(screen.getByText('並び替え')).toBeInTheDocument()
+    expect(screen.getAllByText(/ダブルクリック/).length).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/UsageGuide/UsageGuide.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuide.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { NavArrowLeft, NavArrowRight } from 'iconoir-react'
+import { NavArrowUp, NavArrowDown } from 'iconoir-react'
 import { Button } from '@/components/ui/button'
 
 interface GuideItem {
@@ -24,41 +24,46 @@ export function UsageGuide() {
   const isLast = index === GUIDE_ITEMS.length - 1
 
   return (
-    <div className="flex flex-col items-center gap-2.5">
-      <div className="flex w-full items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="前の項目へ"
-          disabled={isFirst}
-          onClick={() => setIndex(i => Math.max(0, i - 1))}
-        >
-          <NavArrowLeft width={18} height={18} />
-        </Button>
-        <div className="flex min-h-[64px] flex-1 flex-col items-center justify-center gap-1 px-1 text-center">
+    <div className="flex w-full flex-col items-center gap-1.5">
+      {/* 上矢印（パネルの外） */}
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="前の項目へ"
+        disabled={isFirst}
+        onClick={() => setIndex(i => Math.max(0, i - 1))}
+      >
+        <NavArrowUp width={18} height={18} />
+      </Button>
+
+      {/* パネル本体 */}
+      <div className="w-full rounded-lg border border-border bg-card px-4 py-3 shadow-sm">
+        <div className="flex min-h-[60px] flex-col items-center justify-center gap-1 text-center">
           <span className="text-[14px] font-semibold text-foreground">{item.title}</span>
           <span className="text-[12px] leading-snug text-muted-foreground">{item.description}</span>
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="次の項目へ"
-          disabled={isLast}
-          onClick={() => setIndex(i => Math.min(GUIDE_ITEMS.length - 1, i + 1))}
-        >
-          <NavArrowRight width={18} height={18} />
-        </Button>
+        <div className="mt-2.5 flex justify-center gap-1.5">
+          {GUIDE_ITEMS.map((_, i) => (
+            <span
+              key={i}
+              className={`h-1.5 w-1.5 rounded-full transition-all ${
+                i === index ? 'bg-[var(--accent)]' : 'bg-[var(--glass-border)]'
+              }`}
+            />
+          ))}
+        </div>
       </div>
-      <div className="flex gap-1.5">
-        {GUIDE_ITEMS.map((_, i) => (
-          <span
-            key={i}
-            className={`h-1.5 w-1.5 rounded-full transition-all ${
-              i === index ? 'bg-[var(--accent)]' : 'bg-[var(--glass-border)]'
-            }`}
-          />
-        ))}
-      </div>
+
+      {/* 下矢印（パネルの外） */}
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="次の項目へ"
+        disabled={isLast}
+        onClick={() => setIndex(i => Math.min(GUIDE_ITEMS.length - 1, i + 1))}
+      >
+        <NavArrowDown width={18} height={18} />
+      </Button>
     </div>
   )
 }

--- a/src/renderer/src/components/UsageGuide/UsageGuide.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuide.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react'
+import { NavArrowLeft, NavArrowRight } from 'iconoir-react'
+import { Button } from '@/components/ui/button'
+
 interface GuideItem {
   title: string
   description: string
@@ -14,14 +18,47 @@ const GUIDE_ITEMS: GuideItem[] = [
 ]
 
 export function UsageGuide() {
+  const [index, setIndex] = useState(0)
+  const item = GUIDE_ITEMS[index]
+  const isFirst = index === 0
+  const isLast = index === GUIDE_ITEMS.length - 1
+
   return (
-    <ul className="m-0 flex list-none flex-col gap-3 p-0">
-      {GUIDE_ITEMS.map(item => (
-        <li key={item.title} className="flex flex-col gap-0.5">
-          <span className="text-[13px] font-semibold text-foreground">{item.title}</span>
+    <div className="flex flex-col items-center gap-2.5">
+      <div className="flex w-full items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="前の項目へ"
+          disabled={isFirst}
+          onClick={() => setIndex(i => Math.max(0, i - 1))}
+        >
+          <NavArrowLeft width={18} height={18} />
+        </Button>
+        <div className="flex min-h-[64px] flex-1 flex-col items-center justify-center gap-1 px-1 text-center">
+          <span className="text-[14px] font-semibold text-foreground">{item.title}</span>
           <span className="text-[12px] leading-snug text-muted-foreground">{item.description}</span>
-        </li>
-      ))}
-    </ul>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="次の項目へ"
+          disabled={isLast}
+          onClick={() => setIndex(i => Math.min(GUIDE_ITEMS.length - 1, i + 1))}
+        >
+          <NavArrowRight width={18} height={18} />
+        </Button>
+      </div>
+      <div className="flex gap-1.5">
+        {GUIDE_ITEMS.map((_, i) => (
+          <span
+            key={i}
+            className={`h-1.5 w-1.5 rounded-full transition-all ${
+              i === index ? 'bg-[var(--accent)]' : 'bg-[var(--glass-border)]'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
   )
 }

--- a/src/renderer/src/components/UsageGuide/UsageGuide.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuide.tsx
@@ -1,0 +1,27 @@
+interface GuideItem {
+  title: string
+  description: string
+}
+
+const GUIDE_ITEMS: GuideItem[] = [
+  { title: '作業を始める', description: '作業名を入力して「注ぐ」を押すと計測を開始します。' },
+  { title: '記録を編集', description: '一覧の項目をダブルクリックすると編集できます。' },
+  { title: '追加・削除', description: '一覧を右クリックしてメニューから追加・削除します。' },
+  { title: '並び替え', description: '項目をドラッグすると順序を入れ替えられます。' },
+  { title: '休憩・終了', description: 'カード下部のボタンで休憩や業務終了を記録します。' },
+  { title: '勤怠を調整', description: '勤怠タブで出勤・退勤・休憩の時刻をダブルクリックして編集します。' },
+  { title: '共有', description: '勤怠タブの「コピー」「送る」でチームに共有します。' },
+]
+
+export function UsageGuide() {
+  return (
+    <ul className="m-0 flex list-none flex-col gap-3 p-0">
+      {GUIDE_ITEMS.map(item => (
+        <li key={item.title} className="flex flex-col gap-0.5">
+          <span className="text-[13px] font-semibold text-foreground">{item.title}</span>
+          <span className="text-[12px] leading-snug text-muted-foreground">{item.description}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { UsageGuideButton } from './UsageGuideButton'
+
+describe('UsageGuideButton', () => {
+  it('初期状態ではガイドダイアログは閉じている', () => {
+    render(<UsageGuideButton />)
+    expect(screen.queryByText('使い方')).not.toBeInTheDocument()
+  })
+
+  it('「使い方」ボタンでガイドが開く', async () => {
+    const user = userEvent.setup()
+    render(<UsageGuideButton />)
+    await user.click(screen.getByRole('button', { name: '使い方' }))
+    expect(await screen.findByText('使い方')).toBeInTheDocument()
+    expect(screen.getByText('記録を編集')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
@@ -14,6 +14,6 @@ describe('UsageGuideButton', () => {
     render(<UsageGuideButton />)
     await user.click(screen.getByRole('button', { name: '使い方' }))
     expect(await screen.findByText('使い方')).toBeInTheDocument()
-    expect(screen.getByText('記録を編集')).toBeInTheDocument()
+    expect(screen.getByText('作業を始める')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
@@ -20,7 +20,7 @@ export function UsageGuideButton() {
       <Dialog open={open} onOpenChange={setOpen}>
         {/* パネル（内側カード）を見せ、上下矢印はその外に置くため枠を透明化する */}
         <DialogContent
-          className="max-w-[240px] gap-0 border-0 bg-transparent p-0 shadow-none [&>button]:hidden"
+          className="max-w-[280px] gap-0 border-0 bg-transparent p-0 shadow-none [&>button]:hidden"
           aria-describedby={undefined}
         >
           <DialogTitle className="sr-only">使い方</DialogTitle>

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { HelpCircle } from 'iconoir-react'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { UsageGuide } from './UsageGuide'
 
 export function UsageGuideButton() {
@@ -18,10 +18,12 @@ export function UsageGuideButton() {
         <HelpCircle width={16} height={16} />
       </Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-[300px]" aria-describedby={undefined}>
-          <DialogHeader>
-            <DialogTitle>使い方</DialogTitle>
-          </DialogHeader>
+        {/* パネル（内側カード）を見せ、上下矢印はその外に置くため枠を透明化する */}
+        <DialogContent
+          className="max-w-[240px] gap-0 border-0 bg-transparent p-0 shadow-none [&>button]:hidden"
+          aria-describedby={undefined}
+        >
+          <DialogTitle className="sr-only">使い方</DialogTitle>
           <UsageGuide />
         </DialogContent>
       </Dialog>

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { HelpCircle } from 'iconoir-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { UsageGuide } from './UsageGuide'
+
+export function UsageGuideButton() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="使い方"
+        className="[-webkit-app-region:no-drag]"
+        onClick={() => setOpen(true)}
+      >
+        <HelpCircle width={16} height={16} />
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-[300px]" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>使い方</DialogTitle>
+          </DialogHeader>
+          <UsageGuide />
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}


### PR DESCRIPTION
## 対応（#67 Part B: 使用ガイド）
- 操作一覧の共有コンポーネント `UsageGuide` を追加
- ヘッダーに「?」ボタン（使い方）を追加し Dialog で表示
- 初回セットアップに「操作の基本」ステップ（Step5）を追加

Part A（操作ヒント）と合わせて #67 を完了。

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)