### PR TITLE
feat: JWT TTL を 7日へ短縮しセッション自動更新を追加 (#82)

### DIFF
--- a/lambda/src/handler.test.ts
+++ b/lambda/src/handler.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { handler } from './handler'
-import { issueSessionJwt } from './sessionJwt'
+import { issueSessionJwt, verifySessionJwt } from './sessionJwt'
 import { signState, verifyState } from './stateSign'
 import { isRevoked } from './revocations'
 import * as slackOidc from './slackOidc'
@@ -277,4 +277,39 @@ describe('POST /api/whiteboard.*', () => {
 
 it('未知のパスは 404', async () => {
   expect((await handler(makeEvent('/nope'))).statusCode).toBe(404)
+})
+
+describe('POST /auth/refresh', () => {
+  it('有効トークンを 200 でクレームを引き継いで再発行する', async () => {
+    const token = issueSessionJwt(
+      { sub: 'U123', name: '金山', team: 'T999', email: 'a@jsl.co.jp', handle: 'k', picture: 'p' },
+      'test-secret'
+    )
+    const res = await handler(
+      makeEvent('/auth/refresh', {}, { authorization: `Bearer ${token}` }, { method: 'POST' })
+    )
+    expect(res.statusCode).toBe(200)
+    const { token: newToken } = JSON.parse(res.body!)
+    const claims = verifySessionJwt(newToken, 'test-secret')
+    expect(claims).toMatchObject({
+      sub: 'U123', name: '金山', team: 'T999', email: 'a@jsl.co.jp', handle: 'k', picture: 'p',
+    })
+  })
+
+  it('Bearer 無し・改竄トークンは 401', async () => {
+    expect((await handler(makeEvent('/auth/refresh', {}, {}, { method: 'POST' }))).statusCode).toBe(401)
+    const res = await handler(
+      makeEvent('/auth/refresh', {}, { authorization: 'Bearer xx.yy.zz' }, { method: 'POST' })
+    )
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('失効済みユーザーのトークンは 401', async () => {
+    vi.mocked(isRevoked).mockResolvedValue(true)
+    const token = issueSessionJwt({ sub: 'U123', name: '金山', team: 'T999' }, 'test-secret')
+    const res = await handler(
+      makeEvent('/auth/refresh', {}, { authorization: `Bearer ${token}` }, { method: 'POST' })
+    )
+    expect(res.statusCode).toBe(401)
+  })
 })

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -144,6 +144,23 @@ export async function handler(event: FunctionUrlEvent): Promise<FunctionUrlRespo
     return json(200, { sub: claims.sub, name: claims.name, team: claims.team, exp: claims.exp })
   }
 
+  if (path === '/auth/refresh' && event.requestContext.http.method === 'POST') {
+    const claims = await bearerClaims(event, secrets.SESSION_SECRET)
+    if (!claims) return json(401, { error: 'unauthorized' })
+    const token = issueSessionJwt(
+      {
+        sub: claims.sub,
+        name: claims.name,
+        team: claims.team,
+        email: claims.email,
+        handle: claims.handle,
+        picture: claims.picture,
+      },
+      secrets.SESSION_SECRET
+    )
+    return json(200, { token })
+  }
+
   if (path === '/api/attendance.send' && event.requestContext.http.method === 'POST') {
     const claims = await bearerClaims(event, secrets.SESSION_SECRET)
     if (!claims) return json(401, { error: 'unauthorized' })

--- a/lambda/src/sessionJwt.test.ts
+++ b/lambda/src/sessionJwt.test.ts
@@ -10,7 +10,7 @@ describe('sessionJwt', () => {
     const token = issueSessionJwt({ sub: 'U123', name: '金山', team: 'T999' }, SECRET, NOW)
     const claims = verifySessionJwt(token, SECRET, NOW)
     expect(claims).toMatchObject({ sub: 'U123', name: '金山', team: 'T999', iat: NOW })
-    expect(claims!.exp).toBe(NOW + 90 * 24 * 60 * 60)
+    expect(claims!.exp).toBe(NOW + 7 * 24 * 60 * 60)
   })
 
   it('JWT 形式（header.payload.signature）である', () => {
@@ -38,7 +38,7 @@ describe('sessionJwt', () => {
 
   it('期限切れトークンは null', () => {
     const token = issueSessionJwt({ sub: 'U1', name: 'a', team: 'T1' }, SECRET, NOW)
-    const after = NOW + 90 * 24 * 60 * 60 + 1
+    const after = NOW + 7 * 24 * 60 * 60 + 1
     expect(verifySessionJwt(token, SECRET, after)).toBeNull()
   })
 

--- a/lambda/src/sessionJwt.ts
+++ b/lambda/src/sessionJwt.ts
@@ -14,7 +14,7 @@ export interface SessionClaims {
   exp: number
 }
 
-const EXPIRES_IN_SEC = 90 * 24 * 60 * 60 // 90日
+const EXPIRES_IN_SEC = 7 * 24 * 60 * 60 // 7日
 
 const nowSec = (): number => Math.floor(Date.now() / 1000)
 

--- a/src/main/auth/refreshSession.test.ts
+++ b/src/main/auth/refreshSession.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const httpPostMock = vi.fn()
+vi.mock('../http', () => ({ httpPost: (...a: unknown[]) => httpPostMock(...a) }))
+const broadcastAuthToAll = vi.fn()
+vi.mock('../windows/authBroadcast', () => ({ broadcastAuthToAll: (...a: unknown[]) => broadcastAuthToAll(...a) }))
+vi.mock('../logger', () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }))
+
+import { refreshSession, startSessionRefresh } from './refreshSession'
+import type { AuthStore } from './authStore'
+
+function makeAuthStore(token: string | null): AuthStore {
+  return {
+    getToken: vi.fn(async () => token),
+    saveToken: vi.fn(async () => undefined),
+    getStatus: vi.fn(async () => ({ signedIn: true })),
+  } as unknown as AuthStore
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('refreshSession', () => {
+  it('トークン有り＋200 で新トークンを保存し auth を配信する', async () => {
+    httpPostMock.mockResolvedValue({ ok: true, status: 200, body: JSON.stringify({ token: 'NEW' }) })
+    const store = makeAuthStore('OLD')
+    await refreshSession(store)
+    expect(httpPostMock).toHaveBeenCalled()
+    expect(store.saveToken).toHaveBeenCalledWith('NEW')
+    expect(broadcastAuthToAll).toHaveBeenCalled()
+  })
+
+  it('トークン無しなら何もしない', async () => {
+    const store = makeAuthStore(null)
+    await refreshSession(store)
+    expect(httpPostMock).not.toHaveBeenCalled()
+    expect(store.saveToken).not.toHaveBeenCalled()
+  })
+
+  it('非 ok では保存も配信もしない', async () => {
+    httpPostMock.mockResolvedValue({ ok: false, status: 401, body: '' })
+    const store = makeAuthStore('OLD')
+    await refreshSession(store)
+    expect(store.saveToken).not.toHaveBeenCalled()
+    expect(broadcastAuthToAll).not.toHaveBeenCalled()
+  })
+})
+
+describe('startSessionRefresh', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('起動時に1回、24時間後にもう1回更新する', async () => {
+    httpPostMock.mockResolvedValue({ ok: true, status: 200, body: JSON.stringify({ token: 'NEW' }) })
+    startSessionRefresh(makeAuthStore('OLD'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(httpPostMock).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000)
+    expect(httpPostMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/auth/refreshSession.ts
+++ b/src/main/auth/refreshSession.ts
@@ -1,0 +1,33 @@
+import { httpPost } from '../http'
+import { broadcastAuthToAll } from '../windows/authBroadcast'
+import { logger } from '../logger'
+import type { AuthStore } from './authStore'
+
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+/** 有効なセッショントークンを黙って再発行して保存する。失敗時は既存トークンを維持。 */
+export async function refreshSession(authStore: AuthStore): Promise<void> {
+  const token = await authStore.getToken()
+  if (!token) return
+  const result = await httpPost(
+    `${import.meta.env.MAIN_VITE_PROXY_URL}/auth/refresh`,
+    '',
+    { Authorization: `Bearer ${token}` }
+  )
+  if (!result.ok) return
+  try {
+    const parsed = JSON.parse(result.body) as { token?: unknown }
+    if (typeof parsed.token === 'string') {
+      await authStore.saveToken(parsed.token)
+      broadcastAuthToAll(await authStore.getStatus())
+    }
+  } catch (err) {
+    logger.error('session refresh parse failed:', err)
+  }
+}
+
+/** 起動時に一度更新し、以降 24 時間ごとに更新する */
+export function startSessionRefresh(authStore: AuthStore): void {
+  void refreshSession(authStore)
+  setInterval(() => void refreshSession(authStore), REFRESH_INTERVAL_MS)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { createSetupWindow } from './windows/setup'
 import { createTray } from './windows/tray'
 import { startIdleCheck } from './notifications/idle'
 import { registerIpcHandlers } from './ipc/registerHandlers'
+import { startSessionRefresh } from './auth/refreshSession'
 import { logger } from './logger'
 
 // dev とパッケージ版でプロファイルを分離する（起動ロック衝突・localStorage 混入の防止）。
@@ -71,6 +72,7 @@ app.whenReady().then(async () => {
   }
 
   registerIpcHandlers(sessionStore, settingsStore, authStore, dailyStore)
+  startSessionRefresh(authStore)
 
   // 初回セットアップ判定
   const needsSetup = !(await settingsStore.isSetupCompleted())


### PR DESCRIPTION
## 対応（#82）
- JWT TTL を 90日 → 7日へ短縮（lambda/src/sessionJwt.ts）
- `POST /auth/refresh` を追加（有効な Bearer を署名/期限/失効検証して再発行）
- クライアントに自動更新を追加（起動時＋24時間ごと、失敗時は既存トークン維持）

失効ユーザー・期限切れは更新不可（再サインインへ）。スライディングセッション。

## 注意
- **Lambda のデプロイが必要**（sessionJwt.ts / handler.ts の変更）。
- 既存トークンは更新時に 7日トークンへ置き換わる。

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)