### PR TITLE
feat: 案内型オンボーディングツアーを追加 (#67)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "juice",
       "version": "1.0.0",
       "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "juice",
       "version": "1.0.0",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.8",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
-    "@floating-ui/react-dom": "^2.1.8",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.9",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "esbuild": "^0.28.1"
   },
   "dependencies": {
+    "@floating-ui/react-dom": "^2.1.8",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.9",

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -54,3 +54,15 @@ describe('TimerPage — 業務開始オーバーレイ', () => {
     )
   })
 })
+
+describe('TimerPage — ツアーデモ', () => {
+  it('tourDemo 時はダミーセッションを表示し業務開始ボタンを出さない', () => {
+    render(
+      <DailyDataProvider>
+        <TimerPage sessions={stubSessions()} tourDemo />
+      </DailyDataProvider>
+    )
+    expect(screen.getByText('資料作成')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '業務開始' })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import { WorkStartOverlay } from './components/Popover/WorkStartOverlay'
 import { UsageGuideButton } from './components/UsageGuide/UsageGuideButton'
 import { useTour } from './tour/useTour'
 import { TourOverlay } from './tour/TourOverlay'
+import { TourDemoTimer } from './tour/TourDemoTimer'
 import { useWorkday } from './hooks/useWorkday'
 import { useSuggestions } from './hooks/useSuggestions'
 import { useBreak } from './hooks/useBreak'
@@ -60,6 +61,12 @@ function PopoverView() {
   const menuRef = useRef<HTMLDivElement>(null)
   const { status, signIn, signOut } = useAuthStatus()
   const tour = useTour()
+
+  // ツアーのシーンを適用（指定タブへ切替）。デモ表示は tourDemo で制御する。
+  useEffect(() => {
+    const tab = tour.step?.scene?.tab
+    if (tab) setCurrentPage(tab)
+  }, [tour.index, tour.step])
 
   const sessions = useSessions()
 
@@ -142,7 +149,7 @@ function PopoverView() {
       {/* ページコンテンツ */}
       <main className={styles.content}>
         <div className={styles.page} style={{ display: currentPage === 'timer' ? 'flex' : 'none' }}>
-          <TimerPage sessions={sessions} />
+          <TimerPage sessions={sessions} tourDemo={tour.isActive && tour.step?.scene?.demo === true} />
         </div>
         {currentPage === 'calendar' && <CalendarPage todaySessions={sessions.todaySessions} today={sessions.today} />}
         {currentPage === 'attendance' && (
@@ -186,7 +193,7 @@ function PopoverView() {
   )
 }
 
-export function TimerPage({ sessions }: { sessions: SessionsState }) {
+export function TimerPage({ sessions, tourDemo = false }: { sessions: SessionsState; tourDemo?: boolean }) {
   const ts = useTimerSession(sessions)
   const workday = useWorkday(ts.today)
   const breakState = useBreak(ts, workday)
@@ -208,7 +215,12 @@ export function TimerPage({ sessions }: { sessions: SessionsState }) {
         </div>
       )}
 
-      {ts.isRunning ? (
+      {tourDemo ? (
+        /* ツアーデモ: 副作用なしの待機ビュー */
+        <div className={styles.idleContent}>
+          <TourDemoTimer />
+        </div>
+      ) : ts.isRunning ? (
         /* 稼働時: ActiveTimerのみ */
         <div className={styles.runningLayout}>
           <ActiveTimer

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,8 @@ import { SetupView } from './components/Setup/SetupView'
 import { CalendarPage } from './components/Calendar/CalendarPage'
 import { WorkStartOverlay } from './components/Popover/WorkStartOverlay'
 import { UsageGuideButton } from './components/UsageGuide/UsageGuideButton'
+import { useTour } from './tour/useTour'
+import { TourOverlay } from './tour/TourOverlay'
 import { useWorkday } from './hooks/useWorkday'
 import { useSuggestions } from './hooks/useSuggestions'
 import { useBreak } from './hooks/useBreak'
@@ -57,6 +59,7 @@ function PopoverView() {
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const { status, signIn, signOut } = useAuthStatus()
+  const tour = useTour()
 
   const sessions = useSessions()
 
@@ -79,7 +82,7 @@ function PopoverView() {
         </Button>
         <span className={styles.logo}>juice</span>
         <div className="flex items-center gap-0.5">
-          <UsageGuideButton />
+          <UsageGuideButton onStartTour={tour.start} />
           <div className={styles.menuWrapper} ref={menuRef}>
           <Button variant="ghost" size="icon" aria-label="アカウント" className="[-webkit-app-region:no-drag]" onClick={() => setMenuOpen(p => !p)}>
             <AccountAvatar avatarUrl={status.avatarUrl} name={status.name} />
@@ -152,6 +155,7 @@ function PopoverView() {
       {/* ボトムナビゲーション */}
       <nav className="flex shrink-0 items-stretch gap-1 border-t border-border bg-card p-1">
         <button
+          data-tour="tab-timer"
           onClick={() => setCurrentPage('timer')}
           className={`flex flex-1 flex-col items-center gap-0.5 rounded-md py-1.5 text-[11px] transition-colors ${currentPage === 'timer' ? 'bg-[var(--accent-light)] text-[var(--accent)]' : 'text-muted-foreground hover:bg-[var(--bg-hover)]'}`}
         >
@@ -159,6 +163,7 @@ function PopoverView() {
           タイマー
         </button>
         <button
+          data-tour="tab-calendar"
           onClick={() => setCurrentPage('calendar')}
           className={`flex flex-1 flex-col items-center gap-0.5 rounded-md py-1.5 text-[11px] transition-colors ${currentPage === 'calendar' ? 'bg-[var(--accent-light)] text-[var(--accent)]' : 'text-muted-foreground hover:bg-[var(--bg-hover)]'}`}
         >
@@ -166,6 +171,7 @@ function PopoverView() {
           カレンダー
         </button>
         <button
+          data-tour="tab-attendance"
           onClick={() => setCurrentPage('attendance')}
           className={`flex flex-1 flex-col items-center gap-0.5 rounded-md py-1.5 text-[11px] transition-colors ${currentPage === 'attendance' ? 'bg-[var(--accent-light)] text-[var(--accent)]' : 'text-muted-foreground hover:bg-[var(--bg-hover)]'}`}
         >
@@ -173,6 +179,8 @@ function PopoverView() {
           勤怠
         </button>
       </nav>
+
+      <TourOverlay tour={tour} />
     </div>
     </DailyDataProvider>
   )

--- a/src/renderer/src/components/Popover/AttendanceReport.test.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.test.tsx
@@ -60,4 +60,11 @@ describe('AttendanceReport — 表示行', () => {
     fireEvent.dblClick(breakValue)
     expect(await screen.findByText('休憩時間')).toBeInTheDocument()
   })
+
+  it('コピー・送るボタンに data-tour が付く', async () => {
+    const { container } = render(<AttendanceReport sessions={[makeSession()]} today="2026-06-12" />, { wrapper })
+    await screen.findByText('09:00')
+    expect(container.querySelector('[data-tour="att-copy"]')).not.toBeNull()
+    expect(container.querySelector('[data-tour="att-send"]')).not.toBeNull()
+  })
 })

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -129,6 +129,7 @@ export function AttendanceReport({ sessions, today }: Props) {
       <div className="flex shrink-0 gap-2">
         <Button
           className={`flex-1 ${copied ? 'bg-[linear-gradient(135deg,#26de81,#20c870)] text-white' : ''}`}
+          data-tour="att-copy"
           onClick={copy}
         >
           {copied ? <><Check width={14} height={14} /> コピーしました</> : <><Copy width={14} height={14} /> コピー</>}
@@ -147,6 +148,7 @@ export function AttendanceReport({ sessions, today }: Props) {
                         : 'bg-[linear-gradient(135deg,#3b82f6,#2563eb)] shadow-[0_4px_12px_rgba(59,130,246,0.3)] hover:shadow-[0_6px_16px_rgba(59,130,246,0.4)]'
                 }`}
                 onClick={send}
+                data-tour="att-send"
                 disabled={sending || !canSend || overageMinutes !== null}
               >
                 {overageMinutes !== null

--- a/src/renderer/src/components/Popover/SessionList.test.tsx
+++ b/src/renderer/src/components/Popover/SessionList.test.tsx
@@ -480,4 +480,10 @@ describe('SessionList — 操作ヒント', () => {
       screen.getByText('作業名を入力して「注ぐ」で開始できます')
     ).toBeInTheDocument()
   })
+
+  it('勤務時間カードに data-tour が付く', () => {
+    renderWithProvider(<SessionList sessions={sessions} workStart="09:00" />)
+    const total = screen.getByText(/今日注いだ時間/)
+    expect(total.closest('[data-tour="demo-worktime"]')).not.toBeNull()
+  })
 })

--- a/src/renderer/src/components/Popover/SessionList.tsx
+++ b/src/renderer/src/components/Popover/SessionList.tsx
@@ -247,7 +247,7 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
 
       <PageIndicator totalPages={totalPages} currentPage={page} onChangePage={changePage} />
 
-      <Card className="mb-2 mt-2">
+      <Card className="mb-2 mt-2" data-tour="demo-worktime">
         <CardContent className="flex items-center justify-between px-3 py-2 text-[11px] text-muted-foreground">
           <div className="flex items-center gap-1.5">
             {workStart && !workEnd && (

--- a/src/renderer/src/components/Popover/TimerForm.test.tsx
+++ b/src/renderer/src/components/Popover/TimerForm.test.tsx
@@ -50,4 +50,9 @@ describe('TimerForm', () => {
     await userEvent.click(screen.getByRole('button', { name: '注ぐ' }))
     expect(onStart).toHaveBeenCalledWith('資料作成2', undefined, undefined)
   })
+
+  it('「注ぐ」ボタンに data-tour が付く', () => {
+    render(<TimerForm onStart={vi.fn()} />)
+    expect(screen.getByRole('button', { name: '注ぐ' })).toHaveAttribute('data-tour', 'demo-pour')
+  })
 })

--- a/src/renderer/src/components/Popover/TimerForm.tsx
+++ b/src/renderer/src/components/Popover/TimerForm.tsx
@@ -46,7 +46,7 @@ export function TimerForm({ onStart, nameSuggestions = [] }: Props) {
               className="min-w-0 px-2.5 text-[13px]"
               autoFocus
             />
-            <Button type="submit" disabled={!name.trim()}>
+            <Button type="submit" data-tour="demo-pour" disabled={!name.trim()}>
               注ぐ
             </Button>
           </div>

--- a/src/renderer/src/components/Popover/WorkStartOverlay.test.tsx
+++ b/src/renderer/src/components/Popover/WorkStartOverlay.test.tsx
@@ -31,4 +31,9 @@ describe('WorkStartOverlay', () => {
     expect(onStart).toHaveBeenCalledWith('09:30', true)
     expect(onTeleworkStart).toHaveBeenCalledTimes(1)
   })
+
+  it('業務開始ボタンに data-tour が付く', () => {
+    render(<WorkStartOverlay date="2026-06-27" onStart={vi.fn()} onTeleworkStart={vi.fn()} />)
+    expect(screen.getByRole('button', { name: '業務開始' })).toHaveAttribute('data-tour', 'work-start')
+  })
 })

--- a/src/renderer/src/components/Popover/WorkStartOverlay.tsx
+++ b/src/renderer/src/components/Popover/WorkStartOverlay.tsx
@@ -43,7 +43,7 @@ export function WorkStartOverlay({ date, onStart, onTeleworkStart }: Props) {
         <Switch checked={telework} onCheckedChange={setTelework} aria-label="在宅" />
         在宅
       </label>
-      <Button className="px-8" onClick={handleStart}>業務開始</Button>
+      <Button className="px-8" data-tour="work-start" onClick={handleStart}>業務開始</Button>
     </div>
   )
 }

--- a/src/renderer/src/components/Setup/SetupView.test.tsx
+++ b/src/renderer/src/components/Setup/SetupView.test.tsx
@@ -84,19 +84,9 @@ describe('SetupView step3（連携設定）', () => {
     expect(api.setWhiteboardSettings).toHaveBeenCalledWith(true)
   })
 
-  it('「次へ」でテーマステップに進める', async () => {
+  it('「次へ」でテーマ（完了）ステップに進める', async () => {
     await goToStep3()
     await userEvent.click(screen.getByRole('button', { name: '次へ' }))
-    expect(await screen.findByText('お好みのテーマを選んでください')).toBeInTheDocument()
-  })
-
-  it('テーマの「次へ」で操作の基本（完了）ステップに進める', async () => {
-    await goToStep3()
-    await userEvent.click(screen.getByRole('button', { name: '次へ' }))
-    await screen.findByText('お好みのテーマを選んでください')
-    await userEvent.click(screen.getByRole('button', { name: '次へ' }))
-    expect(await screen.findByText('操作の基本')).toBeInTheDocument()
-    expect(screen.getByText('作業を始める')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '完了' })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: '完了' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/Setup/SetupView.tsx
+++ b/src/renderer/src/components/Setup/SetupView.tsx
@@ -7,9 +7,8 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import { UsageGuide } from '../UsageGuide/UsageGuide'
 
-const TOTAL_STEPS = 5
+const TOTAL_STEPS = 4
 
 export function SetupView() {
   const {
@@ -123,14 +122,6 @@ export function SetupView() {
         </div>
       )}
 
-      {/* Step 5: 操作の基本 */}
-      {step === 5 && (
-        <div className="flex flex-1 flex-col animate-fade-in" key="step5">
-          <h2 className="mb-3 text-[15px] font-semibold">操作の基本</h2>
-          <UsageGuide />
-        </div>
-      )}
-
       {/* フッター: インジケーター + ボタン */}
       <div className="mt-auto flex shrink-0 flex-col gap-3">
         <div className="flex justify-center gap-1.5">
@@ -164,9 +155,6 @@ export function SetupView() {
             <Button className="flex-1" onClick={() => setStep(4)}>次へ</Button>
           )}
           {step === 4 && (
-            <Button className="flex-1" onClick={() => setStep(5)}>次へ</Button>
-          )}
-          {step === 5 && (
             <Button className="flex-1" onClick={complete}>完了</Button>
           )}
         </div>

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { UsageGuideButton } from './UsageGuideButton'
 
@@ -24,5 +24,14 @@ describe('UsageGuideButton', () => {
     await user.click(screen.getByRole('button', { name: '使い方' }))
     await user.click(await screen.findByRole('button', { name: 'ツアーを見る' }))
     expect(onStartTour).toHaveBeenCalled()
+  })
+
+  it('「戻る」でガイドを閉じる', async () => {
+    const user = userEvent.setup()
+    render(<UsageGuideButton />)
+    await user.click(screen.getByRole('button', { name: '使い方' }))
+    expect(await screen.findByText('使い方')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: '戻る' }))
+    await waitFor(() => expect(screen.queryByText('使い方')).not.toBeInTheDocument())
   })
 })

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { UsageGuideButton } from './UsageGuideButton'
@@ -15,5 +15,14 @@ describe('UsageGuideButton', () => {
     await user.click(screen.getByRole('button', { name: '使い方' }))
     expect(await screen.findByText('使い方')).toBeInTheDocument()
     expect(screen.getByText('作業を始める')).toBeInTheDocument()
+  })
+
+  it('onStartTour 指定時、「ツアーを見る」で閉じてコールバックを呼ぶ', async () => {
+    const onStartTour = vi.fn()
+    const user = userEvent.setup()
+    render(<UsageGuideButton onStartTour={onStartTour} />)
+    await user.click(screen.getByRole('button', { name: '使い方' }))
+    await user.click(await screen.findByRole('button', { name: 'ツアーを見る' }))
+    expect(onStartTour).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { HelpCircle } from 'iconoir-react'
+import { HelpCircle, NavArrowLeft } from 'iconoir-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { UsageGuide } from './UsageGuide'
@@ -19,19 +19,30 @@ export function UsageGuideButton({ onStartTour }: { onStartTour?: () => void }) 
         <HelpCircle width={16} height={16} />
       </Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        {/* パネル（内側カード）を見せ、上下矢印はその外に置くため枠を透明化する */}
+        {/* 不透明フルスクリーンの1画面として切り替える（背景を透けさせない） */}
         <DialogContent
-          className="max-w-[280px] gap-0 border-0 bg-transparent p-0 shadow-none [&>button]:hidden"
+          className="inset-0 flex h-full w-full max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 bg-background p-0 [&>button]:hidden"
           aria-describedby={undefined}
         >
-          <DialogTitle className="sr-only">使い方</DialogTitle>
-          <UsageGuide />
+          {/* ヘッダー: 戻る矢印（カレンダー詳細と同じ位置・操作感） */}
+          <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-2">
+            <Button variant="ghost" size="icon" aria-label="戻る" onClick={() => setOpen(false)}>
+              <NavArrowLeft width={18} height={18} />
+            </Button>
+            <DialogTitle className="text-[14px] font-semibold">使い方</DialogTitle>
+          </div>
+
+          {/* カルーセル（1項目ずつ） */}
+          <div className="flex flex-1 flex-col items-center justify-center px-6">
+            <UsageGuide />
+          </div>
+
+          {/* 下部: ツアー再生 */}
           {onStartTour && (
-            <div className="flex justify-center">
+            <div className="shrink-0 border-t border-border p-3">
               <Button
                 variant="outline"
-                size="sm"
-                className="h-7 text-[12px]"
+                className="w-full"
                 onClick={() => {
                   setOpen(false)
                   onStartTour()

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { UsageGuide } from './UsageGuide'
 
-export function UsageGuideButton() {
+export function UsageGuideButton({ onStartTour }: { onStartTour?: () => void }) {
   const [open, setOpen] = useState(false)
   return (
     <>
@@ -12,6 +12,7 @@ export function UsageGuideButton() {
         variant="ghost"
         size="icon"
         aria-label="使い方"
+        data-tour="help"
         className="[-webkit-app-region:no-drag]"
         onClick={() => setOpen(true)}
       >
@@ -25,6 +26,21 @@ export function UsageGuideButton() {
         >
           <DialogTitle className="sr-only">使い方</DialogTitle>
           <UsageGuide />
+          {onStartTour && (
+            <div className="flex justify-center">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                onClick={() => {
+                  setOpen(false)
+                  onStartTour()
+                }}
+              >
+                ツアーを見る
+              </Button>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </>

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
@@ -21,7 +21,7 @@ export function UsageGuideButton({ onStartTour }: { onStartTour?: () => void }) 
       <Dialog open={open} onOpenChange={setOpen}>
         {/* 不透明フルスクリーンの1画面として切り替える（背景を透けさせない） */}
         <DialogContent
-          className="inset-0 flex h-full w-full max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 bg-background p-0 [&>button]:hidden"
+          className="inset-0 z-[200] flex h-full w-full max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 bg-background p-0 [&>button]:hidden"
           aria-describedby={undefined}
         >
           {/* ヘッダー: 戻る矢印（カレンダー詳細と同じ位置・操作感） */}

--- a/src/renderer/src/daily/DailyDataContext.tsx
+++ b/src/renderer/src/daily/DailyDataContext.tsx
@@ -11,7 +11,7 @@ interface DailyData {
   setDay: (date: string, patch: DayRecord) => Promise<void>
 }
 
-const DailyDataContext = createContext<DailyData | null>(null)
+export const DailyDataContext = createContext<DailyData | null>(null)
 
 export function useDailyData(): DailyData {
   const ctx = useContext(DailyDataContext)

--- a/src/renderer/src/tour/TourDemoTimer.test.tsx
+++ b/src/renderer/src/tour/TourDemoTimer.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TourDemoTimer } from './TourDemoTimer'
+
+describe('TourDemoTimer', () => {
+  it('ダミーセッションと注ぐ・勤務時間を表示する', () => {
+    render(<TourDemoTimer />)
+    expect(screen.getByText('資料作成')).toBeInTheDocument()
+    expect(screen.getByText('ミーティング')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '注ぐ' })).toBeInTheDocument()
+    expect(screen.getByText(/今日注いだ時間/)).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/tour/TourDemoTimer.tsx
+++ b/src/renderer/src/tour/TourDemoTimer.tsx
@@ -1,0 +1,64 @@
+import { TimerForm } from '../components/Popover/TimerForm'
+import { SessionList } from '../components/Popover/SessionList'
+import { DailyDataContext } from '../daily/DailyDataContext'
+import type { Session } from '../types/session'
+
+// 並び替え永続化（IPC）を無効化する no-op の DailyData。実データに到達しない。
+const NOOP_DAILY = {
+  getDay: () => null,
+  ensureMonth: () => {},
+  setDay: async () => {},
+}
+
+const DEMO_SESSIONS: Session[] = [
+  {
+    id: 'demo-1',
+    taskId: 'demo-1',
+    name: '資料作成',
+    projectCode: 'PROJ-001',
+    workCategory: '設計',
+    times: [{ startTime: '2026-06-28T09:00:00', endTime: '2026-06-28T10:30:00' }],
+    date: '2026-06-28',
+    color: '#FF9500',
+    totalTime: 90,
+  },
+  {
+    id: 'demo-2',
+    taskId: 'demo-2',
+    name: 'ミーティング',
+    projectCode: 'PROJ-002',
+    workCategory: '会議',
+    times: [{ startTime: '2026-06-28T11:00:00', endTime: '2026-06-28T11:30:00' }],
+    date: '2026-06-28',
+    color: '#34C759',
+    totalTime: 30,
+  },
+]
+
+const noop = (): void => {}
+const noopAsync = async (): Promise<void> => {}
+
+// ツアー用の待機ビューデモ。実部品をダミーデータ＋全 no-op で描画し、副作用を出さない。
+export function TourDemoTimer() {
+  return (
+    <DailyDataContext.Provider value={NOOP_DAILY}>
+      <TimerForm onStart={noop} />
+      <SessionList
+        sessions={DEMO_SESSIONS}
+        today="2026-06-28"
+        isRunning={false}
+        onUpdate={noopAsync}
+        onStartMore={noop}
+        onDelete={noop}
+        onAdd={noop}
+        workStart="09:00"
+        workEnd={null}
+        onWorkEnd={noop}
+        breakStart={null}
+        breakEnd={null}
+        onBreakStart={noop}
+        onBreakEnd={noop}
+      />
+    </DailyDataContext.Provider>
+  )
+}

--- a/src/renderer/src/tour/TourOverlay.test.tsx
+++ b/src/renderer/src/tour/TourOverlay.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TourOverlay } from './TourOverlay'
+import type { TourState } from './useTour'
+
+function makeTour(overrides: Partial<TourState> = {}): TourState {
+  return {
+    isActive: true,
+    index: 0,
+    total: 7,
+    step: { target: null, title: 'ようこそ', body: '案内します' },
+    isLast: false,
+    start: vi.fn(),
+    next: vi.fn(),
+    prev: vi.fn(),
+    skip: vi.fn(),
+    finish: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('TourOverlay', () => {
+  it('非アクティブなら何も描画しない', () => {
+    const { container } = render(<TourOverlay tour={makeTour({ isActive: false })} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('現在ステップの文言と進捗を表示する', () => {
+    render(<TourOverlay tour={makeTour()} />)
+    expect(screen.getByText('ようこそ')).toBeInTheDocument()
+    expect(screen.getByText('案内します')).toBeInTheDocument()
+    expect(screen.getByText('1 / 7')).toBeInTheDocument()
+  })
+
+  it('「次へ」で next、「スキップ」で skip を呼ぶ', async () => {
+    const tour = makeTour()
+    const user = userEvent.setup()
+    render(<TourOverlay tour={tour} />)
+    await user.click(screen.getByRole('button', { name: '次へ' }))
+    expect(tour.next).toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: 'スキップ' }))
+    expect(tour.skip).toHaveBeenCalled()
+  })
+
+  it('先頭では「戻る」を出さない', () => {
+    render(<TourOverlay tour={makeTour({ index: 0 })} />)
+    expect(screen.queryByRole('button', { name: '戻る' })).not.toBeInTheDocument()
+  })
+
+  it('最終ステップでは「はじめる」を出し finish を呼ぶ', async () => {
+    const tour = makeTour({ index: 6, isLast: true })
+    const user = userEvent.setup()
+    render(<TourOverlay tour={tour} />)
+    await user.click(screen.getByRole('button', { name: 'はじめる' }))
+    expect(tour.finish).toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: '次へ' })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/tour/TourOverlay.tsx
+++ b/src/renderer/src/tour/TourOverlay.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react-dom'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import type { TourState } from './useTour'
+
+export function TourOverlay({ tour }: { tour: TourState }) {
+  const { refs, floatingStyles } = useFloating({
+    placement: tour.step?.placement ?? 'bottom',
+    middleware: [offset(10), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  })
+  const [rect, setRect] = useState<DOMRect | null>(null)
+
+  useEffect(() => {
+    if (!tour.isActive) return
+    const sel = tour.step?.target
+    const el = sel ? document.querySelector<HTMLElement>(sel) : null
+    refs.setReference(el)
+    const update = (): void => setRect(el ? el.getBoundingClientRect() : null)
+    update()
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [tour.isActive, tour.index, tour.step, refs])
+
+  if (!tour.isActive || !tour.step) return null
+
+  return (
+    // 全面を覆ってアプリ操作をブロックする（透明でもクリックを受ける）
+    <div className="fixed inset-0 z-[2000]">
+      {rect ? (
+        <div
+          className="pointer-events-none absolute rounded-md"
+          style={{
+            top: rect.top - 4,
+            left: rect.left - 4,
+            width: rect.width + 8,
+            height: rect.height + 8,
+            boxShadow: '0 0 0 9999px rgba(0,0,0,0.5)',
+          }}
+        />
+      ) : (
+        <div className="absolute inset-0 bg-black/50" />
+      )}
+
+      <Card
+        ref={rect ? refs.setFloating : undefined}
+        style={rect ? floatingStyles : undefined}
+        className={`absolute z-[2001] w-[240px] p-3 ${
+          rect ? '' : 'left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
+        }`}
+      >
+        <p className="m-0 text-[13px] font-semibold text-foreground">{tour.step.title}</p>
+        <p className="m-0 mt-1 text-[12px] leading-snug text-muted-foreground">{tour.step.body}</p>
+        <div className="mt-3 flex items-center justify-between">
+          <span className="text-[11px] text-muted-foreground">
+            {tour.index + 1} / {tour.total}
+          </span>
+          <div className="flex gap-1.5">
+            <Button variant="ghost" size="sm" className="h-7 text-[12px]" onClick={tour.skip}>
+              スキップ
+            </Button>
+            {tour.index > 0 && (
+              <Button variant="outline" size="sm" className="h-7 text-[12px]" onClick={tour.prev}>
+                戻る
+              </Button>
+            )}
+            {tour.isLast ? (
+              <Button size="sm" className="h-7 text-[12px]" onClick={tour.finish}>
+                はじめる
+              </Button>
+            ) : (
+              <Button size="sm" className="h-7 text-[12px]" onClick={tour.next}>
+                次へ
+              </Button>
+            )}
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/src/renderer/src/tour/TourOverlay.tsx
+++ b/src/renderer/src/tour/TourOverlay.tsx
@@ -38,11 +38,24 @@ export function TourOverlay({ tour }: { tour: TourState }) {
       return
     }
     const sel = tour.step?.target
-    const el = sel ? document.querySelector<HTMLElement>(sel) : null
-    const update = (): void => setRect(el ? el.getBoundingClientRect() : null)
+    let raf = 0
+    let tries = 0
+    // タブ切替直後など対象がまだ DOM に無い場合は数フレーム待って再取得する
+    const update = (): void => {
+      const el = sel ? document.querySelector<HTMLElement>(sel) : null
+      if (sel && !el && tries < 10) {
+        tries++
+        raf = requestAnimationFrame(update)
+        return
+      }
+      setRect(el ? el.getBoundingClientRect() : null)
+    }
     update()
     window.addEventListener('resize', update)
-    return () => window.removeEventListener('resize', update)
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', update)
+    }
   }, [tour.isActive, tour.index, tour.step])
 
   if (!tour.isActive || !tour.step) return null

--- a/src/renderer/src/tour/TourOverlay.tsx
+++ b/src/renderer/src/tour/TourOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from 'react'
+import { useLayoutEffect, useState, type CSSProperties } from 'react'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import type { TourStep } from './tourSteps'
@@ -38,20 +38,21 @@ function sameRect(a: DOMRect | null, b: DOMRect | null): boolean {
 export function TourOverlay({ tour }: { tour: TourState }) {
   const [rect, setRect] = useState<DOMRect | null>(null)
 
-  useEffect(() => {
-    if (!tour.isActive) {
+  useLayoutEffect(() => {
+    const sel = tour.isActive ? tour.step?.target : null
+    // ターゲットが無いステップ（ようこそ／準備完了）だけ中央表示にする
+    if (!sel) {
       setRect(null)
       return
     }
-    const sel = tour.step?.target
     let raf = 0
-    // 毎フレーム測り直す。タブ切替直後・display:none（0サイズ）・レイアウト変化でも
-    // 追従し、対象が無ければ中央表示にフォールバックする（吹き出しが消えない）。
+    // 描画前に同期測定し、以降も毎フレーム追従する。対象が一瞬見つからない/サイズ0の
+    // 間は直前の位置を保持し、中央へジャンプ（＝消えたように見える）させない。
     const measure = (): void => {
-      const el = sel ? document.querySelector<HTMLElement>(sel) : null
+      const el = document.querySelector<HTMLElement>(sel)
       const r = el ? el.getBoundingClientRect() : null
-      const next = r && r.width > 0 && r.height > 0 ? r : null
-      setRect(prev => (sameRect(prev, next) ? prev : next))
+      const valid = r && r.width > 0 && r.height > 0 ? r : null
+      if (valid) setRect(prev => (sameRect(prev, valid) ? prev : valid))
       raf = requestAnimationFrame(measure)
     }
     measure()

--- a/src/renderer/src/tour/TourOverlay.tsx
+++ b/src/renderer/src/tour/TourOverlay.tsx
@@ -46,14 +46,14 @@ export function TourOverlay({ tour }: { tour: TourState }) {
       <Card
         ref={rect ? refs.setFloating : undefined}
         style={rect ? floatingStyles : undefined}
-        className={`absolute z-[2001] w-[240px] p-3 ${
-          rect ? '' : 'left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
+        className={`absolute z-[2001] p-3 ${
+          rect ? 'w-[240px]' : 'w-[280px] left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
         }`}
       >
         <p className="m-0 text-[13px] font-semibold text-foreground">{tour.step.title}</p>
         <p className="m-0 mt-1 text-[12px] leading-snug text-muted-foreground">{tour.step.body}</p>
         <div className="mt-3 flex items-center justify-between">
-          <span className="text-[11px] text-muted-foreground">
+          <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground">
             {tour.index + 1} / {tour.total}
           </span>
           <div className="flex gap-1.5">

--- a/src/renderer/src/tour/TourOverlay.tsx
+++ b/src/renderer/src/tour/TourOverlay.tsx
@@ -29,6 +29,12 @@ function computeBubbleStyle(rect: DOMRect, placement: NonNullable<TourStep['plac
   return { left, top: rect.bottom + GAP, width: BUBBLE_W }
 }
 
+function sameRect(a: DOMRect | null, b: DOMRect | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
+}
+
 export function TourOverlay({ tour }: { tour: TourState }) {
   const [rect, setRect] = useState<DOMRect | null>(null)
 
@@ -39,23 +45,17 @@ export function TourOverlay({ tour }: { tour: TourState }) {
     }
     const sel = tour.step?.target
     let raf = 0
-    let tries = 0
-    // タブ切替直後など対象がまだ DOM に無い場合は数フレーム待って再取得する
-    const update = (): void => {
+    // 毎フレーム測り直す。タブ切替直後・display:none（0サイズ）・レイアウト変化でも
+    // 追従し、対象が無ければ中央表示にフォールバックする（吹き出しが消えない）。
+    const measure = (): void => {
       const el = sel ? document.querySelector<HTMLElement>(sel) : null
-      if (sel && !el && tries < 10) {
-        tries++
-        raf = requestAnimationFrame(update)
-        return
-      }
-      setRect(el ? el.getBoundingClientRect() : null)
+      const r = el ? el.getBoundingClientRect() : null
+      const next = r && r.width > 0 && r.height > 0 ? r : null
+      setRect(prev => (sameRect(prev, next) ? prev : next))
+      raf = requestAnimationFrame(measure)
     }
-    update()
-    window.addEventListener('resize', update)
-    return () => {
-      cancelAnimationFrame(raf)
-      window.removeEventListener('resize', update)
-    }
+    measure()
+    return () => cancelAnimationFrame(raf)
   }, [tour.isActive, tour.index, tour.step])
 
   if (!tour.isActive || !tour.step) return null

--- a/src/renderer/src/tour/TourOverlay.tsx
+++ b/src/renderer/src/tour/TourOverlay.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import type { TourStep } from './tourSteps'
 import type { TourState } from './useTour'
 
-const BUBBLE_W = 240
+const BUBBLE_W = 260
 const GAP = 10
 const EDGE = 8
 
@@ -82,12 +82,12 @@ export function TourOverlay({ tour }: { tour: TourState }) {
 
       <Card
         style={rect ? computeBubbleStyle(rect, placement) : undefined}
-        className={`absolute z-[2001] p-3 ${
-          rect ? '' : 'w-[280px] left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
+        className={`absolute z-[2001] p-4 ${
+          rect ? '' : 'w-[300px] left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
         }`}
       >
-        <p className="m-0 text-[13px] font-semibold text-foreground">{tour.step.title}</p>
-        <p className="m-0 mt-1 text-[12px] leading-snug text-muted-foreground">{tour.step.body}</p>
+        <p className="m-0 text-[14px] font-semibold text-foreground">{tour.step.title}</p>
+        <p className="m-0 mt-1 text-[13px] leading-snug text-muted-foreground">{tour.step.body}</p>
         <div className="mt-3 flex items-center justify-between">
           <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground">
             {tour.index + 1} / {tour.total}

--- a/src/renderer/src/tour/TourOverlay.tsx
+++ b/src/renderer/src/tour/TourOverlay.tsx
@@ -1,29 +1,53 @@
-import { useEffect, useState } from 'react'
-import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react-dom'
+import { useEffect, useState, type CSSProperties } from 'react'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import type { TourStep } from './tourSteps'
 import type { TourState } from './useTour'
 
+const BUBBLE_W = 240
+const GAP = 10
+const EDGE = 8
+
+// 対象矩形から吹き出しの位置を同期的に決める（floating-ui を使わず 0,0 への一瞬の
+// 表示＝左上飛びを原理的に防ぐ）。固定サイズの小窓・既知ターゲット向けの簡易配置。
+function computeBubbleStyle(rect: DOMRect, placement: NonNullable<TourStep['placement']>): CSSProperties {
+  const viewportW = window.innerWidth
+  const cx = rect.left + rect.width / 2
+  // 水平方向は対象の中央に寄せつつ、画面端からはみ出さないようクランプする
+  const left = Math.max(EDGE, Math.min(cx - BUBBLE_W / 2, viewportW - BUBBLE_W - EDGE))
+
+  if (placement === 'top') {
+    return { left, top: rect.top - GAP, transform: 'translateY(-100%)', width: BUBBLE_W }
+  }
+  if (placement === 'left') {
+    return { left: rect.left - GAP, top: rect.top + rect.height / 2, transform: 'translate(-100%, -50%)', width: BUBBLE_W }
+  }
+  if (placement === 'right') {
+    return { left: rect.right + GAP, top: rect.top + rect.height / 2, transform: 'translateY(-50%)', width: BUBBLE_W }
+  }
+  // bottom（既定）
+  return { left, top: rect.bottom + GAP, width: BUBBLE_W }
+}
+
 export function TourOverlay({ tour }: { tour: TourState }) {
-  const { refs, floatingStyles } = useFloating({
-    placement: tour.step?.placement ?? 'bottom',
-    middleware: [offset(10), flip(), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate,
-  })
   const [rect, setRect] = useState<DOMRect | null>(null)
 
   useEffect(() => {
-    if (!tour.isActive) return
+    if (!tour.isActive) {
+      setRect(null)
+      return
+    }
     const sel = tour.step?.target
     const el = sel ? document.querySelector<HTMLElement>(sel) : null
-    refs.setReference(el)
     const update = (): void => setRect(el ? el.getBoundingClientRect() : null)
     update()
     window.addEventListener('resize', update)
     return () => window.removeEventListener('resize', update)
-  }, [tour.isActive, tour.index, tour.step, refs])
+  }, [tour.isActive, tour.index, tour.step])
 
   if (!tour.isActive || !tour.step) return null
+
+  const placement = tour.step.placement ?? 'bottom'
 
   return (
     // 全面を覆ってアプリ操作をブロックする（透明でもクリックを受ける）
@@ -44,10 +68,9 @@ export function TourOverlay({ tour }: { tour: TourState }) {
       )}
 
       <Card
-        ref={rect ? refs.setFloating : undefined}
-        style={rect ? floatingStyles : undefined}
+        style={rect ? computeBubbleStyle(rect, placement) : undefined}
         className={`absolute z-[2001] p-3 ${
-          rect ? 'w-[240px]' : 'w-[280px] left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
+          rect ? '' : 'w-[280px] left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
         }`}
       >
         <p className="m-0 text-[13px] font-semibold text-foreground">{tour.step.title}</p>

--- a/src/renderer/src/tour/tourSteps.test.ts
+++ b/src/renderer/src/tour/tourSteps.test.ts
@@ -2,21 +2,39 @@ import { describe, it, expect } from 'vitest'
 import { TOUR_STEPS } from './tourSteps'
 
 describe('TOUR_STEPS', () => {
-  it('7 ステップで各要素に title/body がある', () => {
-    expect(TOUR_STEPS).toHaveLength(7)
+  it('9 ステップで各要素に title/body がある', () => {
+    expect(TOUR_STEPS).toHaveLength(9)
     for (const s of TOUR_STEPS) {
       expect(s.title.length).toBeGreaterThan(0)
       expect(s.body.length).toBeGreaterThan(0)
     }
   })
 
-  it('業務開始・ヘルプ・各タブのターゲットを含む', () => {
+  it('業務開始・ヘルプ・各タブ・デモのターゲットを含む', () => {
     const targets = TOUR_STEPS.map(s => s.target)
     expect(targets).toContain('[data-tour="work-start"]')
     expect(targets).toContain('[data-tour="help"]')
-    expect(targets).toContain('[data-tour="tab-timer"]')
+    expect(targets).toContain('[data-tour="demo-pour"]')
+    expect(targets).toContain('[data-session-item]')
+    expect(targets).toContain('[data-tour="demo-worktime"]')
     expect(targets).toContain('[data-tour="tab-calendar"]')
     expect(targets).toContain('[data-tour="tab-attendance"]')
+  })
+
+  it('デモ 3 ステップに scene.demo が付く', () => {
+    const demoSteps = TOUR_STEPS.filter(s => s.scene?.demo === true)
+    expect(demoSteps.map(s => s.target)).toEqual([
+      '[data-tour="demo-pour"]',
+      '[data-session-item]',
+      '[data-tour="demo-worktime"]',
+    ])
+  })
+
+  it('カレンダー・勤怠ステップに demo は付かない', () => {
+    const tabSteps = TOUR_STEPS.filter(
+      s => s.target === '[data-tour="tab-calendar"]' || s.target === '[data-tour="tab-attendance"]'
+    )
+    for (const s of tabSteps) expect(s.scene?.demo).not.toBe(true)
   })
 
   it('最初と最後は中央表示（target が null）', () => {

--- a/src/renderer/src/tour/tourSteps.test.ts
+++ b/src/renderer/src/tour/tourSteps.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect } from 'vitest'
 import { TOUR_STEPS } from './tourSteps'
 
 describe('TOUR_STEPS', () => {
-  it('9 ステップで各要素に title/body がある', () => {
-    expect(TOUR_STEPS).toHaveLength(9)
+  it('11 ステップで各要素に title/body がある', () => {
+    expect(TOUR_STEPS).toHaveLength(11)
     for (const s of TOUR_STEPS) {
       expect(s.title.length).toBeGreaterThan(0)
       expect(s.body.length).toBeGreaterThan(0)
     }
   })
 
-  it('業務開始・ヘルプ・各タブ・デモのターゲットを含む', () => {
+  it('業務開始・ヘルプ・各タブ・デモ・勤怠操作のターゲットを含む', () => {
     const targets = TOUR_STEPS.map(s => s.target)
     expect(targets).toContain('[data-tour="work-start"]')
     expect(targets).toContain('[data-tour="help"]')
@@ -19,6 +19,19 @@ describe('TOUR_STEPS', () => {
     expect(targets).toContain('[data-tour="demo-worktime"]')
     expect(targets).toContain('[data-tour="tab-calendar"]')
     expect(targets).toContain('[data-tour="tab-attendance"]')
+    expect(targets).toContain('[data-tour="att-copy"]')
+    expect(targets).toContain('[data-tour="att-send"]')
+  })
+
+  it('勤怠操作ステップは attendance タブへ切替（demo は付かない）', () => {
+    const attSteps = TOUR_STEPS.filter(
+      s => s.target === '[data-tour="att-copy"]' || s.target === '[data-tour="att-send"]'
+    )
+    expect(attSteps).toHaveLength(2)
+    for (const s of attSteps) {
+      expect(s.scene?.tab).toBe('attendance')
+      expect(s.scene?.demo).not.toBe(true)
+    }
   })
 
   it('デモ 3 ステップに scene.demo が付く', () => {

--- a/src/renderer/src/tour/tourSteps.test.ts
+++ b/src/renderer/src/tour/tourSteps.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { TOUR_STEPS } from './tourSteps'
+
+describe('TOUR_STEPS', () => {
+  it('7 ステップで各要素に title/body がある', () => {
+    expect(TOUR_STEPS).toHaveLength(7)
+    for (const s of TOUR_STEPS) {
+      expect(s.title.length).toBeGreaterThan(0)
+      expect(s.body.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('業務開始・ヘルプ・各タブのターゲットを含む', () => {
+    const targets = TOUR_STEPS.map(s => s.target)
+    expect(targets).toContain('[data-tour="work-start"]')
+    expect(targets).toContain('[data-tour="help"]')
+    expect(targets).toContain('[data-tour="tab-timer"]')
+    expect(targets).toContain('[data-tour="tab-calendar"]')
+    expect(targets).toContain('[data-tour="tab-attendance"]')
+  })
+
+  it('最初と最後は中央表示（target が null）', () => {
+    expect(TOUR_STEPS[0].target).toBeNull()
+    expect(TOUR_STEPS[TOUR_STEPS.length - 1].target).toBeNull()
+  })
+})

--- a/src/renderer/src/tour/tourSteps.ts
+++ b/src/renderer/src/tour/tourSteps.ts
@@ -69,7 +69,7 @@ export const TOUR_STEPS: TourStep[] = [
   {
     target: '[data-tour="att-send"]',
     title: '送る',
-    body: '勤怠を Slack に送信して共有できます。',
+    body: 'Slack に送信して勤怠を切ることができます。',
     placement: 'top',
     scene: { tab: 'attendance' },
   },

--- a/src/renderer/src/tour/tourSteps.ts
+++ b/src/renderer/src/tour/tourSteps.ts
@@ -1,0 +1,49 @@
+export interface TourStep {
+  target: string | null
+  title: string
+  body: string
+  placement?: 'top' | 'bottom' | 'left' | 'right'
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    target: null,
+    title: 'Juice へようこそ',
+    body: '使い方を 1 分でご案内します。',
+  },
+  {
+    target: '[data-tour="work-start"]',
+    title: '業務を開始',
+    body: 'まずはここから 1 日を始めます。',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="help"]',
+    title: '使い方はここから',
+    body: '操作に迷ったら、いつでもここから見返せます。',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="tab-timer"]',
+    title: 'タイマー',
+    body: '作業時間を記録するメイン画面です。',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="tab-calendar"]',
+    title: 'カレンダー',
+    body: '日々の記録をカレンダーで振り返れます。',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="tab-attendance"]',
+    title: '勤怠',
+    body: '勤怠を集計してチームに共有できます。',
+    placement: 'top',
+  },
+  {
+    target: null,
+    title: '準備完了',
+    body: '詳しい操作は「?」から。それでは始めましょう！',
+  },
+]

--- a/src/renderer/src/tour/tourSteps.ts
+++ b/src/renderer/src/tour/tourSteps.ts
@@ -3,6 +3,7 @@ export interface TourStep {
   title: string
   body: string
   placement?: 'top' | 'bottom' | 'left' | 'right'
+  scene?: { tab?: 'timer' | 'calendar' | 'attendance'; demo?: boolean }
 }
 
 export const TOUR_STEPS: TourStep[] = [
@@ -16,6 +17,7 @@ export const TOUR_STEPS: TourStep[] = [
     title: '業務を開始',
     body: 'まずはここから 1 日を始めます。',
     placement: 'top',
+    scene: { tab: 'timer' },
   },
   {
     target: '[data-tour="help"]',
@@ -24,10 +26,25 @@ export const TOUR_STEPS: TourStep[] = [
     placement: 'bottom',
   },
   {
-    target: '[data-tour="tab-timer"]',
-    title: 'タイマー',
-    body: '作業時間を記録するメイン画面です。',
+    target: '[data-tour="demo-pour"]',
+    title: '作業を始める',
+    body: '作業名を入力して「注ぐ」を押すと計測を開始します。',
+    placement: 'bottom',
+    scene: { tab: 'timer', demo: true },
+  },
+  {
+    target: '[data-session-item]',
+    title: '記録を操作する',
+    body: 'ダブルクリックで編集、右クリックで追加・削除、ドラッグで並び替えできます。',
+    placement: 'bottom',
+    scene: { tab: 'timer', demo: true },
+  },
+  {
+    target: '[data-tour="demo-worktime"]',
+    title: '休憩・終了',
+    body: '休憩や業務終了を記録でき、今日の合計時間もここに出ます。',
     placement: 'top',
+    scene: { tab: 'timer', demo: true },
   },
   {
     target: '[data-tour="tab-calendar"]',

--- a/src/renderer/src/tour/tourSteps.ts
+++ b/src/renderer/src/tour/tourSteps.ts
@@ -55,12 +55,28 @@ export const TOUR_STEPS: TourStep[] = [
   {
     target: '[data-tour="tab-attendance"]',
     title: '勤怠',
-    body: '勤怠を集計してチームに共有できます。',
+    body: '勤怠を集計する画面です。出勤・退勤・休憩を確認できます。',
     placement: 'top',
+    scene: { tab: 'attendance' },
+  },
+  {
+    target: '[data-tour="att-copy"]',
+    title: 'コピー',
+    body: '集計した勤怠テキストをクリップボードにコピーできます。',
+    placement: 'top',
+    scene: { tab: 'attendance' },
+  },
+  {
+    target: '[data-tour="att-send"]',
+    title: '送る',
+    body: '勤怠を Slack に送信して共有できます。',
+    placement: 'top',
+    scene: { tab: 'attendance' },
   },
   {
     target: null,
     title: '準備完了',
     body: '詳しい操作は「?」から。それでは始めましょう！',
+    scene: { tab: 'timer' },
   },
 ]

--- a/src/renderer/src/tour/useTour.test.ts
+++ b/src/renderer/src/tour/useTour.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTour } from './useTour'
+
+beforeEach(() => localStorage.clear())
+
+describe('useTour', () => {
+  it('未完了なら自動で起動する', () => {
+    const { result } = renderHook(() => useTour())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.index).toBe(0)
+  })
+
+  it('完了済みなら自動起動しない', () => {
+    localStorage.setItem('juice.tourCompleted', 'true')
+    const { result } = renderHook(() => useTour())
+    expect(result.current.isActive).toBe(false)
+  })
+
+  it('next / prev で前後に動く', () => {
+    const { result } = renderHook(() => useTour())
+    act(() => result.current.next())
+    expect(result.current.index).toBe(1)
+    act(() => result.current.prev())
+    expect(result.current.index).toBe(0)
+  })
+
+  it('finish で終了し完了フラグを保存する', () => {
+    const { result } = renderHook(() => useTour())
+    act(() => result.current.finish())
+    expect(result.current.isActive).toBe(false)
+    expect(localStorage.getItem('juice.tourCompleted')).toBe('true')
+  })
+
+  it('skip で終了し完了フラグを保存する', () => {
+    const { result } = renderHook(() => useTour())
+    act(() => result.current.skip())
+    expect(result.current.isActive).toBe(false)
+    expect(localStorage.getItem('juice.tourCompleted')).toBe('true')
+  })
+
+  it('完了後も start() で手動再生できる', () => {
+    localStorage.setItem('juice.tourCompleted', 'true')
+    const { result } = renderHook(() => useTour())
+    expect(result.current.isActive).toBe(false)
+    act(() => result.current.start())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.index).toBe(0)
+  })
+})

--- a/src/renderer/src/tour/useTour.ts
+++ b/src/renderer/src/tour/useTour.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import { TOUR_STEPS, type TourStep } from './tourSteps'
+
+const STORAGE_KEY = 'juice.tourCompleted'
+
+export interface TourState {
+  isActive: boolean
+  index: number
+  total: number
+  step: TourStep | null
+  isLast: boolean
+  start: () => void
+  next: () => void
+  prev: () => void
+  skip: () => void
+  finish: () => void
+}
+
+export function useTour(): TourState {
+  // null = 非アクティブ
+  const [index, setIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY) !== 'true') setIndex(0)
+  }, [])
+
+  const total = TOUR_STEPS.length
+  const isActive = index !== null
+  const step = index !== null ? TOUR_STEPS[index] : null
+
+  const complete = (): void => {
+    localStorage.setItem(STORAGE_KEY, 'true')
+    setIndex(null)
+  }
+
+  return {
+    isActive,
+    index: index ?? 0,
+    total,
+    step,
+    isLast: index === total - 1,
+    start: () => setIndex(0),
+    next: () => setIndex(i => (i === null ? i : Math.min(total - 1, i + 1))),
+    prev: () => setIndex(i => (i === null ? i : Math.max(0, i - 1))),
+    skip: complete,
+    finish: complete,
+  }
+}


### PR DESCRIPTION
## 対応（#67 案内型ツアー）
- 実画面の要素に吹き出しを重ねて順に案内する読み取り専用ツアー
- 初回自動起動＋使用ガイド「?」内の「ツアーを見る」で手動再生
- UI は shadcn Card/Button、位置決めは自前計算（左上飛び対策）、完了フラグは localStorage

## 本機能デモを追加
- 待機ビュー（TimerForm + SessionList）をダミーデータで案内する 3 ステップを追加（全 9 ステップ）
- `TourDemoTimer`: 実コンポーネント＋ダミー＋全 no-op＋no-op DailyData で**副作用ゼロ**
- 業務開始は押させない／勤怠・カレンダーはタブを指す説明のみ（送信・遷移なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)