### PR TITLE
test: hooks のテストカバレッジを追加 (#84)

### DIFF
--- a/src/renderer/src/hooks/useCalendar.test.ts
+++ b/src/renderer/src/hooks/useCalendar.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { Session } from '../types/session'
+
+const mockList = vi.fn()
+const mockUpdate = vi.fn()
+const mockGetAll = vi.fn()
+
+vi.mock('../repositories/sessionRepository', () => ({
+  sessionRepository: {
+    list: (ym: string) => mockList(ym),
+    update: (s: Session) => mockUpdate(s),
+  },
+}))
+vi.mock('../repositories/holidayRepository', () => ({
+  holidayRepository: { getAll: () => mockGetAll() },
+}))
+
+import { useCalendar } from './useCalendar'
+
+function makeSession(id: string, date: string): Session {
+  return {
+    id,
+    taskId: id,
+    name: `作業${id}`,
+    projectCode: 'P',
+    workCategory: 'C',
+    times: [{ startTime: `${date}T10:00:00`, endTime: `${date}T11:00:00` }],
+    date,
+    color: '#FF9500',
+    totalTime: 60,
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2026-06-15T12:00:00'))
+  vi.clearAllMocks()
+  mockGetAll.mockResolvedValue({})
+  mockUpdate.mockResolvedValue(undefined)
+  mockList.mockImplementation((ym: string) =>
+    Promise.resolve(
+      ym === '2026-06'
+        ? [makeSession('1', '2026-06-10'), makeSession('2', '2026-06-10'), makeSession('3', '2026-06-15')]
+        : []
+    )
+  )
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useCalendar', () => {
+  it('初期ロードで祝日とその月のセッションを日別にまとめる', async () => {
+    mockGetAll.mockResolvedValue({ '2026-06-15': '記念日' })
+    const { result } = renderHook(() => useCalendar())
+    await waitFor(() => expect(result.current.sessionDates.length).toBe(2))
+    expect(result.current.year).toBe(2026)
+    expect(result.current.month).toBe(6)
+    expect(result.current.sessionDates).toEqual(expect.arrayContaining(['2026-06-10', '2026-06-15']))
+    expect(result.current.holidays).toEqual({ '2026-06-15': '記念日' })
+  })
+
+  it('selectDate でその日のセッションを返す', async () => {
+    const { result } = renderHook(() => useCalendar())
+    await waitFor(() => expect(result.current.sessionDates.length).toBe(2))
+    act(() => result.current.selectDate('2026-06-10'))
+    expect(result.current.selectedDate).toBe('2026-06-10')
+    expect(result.current.selectedSessions.map(s => s.id)).toEqual(['1', '2'])
+  })
+
+  it('nextMonth / prevMonth で月が進み・戻り、選択日がリセットされる', async () => {
+    const { result } = renderHook(() => useCalendar())
+    await waitFor(() => expect(result.current.sessionDates.length).toBe(2))
+    act(() => result.current.selectDate('2026-06-10'))
+    act(() => result.current.nextMonth())
+    expect(result.current.month).toBe(7)
+    expect(result.current.selectedDate).toBeNull()
+    act(() => result.current.prevMonth())
+    expect(result.current.month).toBe(6)
+  })
+
+  it('1月で prevMonth すると前年の12月になる', async () => {
+    vi.setSystemTime(new Date('2026-01-10T12:00:00'))
+    const { result } = renderHook(() => useCalendar())
+    await waitFor(() => expect(result.current.month).toBe(1))
+    act(() => result.current.prevMonth())
+    expect(result.current.year).toBe(2025)
+    expect(result.current.month).toBe(12)
+  })
+
+  it('12月で nextMonth すると翌年の1月になる', async () => {
+    vi.setSystemTime(new Date('2026-12-10T12:00:00'))
+    const { result } = renderHook(() => useCalendar())
+    await waitFor(() => expect(result.current.month).toBe(12))
+    act(() => result.current.nextMonth())
+    expect(result.current.year).toBe(2027)
+    expect(result.current.month).toBe(1)
+  })
+
+  it('updateSession で永続化し、該当セッションを差し替える', async () => {
+    const { result } = renderHook(() => useCalendar())
+    await waitFor(() => expect(result.current.sessionDates.length).toBe(2))
+    act(() => result.current.selectDate('2026-06-10'))
+    const updated = { ...makeSession('1', '2026-06-10'), name: '変更後' }
+    await act(async () => { await result.current.updateSession(updated) })
+    expect(mockUpdate).toHaveBeenCalledWith(updated)
+    expect(result.current.selectedSessions.find(s => s.id === '1')?.name).toBe('変更後')
+  })
+})

--- a/src/renderer/src/hooks/useSettings.test.ts
+++ b/src/renderer/src/hooks/useSettings.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+const mockGetTheme = vi.fn()
+const mockSetTheme = vi.fn()
+const mockOnThemeChanged = vi.fn()
+const mockGetIdle = vi.fn()
+const mockSetIdle = vi.fn()
+const mockGetElapsed = vi.fn()
+const mockSetElapsed = vi.fn()
+const mockGetPomodoro = vi.fn()
+const mockSetPomodoro = vi.fn()
+const mockGetWhiteboard = vi.fn()
+const mockSetWhiteboard = vi.fn()
+const mockGetBreakBehavior = vi.fn()
+const mockSetBreakBehavior = vi.fn()
+const mockGetMainProjectCode = vi.fn()
+const mockSetMainProjectCode = vi.fn()
+
+vi.mock('../repositories/settingsRepository', () => ({
+  settingsRepository: {
+    getTheme: () => mockGetTheme(),
+    setTheme: (t: string) => mockSetTheme(t),
+    onThemeChanged: (cb: (t: string) => void) => mockOnThemeChanged(cb),
+    getIdle: () => mockGetIdle(),
+    setIdle: (e: boolean, m: number) => mockSetIdle(e, m),
+    getElapsed: () => mockGetElapsed(),
+    setElapsed: (e: boolean, m: number) => mockSetElapsed(e, m),
+    getPomodoro: () => mockGetPomodoro(),
+    setPomodoro: (e: boolean) => mockSetPomodoro(e),
+    getWhiteboard: () => mockGetWhiteboard(),
+    setWhiteboard: (e: boolean) => mockSetWhiteboard(e),
+    getBreakBehavior: () => mockGetBreakBehavior(),
+    setBreakBehavior: (b: string) => mockSetBreakBehavior(b),
+    getMainProjectCode: () => mockGetMainProjectCode(),
+    setMainProjectCode: (c: string) => mockSetMainProjectCode(c),
+  },
+}))
+
+const mockApplyTheme = vi.fn()
+vi.mock('../theme/applyTheme', () => ({ applyTheme: (t: string) => mockApplyTheme(t) }))
+
+import { useSettings } from './useSettings'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetTheme.mockResolvedValue('milk')
+  mockOnThemeChanged.mockReturnValue(() => {})
+  mockGetIdle.mockResolvedValue({ enabled: false, minutes: 60 })
+  mockGetElapsed.mockResolvedValue({ enabled: false, minutes: 30 })
+  mockGetPomodoro.mockResolvedValue({ enabled: false })
+  mockGetWhiteboard.mockResolvedValue({ enabled: false })
+  mockGetBreakBehavior.mockResolvedValue({ behavior: 'stop' })
+  mockGetMainProjectCode.mockResolvedValue('')
+})
+
+describe('useSettings', () => {
+  it('初期ロードで全設定を反映する', async () => {
+    mockGetTheme.mockResolvedValue('rose')
+    mockGetIdle.mockResolvedValue({ enabled: true, minutes: 45 })
+    mockGetElapsed.mockResolvedValue({ enabled: true, minutes: 25 })
+    mockGetPomodoro.mockResolvedValue({ enabled: true })
+    mockGetWhiteboard.mockResolvedValue({ enabled: true })
+    mockGetBreakBehavior.mockResolvedValue({ behavior: 'pause' })
+    mockGetMainProjectCode.mockResolvedValue('PJ-1')
+
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('rose'))
+    expect(result.current.idleEnabled).toBe(true)
+    expect(result.current.idleMinutes).toBe(45)
+    expect(result.current.elapsedEnabled).toBe(true)
+    expect(result.current.elapsedMinutes).toBe(25)
+    expect(result.current.pomodoroEnabled).toBe(true)
+    expect(result.current.whiteboardEnabled).toBe(true)
+    expect(result.current.breakBehavior).toBe('pause')
+    expect(result.current.mainProjectCode).toBe('PJ-1')
+  })
+
+  it('setTheme で applyTheme と永続化を呼び state を更新する', async () => {
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setTheme('graphite'))
+    expect(mockApplyTheme).toHaveBeenCalledWith('graphite')
+    expect(mockSetTheme).toHaveBeenCalledWith('graphite')
+    expect(result.current.activeThemeId).toBe('graphite')
+  })
+
+  it('setIdle で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setIdle(true, 90))
+    expect(mockSetIdle).toHaveBeenCalledWith(true, 90)
+    expect(result.current.idleEnabled).toBe(true)
+    expect(result.current.idleMinutes).toBe(90)
+  })
+
+  it('setElapsed で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setElapsed(true, 15))
+    expect(mockSetElapsed).toHaveBeenCalledWith(true, 15)
+    expect(result.current.elapsedEnabled).toBe(true)
+    expect(result.current.elapsedMinutes).toBe(15)
+  })
+
+  it('setPomodoro で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setPomodoro(true))
+    expect(mockSetPomodoro).toHaveBeenCalledWith(true)
+    expect(result.current.pomodoroEnabled).toBe(true)
+  })
+
+  it('setBreakBehavior で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setBreakBehavior('pause'))
+    expect(mockSetBreakBehavior).toHaveBeenCalledWith('pause')
+    expect(result.current.breakBehavior).toBe('pause')
+  })
+
+  it('setMainProjectCode で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setMainProjectCode('PJ-9'))
+    expect(mockSetMainProjectCode).toHaveBeenCalledWith('PJ-9')
+    expect(result.current.mainProjectCode).toBe('PJ-9')
+  })
+})

