### PR TITLE
test: main プロセスのテストカバレッジを追加 (#84)

### DIFF
--- a/src/main/ipc/registerHandlers.test.ts
+++ b/src/main/ipc/registerHandlers.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SessionStore } from '../sessionStore'
+import type { SettingsStore } from '../settingsStore'
+import type { AuthStore } from '../auth/authStore'
+import type { DailyStore } from '../dailyStore'
+
+// すべての外部依存をモック化し、handle() で登録されたハンドラを捕捉する。
+const m = vi.hoisted(() => ({
+  handlers: new Map<string, (...a: unknown[]) => unknown>(),
+  shellOpenExternal: vi.fn(),
+  dockHide: vi.fn(),
+  recordActivity: vi.fn(),
+  onTimerStarted: vi.fn(),
+  onTimerStopped: vi.fn(),
+  onTimerAdjustStartTime: vi.fn(),
+  reschedule: vi.fn(),
+  pomoStarted: vi.fn(),
+  pomoStopped: vi.fn(),
+  pomoAdjust: vi.fn(),
+  pomoReschedule: vi.fn(),
+  startIdleCheck: vi.fn(),
+  sendAttendance: vi.fn(() => Promise.resolve({ ok: true })),
+  sendWhiteboardTeleworkStart: vi.fn(() => Promise.resolve()),
+  getHolidays: vi.fn(() => ({})),
+  broadcastThemeToAll: vi.fn(),
+  broadcastAuthToAll: vi.fn(),
+  hidePopover: vi.fn(),
+  resizePopover: vi.fn(),
+  getSetupWindow: vi.fn(() => null),
+  createTray: vi.fn(),
+  startSignIn: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn(),
+}))
+
+vi.mock('./handle', () => ({
+  handle: (channel: string, fn: (...a: unknown[]) => unknown) => {
+    m.handlers.set(channel, fn)
+  },
+}))
+vi.mock('electron', () => ({
+  app: { dock: { hide: m.dockHide } },
+  shell: { openExternal: m.shellOpenExternal },
+}))
+vi.mock('../notifications/activity', () => ({ recordActivity: m.recordActivity }))
+vi.mock('../notifications/elapsed', () => ({
+  onTimerStarted: m.onTimerStarted,
+  onTimerStopped: m.onTimerStopped,
+  onTimerAdjustStartTime: m.onTimerAdjustStartTime,
+  reschedule: m.reschedule,
+}))
+vi.mock('../notifications/pomodoro', () => ({
+  onTimerStarted: m.pomoStarted,
+  onTimerStopped: m.pomoStopped,
+  onTimerAdjustStartTime: m.pomoAdjust,
+  reschedule: m.pomoReschedule,
+}))
+vi.mock('../notifications/idle', () => ({ startIdleCheck: m.startIdleCheck }))
+vi.mock('../integrations/attendance', () => ({ sendAttendance: m.sendAttendance }))
+vi.mock('../integrations/whiteboard', () => ({ sendWhiteboardTeleworkStart: m.sendWhiteboardTeleworkStart }))
+vi.mock('../integrations/holidays', () => ({ getHolidays: m.getHolidays }))
+vi.mock('../windows/themeBroadcast', () => ({ broadcastThemeToAll: m.broadcastThemeToAll }))
+vi.mock('../windows/authBroadcast', () => ({ broadcastAuthToAll: m.broadcastAuthToAll }))
+vi.mock('../windows/popover', () => ({ hidePopover: m.hidePopover, resizePopover: m.resizePopover }))
+vi.mock('../windows/setup', () => ({ getSetupWindow: m.getSetupWindow }))
+vi.mock('../windows/tray', () => ({ createTray: m.createTray }))
+vi.mock('../auth/signIn', () => ({ startSignIn: m.startSignIn }))
+vi.mock('../logger', () => ({ logger: { warn: m.loggerWarn, error: m.loggerError, info: vi.fn() } }))
+
+import { registerIpcHandlers } from './registerHandlers'
+
+const STORE_METHODS = {
+  session: ['getSessions', 'saveSession', 'updateSession', 'deleteSession'],
+  settings: [
+    'getTheme', 'setTheme', 'getIdleSettings', 'setIdleSettings', 'getElapsedSettings',
+    'setElapsedSettings', 'getPomodoroSettings', 'setPomodoroSettings', 'getWhiteboardSettings',
+    'setWhiteboardSettings', 'getBreakBehaviorSettings', 'setBreakBehaviorSettings',
+    'getMainProjectCode', 'setMainProjectCode', 'completeSetup',
+  ],
+  auth: ['getStatus', 'clearToken'],
+  daily: ['getMonth', 'setDay', 'prune', 'importLegacy'],
+}
+
+function stub(names: string[]): Record<string, ReturnType<typeof vi.fn>> {
+  return Object.fromEntries(names.map(n => [n, vi.fn(async () => undefined)]))
+}
+
+let sessionStore: SessionStore
+let settingsStore: SettingsStore
+let authStore: AuthStore
+let dailyStore: DailyStore
+
+function invoke(channel: string, arg?: unknown): unknown {
+  const fn = m.handlers.get(channel)
+  if (!fn) throw new Error(`handler not registered: ${channel}`)
+  return fn({}, arg)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  m.handlers.clear()
+  sessionStore = stub(STORE_METHODS.session) as unknown as SessionStore
+  settingsStore = stub(STORE_METHODS.settings) as unknown as SettingsStore
+  authStore = stub(STORE_METHODS.auth) as unknown as AuthStore
+  dailyStore = stub(STORE_METHODS.daily) as unknown as DailyStore
+  registerIpcHandlers(sessionStore, settingsStore, authStore, dailyStore)
+})
+
+describe('registerIpcHandlers', () => {
+  it('主要なチャンネルを登録する', () => {
+    for (const ch of ['sessions:get', 'daily:getMonth', 'settings:setTheme', 'timer:started', 'attendance:send', 'shell:openUrl']) {
+      expect(m.handlers.has(ch)).toBe(true)
+    }
+  })
+
+  it('sessions:save はストアへ保存し操作を記録する', async () => {
+    const session = { id: '1' }
+    await invoke('sessions:save', session)
+    expect(sessionStore.saveSession).toHaveBeenCalledWith(session)
+    expect(m.recordActivity).toHaveBeenCalled()
+  })
+
+  it('timer:started は elapsed と pomodoro 両方を起動する', () => {
+    invoke('timer:started')
+    expect(m.onTimerStarted).toHaveBeenCalledWith(settingsStore)
+    expect(m.pomoStarted).toHaveBeenCalledWith(settingsStore)
+  })
+
+  it('settings:setTheme は保存しテーマを全ウィンドウへ配信する', async () => {
+    await invoke('settings:setTheme', 'rose')
+    expect(settingsStore.setTheme).toHaveBeenCalledWith('rose')
+    expect(m.broadcastThemeToAll).toHaveBeenCalledWith('rose')
+  })
+
+  it('settings:setIdleSettings は保存後に操作記録とアイドル再開を行う', async () => {
+    await invoke('settings:setIdleSettings', { enabled: true, minutes: 30 })
+    expect(settingsStore.setIdleSettings).toHaveBeenCalledWith(true, 30)
+    expect(m.recordActivity).toHaveBeenCalled()
+    expect(m.startIdleCheck).toHaveBeenCalledWith(settingsStore)
+  })
+
+  it('attendance:send はストアとテキストを渡して送信する', () => {
+    invoke('attendance:send', '勤怠テキスト')
+    expect(m.sendAttendance).toHaveBeenCalledWith(settingsStore, authStore, '勤怠テキスト')
+  })
+
+  it('whiteboard:teleworkStart はテレワーク開始を送信する', async () => {
+    await invoke('whiteboard:teleworkStart')
+    expect(m.sendWhiteboardTeleworkStart).toHaveBeenCalledWith(settingsStore, authStore)
+  })
+
+  it('window:resize はポップオーバーをリサイズする', () => {
+    invoke('window:resize', { width: 560, height: 420 })
+    expect(m.resizePopover).toHaveBeenCalledWith(560, 420)
+  })
+
+  it('shell:openUrl は http(s) のみ外部に開く', () => {
+    invoke('shell:openUrl', 'https://example.com')
+    expect(m.shellOpenExternal).toHaveBeenCalledWith('https://example.com')
+  })
+
+  it('shell:openUrl は非 http(s) スキームをブロックする', () => {
+    invoke('shell:openUrl', 'file:///etc/passwd')
+    expect(m.shellOpenExternal).not.toHaveBeenCalled()
+  })
+
+  it('shell:openUrl は不正な URL をブロックする', () => {
+    invoke('shell:openUrl', 'not a url')
+    expect(m.shellOpenExternal).not.toHaveBeenCalled()
+  })
+
+  it('setup:complete は完了保存しトレイを作る', async () => {
+    await invoke('setup:complete')
+    expect(settingsStore.completeSetup).toHaveBeenCalled()
+    expect(m.createTray).toHaveBeenCalledWith(settingsStore)
+  })
+
+  it('auth:signOut はトークンを消し状態を配信する', async () => {
+    await invoke('auth:signOut')
+    expect(authStore.clearToken).toHaveBeenCalled()
+    expect(m.broadcastAuthToAll).toHaveBeenCalled()
+  })
+})

