### PR TITLE
feat: ログイン時に起動する設定を追加 (#71)

### DIFF
--- a/src/main/ipc/registerHandlers.test.ts
+++ b/src/main/ipc/registerHandlers.test.ts
@@ -9,6 +9,8 @@ const m = vi.hoisted(() => ({
   handlers: new Map<string, (...a: unknown[]) => unknown>(),
   shellOpenExternal: vi.fn(),
   dockHide: vi.fn(),
+  getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
+  setLoginItemSettings: vi.fn(),
   recordActivity: vi.fn(),
   onTimerStarted: vi.fn(),
   onTimerStopped: vi.fn(),
@@ -39,7 +41,11 @@ vi.mock('./handle', () => ({
   },
 }))
 vi.mock('electron', () => ({
-  app: { dock: { hide: m.dockHide } },
+  app: {
+    dock: { hide: m.dockHide },
+    getLoginItemSettings: m.getLoginItemSettings,
+    setLoginItemSettings: m.setLoginItemSettings,
+  },
   shell: { openExternal: m.shellOpenExternal },
 }))
 vi.mock('../notifications/activity', () => ({ recordActivity: m.recordActivity }))
@@ -179,5 +185,15 @@ describe('registerIpcHandlers', () => {
     await invoke('auth:signOut')
     expect(authStore.clearToken).toHaveBeenCalled()
     expect(m.broadcastAuthToAll).toHaveBeenCalled()
+  })
+
+  it('settings:getLaunchAtLogin は OS のログイン項目状態を返す', async () => {
+    m.getLoginItemSettings.mockReturnValue({ openAtLogin: true })
+    expect(await invoke('settings:getLaunchAtLogin')).toBe(true)
+  })
+
+  it('settings:setLaunchAtLogin は OS のログイン項目を設定する', async () => {
+    await invoke('settings:setLaunchAtLogin', true)
+    expect(m.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true })
   })
 })

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -85,6 +85,12 @@ export function registerIpcHandlers(
   handle('settings:getMainProjectCode', () => settingsStore.getMainProjectCode())
   handle('settings:setMainProjectCode', (_, code) => settingsStore.setMainProjectCode(code))
 
+  // startup（ログイン時に起動。OS のログイン項目が真実）
+  handle('settings:getLaunchAtLogin', () => app.getLoginItemSettings().openAtLogin)
+  handle('settings:setLaunchAtLogin', (_, enabled) =>
+    app.setLoginItemSettings({ openAtLogin: enabled })
+  )
+
   // timer signals
   handle('timer:started', () => {
     onTimerStarted(settingsStore)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -47,6 +47,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // settings: integrations
   getWhiteboardSettings: () => invoke('settings:getWhiteboardSettings', undefined),
   setWhiteboardSettings: (enabled: boolean) => invoke('settings:setWhiteboardSettings', { enabled }),
+  getLaunchAtLogin: () => invoke('settings:getLaunchAtLogin', undefined),
+  setLaunchAtLogin: (enabled: boolean) => invoke('settings:setLaunchAtLogin', enabled),
   getBreakBehaviorSettings: () => invoke('settings:getBreakBehaviorSettings', undefined),
   setBreakBehaviorSettings: (behavior: 'stop' | 'pause') => invoke('settings:setBreakBehaviorSettings', { behavior }),
   getMainProjectCode: () => invoke('settings:getMainProjectCode', undefined),

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -15,13 +15,14 @@ import {
 } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-type Section = 'theme' | 'notification' | 'account' | 'analysis'
+type Section = 'theme' | 'notification' | 'account' | 'analysis' | 'startup'
 
 const NAV_ITEMS: { id: Section; label: string }[] = [
   { id: 'theme', label: 'テーマ' },
   { id: 'notification', label: '通知' },
   { id: 'account', label: '連携' },
   { id: 'analysis', label: '分析' },
+  { id: 'startup', label: '起動' },
 ]
 
 const heading = 'mb-2 mt-0 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground'
@@ -39,8 +40,9 @@ export function SettingsView() {
   const [activeSection, setActiveSection] = useState<Section>('theme')
   const {
     activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
-    whiteboardEnabled, breakBehavior, mainProjectCode,
+    whiteboardEnabled, breakBehavior, mainProjectCode, launchAtLogin,
     setTheme, setIdle, setElapsed, setPomodoro, setWhiteboard, setBreakBehavior, setMainProjectCode,
+    setLaunchAtLogin,
   } = useSettings()
 
   return (
@@ -252,6 +254,24 @@ export function SettingsView() {
                     className="h-8 w-32 rounded-md border border-input bg-background px-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                   />
                 </div>
+              </CardContent>
+            </Card>
+          </>
+        )}
+
+        {/* ─── 起動 ─── */}
+        {activeSection === 'startup' && (
+          <>
+            <h2 className={heading}>起動</h2>
+            <Card>
+              <CardContent className="flex items-center justify-between gap-4 px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium">ログイン時に起動</p>
+                  <p className="text-xs text-muted-foreground">
+                    macOS のログイン時に Juice を自動で起動します
+                  </p>
+                </div>
+                <Switch checked={launchAtLogin} onCheckedChange={setLaunchAtLogin} />
               </CardContent>
             </Card>
           </>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -36,6 +36,8 @@ interface ElectronAPI {
   setWhiteboardSettings: (enabled: boolean) => Promise<void>
   getBreakBehaviorSettings: () => Promise<BreakBehaviorSettings>
   setBreakBehaviorSettings: (behavior: 'stop' | 'pause') => Promise<void>
+  getLaunchAtLogin: () => Promise<boolean>
+  setLaunchAtLogin: (enabled: boolean) => Promise<void>
   getMainProjectCode: () => Promise<string>
   setMainProjectCode: (code: string) => Promise<void>
 

--- a/src/renderer/src/hooks/useSettings.test.ts
+++ b/src/renderer/src/hooks/useSettings.test.ts
@@ -16,6 +16,8 @@ const mockGetBreakBehavior = vi.fn()
 const mockSetBreakBehavior = vi.fn()
 const mockGetMainProjectCode = vi.fn()
 const mockSetMainProjectCode = vi.fn()
+const mockGetLaunchAtLogin = vi.fn()
+const mockSetLaunchAtLogin = vi.fn()
 
 vi.mock('../repositories/settingsRepository', () => ({
   settingsRepository: {
@@ -34,6 +36,8 @@ vi.mock('../repositories/settingsRepository', () => ({
     setBreakBehavior: (b: string) => mockSetBreakBehavior(b),
     getMainProjectCode: () => mockGetMainProjectCode(),
     setMainProjectCode: (c: string) => mockSetMainProjectCode(c),
+    getLaunchAtLogin: () => mockGetLaunchAtLogin(),
+    setLaunchAtLogin: (e: boolean) => mockSetLaunchAtLogin(e),
   },
 }))
 
@@ -52,6 +56,7 @@ beforeEach(() => {
   mockGetWhiteboard.mockResolvedValue({ enabled: false })
   mockGetBreakBehavior.mockResolvedValue({ behavior: 'stop' })
   mockGetMainProjectCode.mockResolvedValue('')
+  mockGetLaunchAtLogin.mockResolvedValue(false)
 })
 
 describe('useSettings', () => {
@@ -125,5 +130,19 @@ describe('useSettings', () => {
     act(() => result.current.setMainProjectCode('PJ-9'))
     expect(mockSetMainProjectCode).toHaveBeenCalledWith('PJ-9')
     expect(result.current.mainProjectCode).toBe('PJ-9')
+  })
+
+  it('初期ロードで launchAtLogin を反映する', async () => {
+    mockGetLaunchAtLogin.mockResolvedValue(true)
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.launchAtLogin).toBe(true))
+  })
+
+  it('setLaunchAtLogin で永続化と state を更新する', async () => {
+    const { result } = renderHook(() => useSettings())
+    await waitFor(() => expect(result.current.activeThemeId).toBe('milk'))
+    act(() => result.current.setLaunchAtLogin(true))
+    expect(mockSetLaunchAtLogin).toHaveBeenCalledWith(true)
+    expect(result.current.launchAtLogin).toBe(true)
   })
 })

--- a/src/renderer/src/hooks/useSettings.ts
+++ b/src/renderer/src/hooks/useSettings.ts
@@ -13,6 +13,7 @@ export interface SettingsState {
   whiteboardEnabled: boolean
   breakBehavior: 'stop' | 'pause'
   mainProjectCode: string
+  launchAtLogin: boolean
   setTheme: (themeId: string) => void
   setIdle: (enabled: boolean, minutes: number) => void
   setElapsed: (enabled: boolean, minutes: number) => void
@@ -20,6 +21,7 @@ export interface SettingsState {
   setWhiteboard: (enabled: boolean) => void
   setBreakBehavior: (b: 'stop' | 'pause') => void
   setMainProjectCode: (code: string) => void
+  setLaunchAtLogin: (enabled: boolean) => void
 }
 
 /** 設定画面のオーケストレーション。各設定の読み出し・即時反映・永続化を統括。 */
@@ -33,6 +35,7 @@ export function useSettings(): SettingsState {
   const [whiteboardEnabled, setWhiteboardEnabled] = useState(false)
   const [breakBehavior, setBreakBehaviorState] = useState<'stop' | 'pause'>('stop')
   const [mainProjectCode, setMainProjectCodeState] = useState('')
+  const [launchAtLogin, setLaunchAtLoginState] = useState(false)
 
   useEffect(() => {
     const offThemeChanged = settingsRepository.onThemeChanged(setActiveThemeId)
@@ -53,12 +56,13 @@ export function useSettings(): SettingsState {
     })
     settingsRepository.getBreakBehavior().then(({ behavior }) => setBreakBehaviorState(behavior))
     settingsRepository.getMainProjectCode().then(setMainProjectCodeState)
+    settingsRepository.getLaunchAtLogin().then(setLaunchAtLoginState)
     return offThemeChanged
   }, [])
 
   return {
     activeThemeId, idleEnabled, idleMinutes, elapsedEnabled, elapsedMinutes, pomodoroEnabled,
-    whiteboardEnabled, breakBehavior, mainProjectCode,
+    whiteboardEnabled, breakBehavior, mainProjectCode, launchAtLogin,
 
     setTheme: (themeId): void => {
       // 即時反映（IPC待ちなし）
@@ -91,6 +95,10 @@ export function useSettings(): SettingsState {
     setMainProjectCode: (code): void => {
       setMainProjectCodeState(code)
       settingsRepository.setMainProjectCode(code)
+    },
+    setLaunchAtLogin: (enabled): void => {
+      setLaunchAtLoginState(enabled)
+      settingsRepository.setLaunchAtLogin(enabled)
     },
   }
 }

--- a/src/renderer/src/repositories/settingsRepository.ts
+++ b/src/renderer/src/repositories/settingsRepository.ts
@@ -53,6 +53,13 @@ export const settingsRepository = {
     return window.electronAPI.setMainProjectCode(code)
   },
 
+  getLaunchAtLogin(): Promise<boolean> {
+    return window.electronAPI.getLaunchAtLogin()
+  },
+  setLaunchAtLogin(enabled: boolean): Promise<void> {
+    return window.electronAPI.setLaunchAtLogin(enabled)
+  },
+
   completeSetup(): Promise<void> {
     return window.electronAPI.completeSetup()
   },

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -69,6 +69,8 @@ export interface IpcContract {
   'settings:setWhiteboardSettings': [{ enabled: boolean }, void]
   'settings:getBreakBehaviorSettings': [void, BreakBehaviorSettings]
   'settings:setBreakBehaviorSettings': [{ behavior: 'stop' | 'pause' }, void]
+  'settings:getLaunchAtLogin': [void, boolean]
+  'settings:setLaunchAtLogin': [boolean, void]
 
   // settings: analysis
   'settings:getMainProjectCode': [void, string]


### PR DESCRIPTION
## 対応（#71）
- 設定に新規「起動」セクションを追加し、「ログイン時に起動」トグルを実装
- OS のログイン項目（Electron getLoginItemSettings/setLoginItemSettings）を直接読み書き
- settings.json にフラグは持たない（OS が真実）

対象は macOS。実際のログイン登録は配布版（.app）で有効。

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)