--- a/src/renderer/src/hooks/useSetup.test.ts
+++ b/src/renderer/src/hooks/useSetup.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+const mockGetTheme = vi.fn()
+const mockSetTheme = vi.fn()
+const mockOnThemeChanged = vi.fn()
+const mockGetWhiteboard = vi.fn()
+const mockSetWhiteboard = vi.fn()
+const mockGetMainProjectCode = vi.fn()
+const mockSetMainProjectCode = vi.fn()
+const mockCompleteSetup = vi.fn()
+
+vi.mock('../repositories/settingsRepository', () => ({
+  settingsRepository: {
+    getTheme: () => mockGetTheme(),
+    setTheme: (t: string) => mockSetTheme(t),
+    onThemeChanged: (cb: (t: string) => void) => mockOnThemeChanged(cb),
+    getWhiteboard: () => mockGetWhiteboard(),
+    setWhiteboard: (e: boolean) => mockSetWhiteboard(e),
+    getMainProjectCode: () => mockGetMainProjectCode(),
+    setMainProjectCode: (c: string) => mockSetMainProjectCode(c),
+    completeSetup: () => mockCompleteSetup(),
+  },
+}))
+
+const mockApplyTheme = vi.fn()
+vi.mock('../theme/applyTheme', () => ({ applyTheme: (t: string) => mockApplyTheme(t) }))
+
+import { useSetup } from './useSetup'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetTheme.mockResolvedValue('milk')
+  mockOnThemeChanged.mockReturnValue(() => {})
+  mockGetWhiteboard.mockResolvedValue({ enabled: false })
+  mockGetMainProjectCode.mockResolvedValue('')
+  mockSetTheme.mockResolvedValue(undefined)
+  mockSetWhiteboard.mockResolvedValue(undefined)
+  mockSetMainProjectCode.mockResolvedValue(undefined)
+  mockCompleteSetup.mockResolvedValue(undefined)
+})
+
+describe('useSetup', () => {
+  it('初期ロードで取得した設定値を反映する', async () => {
+    mockGetTheme.mockResolvedValue('rose')
+    mockGetWhiteboard.mockResolvedValue({ enabled: true })
+    mockGetMainProjectCode.mockResolvedValue('PJ-1')
+    const { result } = renderHook(() => useSetup())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('rose'))
+    expect(result.current.whiteboardEnabled).toBe(true)
+    expect(result.current.mainProjectCode).toBe('PJ-1')
+  })
+
+  it('setTheme で applyTheme と永続化を呼び state を更新する', async () => {
+    const { result } = renderHook(() => useSetup())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setTheme('graphite'))
+    expect(mockApplyTheme).toHaveBeenCalledWith('graphite')
+    expect(mockSetTheme).toHaveBeenCalledWith('graphite')
+    expect(result.current.activeThemeId).toBe('graphite')
+  })
+
+  it('setWhiteboard で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSetup())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setWhiteboard(true))
+    expect(mockSetWhiteboard).toHaveBeenCalledWith(true)
+    expect(result.current.whiteboardEnabled).toBe(true)
+  })
+
+  it('setMainProjectCode で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSetup())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setMainProjectCode('PJ-9'))
+    expect(mockSetMainProjectCode).toHaveBeenCalledWith('PJ-9')
+    expect(result.current.mainProjectCode).toBe('PJ-9')
+  })
+
+  it('complete で completeSetup を呼ぶ', async () => {
+    const { result } = renderHook(() => useSetup())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    await act(async () => { await result.current.complete() })
+    expect(mockCompleteSetup).toHaveBeenCalled()
+  })
+
+  it('onThemeChanged の購読をアンマウントで解除する', async () => {
+    const off = vi.fn()
+    mockOnThemeChanged.mockReturnValue(off)
+    const { unmount, result } = renderHook(() => useSetup())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    unmount()
+    expect(off).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 対応（#84 hooks 部分）
未テストだったフックに renderHook ベースのテストを追加。

- `useSetup`: 初期ロード反映 / テーマ即時反映＋永続化 / 連携設定の保存 / 完了 / 購読解除
- `useSettings`: 全設定の初期ロード / 各設定の即時反映＋永続化
- `useCalendar`: 祝日・日別セッション取得 / 月送り（年跨ぎ境界含む）/ 選択日 / セッション更新

リポジトリと applyTheme を `vi.mock`。テスト +19（計 651 pass）。

※ useSessions・integrations/attendance は issue 作成後に既にテスト済みでした。
main プロセス（IPC handlers / notifications）は別 PR で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)