--- a/src/main/notifications/activity.test.ts
+++ b/src/main/notifications/activity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  recordActivity,
+  getLastActivityTime,
+  wasIdleNotificationSent,
+  markIdleNotificationSent,
+} from './activity'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('activity', () => {
+  it('recordActivity が最終操作時刻を現在へ更新し、通知済みフラグを下げる', () => {
+    markIdleNotificationSent()
+    expect(wasIdleNotificationSent()).toBe(true)
+
+    vi.setSystemTime(new Date('2026-06-28T10:00:00'))
+    recordActivity()
+
+    expect(getLastActivityTime().getTime()).toBe(new Date('2026-06-28T10:00:00').getTime())
+    expect(wasIdleNotificationSent()).toBe(false)
+  })
+
+  it('markIdleNotificationSent で通知済みになる', () => {
+    recordActivity()
+    expect(wasIdleNotificationSent()).toBe(false)
+    markIdleNotificationSent()
+    expect(wasIdleNotificationSent()).toBe(true)
+  })
+})

--- a/src/main/notifications/elapsed.test.ts
+++ b/src/main/notifications/elapsed.test.ts
@@ -12,7 +12,9 @@ vi.mock('electron', () => ({
     constructor(opts: { title: string; body: string }) {
       notificationCtor(opts)
     }
-    on(): void {}
+    on(): void {
+      // no-op
+    }
     show(): void {
       showMock()
     }

--- a/src/main/notifications/elapsed.test.ts
+++ b/src/main/notifications/elapsed.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SettingsStore } from '../settingsStore'
+
+const { notificationCtor, showMock, isSupportedMock } = vi.hoisted(() => ({
+  notificationCtor: vi.fn(),
+  showMock: vi.fn(),
+  isSupportedMock: vi.fn(() => true),
+}))
+
+vi.mock('electron', () => ({
+  Notification: class {
+    constructor(opts: { title: string; body: string }) {
+      notificationCtor(opts)
+    }
+    on(): void {}
+    show(): void {
+      showMock()
+    }
+    static isSupported(): boolean {
+      return isSupportedMock()
+    }
+  },
+}))
+
+vi.mock('../windows/popover', () => ({ showPopoverFromNotification: vi.fn() }))
+vi.mock('./activity', () => ({ recordActivity: vi.fn() }))
+
+import { onTimerStarted, onTimerStopped, onTimerAdjustStartTime, isTimerRunning } from './elapsed'
+
+const MINUTE = 60 * 1000
+
+function makeStore(enabled: boolean, minutes: number): SettingsStore {
+  return { getElapsedSettings: vi.fn(async () => ({ enabled, minutes })) } as unknown as SettingsStore
+}
+
+describe('elapsed notifications', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    isSupportedMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    onTimerStopped()
+    vi.useRealTimers()
+  })
+
+  it('開始から指定分で経過通知が出る', async () => {
+    onTimerStarted(makeStore(true, 30))
+    expect(isTimerRunning()).toBe(true)
+    await vi.advanceTimersByTimeAsync(30 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(1)
+    expect(notificationCtor).toHaveBeenCalledWith({ title: 'Juice', body: '作業中 — 30分経過しました' })
+  })
+
+  it('次の境界でも継続通知される（60分）', async () => {
+    onTimerStarted(makeStore(true, 30))
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(2)
+    expect(notificationCtor).toHaveBeenLastCalledWith({ title: 'Juice', body: '作業中 — 60分経過しました' })
+  })
+
+  it('停止後は通知せず isTimerRunning が false になる', async () => {
+    onTimerStarted(makeStore(true, 30))
+    onTimerStopped()
+    expect(isTimerRunning()).toBe(false)
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+  })
+
+  it('設定 OFF のときは通知しない', async () => {
+    onTimerStarted(makeStore(false, 30))
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+  })
+
+  it('開始時刻を調整すると新しい起点から数え直す', async () => {
+    const store = makeStore(true, 30)
+    onTimerStarted(store)
+    await vi.advanceTimersByTimeAsync(20 * MINUTE)
+    onTimerAdjustStartTime(Date.now(), store)
+    await vi.advanceTimersByTimeAsync(29 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('Notification 非対応環境では通知しない', async () => {
+    isSupportedMock.mockReturnValue(false)
+    onTimerStarted(makeStore(true, 30))
+    await vi.advanceTimersByTimeAsync(30 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/notifications/idle.test.ts
+++ b/src/main/notifications/idle.test.ts
@@ -12,7 +12,9 @@ vi.mock('electron', () => ({
     constructor(opts: { title: string; body: string }) {
       notificationCtor(opts)
     }
-    on(): void {}
+    on(): void {
+      // no-op
+    }
     show(): void {
       showMock()
     }

--- a/src/main/notifications/idle.test.ts
+++ b/src/main/notifications/idle.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SettingsStore } from '../settingsStore'
+
+const { notificationCtor, showMock, isSupportedMock } = vi.hoisted(() => ({
+  notificationCtor: vi.fn(),
+  showMock: vi.fn(),
+  isSupportedMock: vi.fn(() => true),
+}))
+
+vi.mock('electron', () => ({
+  Notification: class {
+    constructor(opts: { title: string; body: string }) {
+      notificationCtor(opts)
+    }
+    on(): void {}
+    show(): void {
+      showMock()
+    }
+    static isSupported(): boolean {
+      return isSupportedMock()
+    }
+  },
+}))
+
+vi.mock('../windows/popover', () => ({ showPopoverFromNotification: vi.fn() }))
+
+const { lastActivityMock, isRunningMock } = vi.hoisted(() => ({
+  lastActivityMock: vi.fn(),
+  isRunningMock: vi.fn(() => false),
+}))
+
+let idleSent = false
+vi.mock('./activity', () => ({
+  getLastActivityTime: () => lastActivityMock(),
+  wasIdleNotificationSent: () => idleSent,
+  markIdleNotificationSent: () => {
+    idleSent = true
+  },
+}))
+vi.mock('./elapsed', () => ({ isTimerRunning: () => isRunningMock() }))
+
+import { startIdleCheck } from './idle'
+
+const MINUTE = 60 * 1000
+const BASE = new Date('2026-06-28T10:00:00').getTime()
+
+function makeStore(enabled: boolean, minutes: number): SettingsStore {
+  return { getIdleSettings: vi.fn(async () => ({ enabled, minutes })) } as unknown as SettingsStore
+}
+
+describe('idle notifications', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(BASE)
+    vi.clearAllMocks()
+    isSupportedMock.mockReturnValue(true)
+    isRunningMock.mockReturnValue(false)
+    lastActivityMock.mockReturnValue(new Date(BASE))
+    idleSent = false
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('アイドルが閾値を超えると一度だけ通知し、通知済みにする', async () => {
+    await startIdleCheck(makeStore(true, 30))
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+    expect(showMock).toHaveBeenCalledTimes(1)
+    expect(notificationCtor).toHaveBeenCalledWith({
+      title: 'Juice',
+      body: 'ジュースを飲みたくありませんか？',
+    })
+  })
+
+  it('設定 OFF では interval を張らず通知しない', async () => {
+    await startIdleCheck(makeStore(false, 30))
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+  })
+
+  it('タイマー稼働中はアイドルでも通知しない', async () => {
+    isRunningMock.mockReturnValue(true)
+    await startIdleCheck(makeStore(true, 30))
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+  })
+
+  it('閾値未満では通知しない', async () => {
+    await startIdleCheck(makeStore(true, 30))
+    await vi.advanceTimersByTimeAsync(20 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+  })
+
+  it('Notification 非対応環境では通知しない', async () => {
+    isSupportedMock.mockReturnValue(false)
+    await startIdleCheck(makeStore(true, 30))
+    await vi.advanceTimersByTimeAsync(60 * MINUTE)
+    expect(showMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 対応（#84 main プロセス部分）
未テストだった main プロセスのコードにテストを追加。

- `notifications/activity`: 操作記録・通知済みフラグ
- `notifications/elapsed`: 経過通知の境界・停止/OFF・起点調整・非対応環境
- `notifications/idle`: アイドル閾値・稼働中抑制・通知済み制御・OFF
- `ipc/registerHandlers`: ハンドラ配線（保存＋操作記録、timer/勤怠/テレワーク/リサイズ委譲）と `shell:openUrl` の http(s) 限定検証

electron は `vi.mock`、通知系は fake timers で検証。テスト +26（計 677 pass）。

これで #84（hooks / main）のカバレッジ補完は一通り完了です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)