### PR TITLE
feat: 勤怠超過時に超過分を自動調整して送信可能に (#72)

### DIFF
--- a/src/renderer/src/components/Popover/AttendanceReport.test.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { DailyDataProvider } from '../../daily/DailyDataContext'
 import { AttendanceReport } from './AttendanceReport'
 import type { Session } from '../../types/session'
+import { attendanceRepository } from '../../repositories/attendanceRepository'
 
 vi.mock('../../repositories/attendanceRepository', () => ({
   attendanceRepository: { send: vi.fn().mockResolvedValue({ ok: true, status: 200, body: '{}' }) },
@@ -66,5 +67,50 @@ describe('AttendanceReport — 表示行', () => {
     await screen.findByText('09:00')
     expect(container.querySelector('[data-tour="att-copy"]')).not.toBeNull()
     expect(container.querySelector('[data-tour="att-send"]')).not.toBeNull()
+  })
+})
+
+describe('AttendanceReport — 0分タスクの送信確認', () => {
+  beforeEach(() => {
+    vi.mocked(attendanceRepository.send).mockClear()
+  })
+
+  // 実労働 480分（09:00〜18:00 − 休憩60分）。タイマー合計 510分 → 超過30分で
+  // 末尾タスクが 0 分になる。
+  function overageSessions(): Session[] {
+    return [
+      { id: '1', taskId: '1', name: '設計', projectCode: 'P', workCategory: 'C',
+        times: [], date: '2026-06-12', color: '#FF9500', totalTime: 480 },
+      { id: '2', taskId: '2', name: 'レビュー', projectCode: 'P', workCategory: 'C',
+        times: [], date: '2026-06-12', color: '#FF9500', totalTime: 30 },
+    ]
+  }
+
+  it('超過時の送るボタンに調整分が表示される', async () => {
+    render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
+    expect(await screen.findByText('30分を調整して送る')).toBeInTheDocument()
+  })
+
+  it('0分タスクを含む送信は確認ダイアログを出し、確定で送信する', async () => {
+    const { container } = render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
+    const sendBtn = container.querySelector('[data-tour="att-send"]') as HTMLElement
+    await screen.findByText('30分を調整して送る')
+    fireEvent.click(sendBtn)
+    // この時点ではまだ送信されない
+    expect(attendanceRepository.send).not.toHaveBeenCalled()
+    // 確認ダイアログが出る
+    expect(await screen.findByText('0分のタスクが含まれています。本当に送信しますか？')).toBeInTheDocument()
+    // 確定で送信
+    fireEvent.click(screen.getByRole('button', { name: '送信' }))
+    expect(attendanceRepository.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('確認ダイアログをキャンセルすると送信しない', async () => {
+    const { container } = render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
+    const sendBtn = container.querySelector('[data-tour="att-send"]') as HTMLElement
+    await screen.findByText('30分を調整して送る')
+    fireEvent.click(sendBtn)
+    fireEvent.click(await screen.findByRole('button', { name: 'キャンセル' }))
+    expect(attendanceRepository.send).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/Popover/AttendanceReport.test.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.test.tsx
@@ -70,14 +70,14 @@ describe('AttendanceReport — 表示行', () => {
   })
 })
 
-describe('AttendanceReport — 0分タスクの送信確認', () => {
+describe('AttendanceReport — 超過調整時の送信確認', () => {
   beforeEach(() => {
     vi.mocked(attendanceRepository.send).mockClear()
   })
 
   // 実労働 480分（09:00〜18:00 − 休憩60分）。タイマー合計 510分 → 超過30分で
   // 末尾タスクが 0 分になる。
-  function overageSessions(): Session[] {
+  function zeroTaskSessions(): Session[] {
     return [
       { id: '1', taskId: '1', name: '設計', projectCode: 'P', workCategory: 'C',
         times: [], date: '2026-06-12', color: '#FF9500', totalTime: 480 },
@@ -86,27 +86,44 @@ describe('AttendanceReport — 0分タスクの送信確認', () => {
     ]
   }
 
+  // タイマー合計 500分 → 超過20分。1タスクが 480 に減るだけで 0 分タスクは無い。
+  function noZeroOverageSessions(): Session[] {
+    return [
+      { id: '1', taskId: '1', name: '設計', projectCode: 'P', workCategory: 'C',
+        times: [], date: '2026-06-12', color: '#FF9500', totalTime: 500 },
+    ]
+  }
+
   it('超過時の送るボタンは「調整して送る」になる', async () => {
-    render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
+    render(<AttendanceReport sessions={zeroTaskSessions()} today="2026-06-12" />, { wrapper })
     expect(await screen.findByText('調整して送る')).toBeInTheDocument()
   })
 
-  it('0分タスクを含む送信は確認ダイアログを出し、確定で送信する', async () => {
-    const { container } = render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
+  it('超過調整がある送信は確認ダイアログを出し、確定で送信する', async () => {
+    const { container } = render(<AttendanceReport sessions={zeroTaskSessions()} today="2026-06-12" />, { wrapper })
     const sendBtn = container.querySelector('[data-tour="att-send"]') as HTMLElement
     await screen.findByText('調整して送る')
     fireEvent.click(sendBtn)
     // この時点ではまだ送信されない
     expect(attendanceRepository.send).not.toHaveBeenCalled()
     // 確認ダイアログが出る
-    expect(await screen.findByText('0分のタスクが含まれています。本当に送信しますか？')).toBeInTheDocument()
+    expect(await screen.findByText('超過分を調整して送信します。よろしいですか？')).toBeInTheDocument()
     // 確定で送信
     fireEvent.click(screen.getByRole('button', { name: '送信' }))
     expect(attendanceRepository.send).toHaveBeenCalledTimes(1)
   })
 
+  it('0分タスクが無い超過調整でも確認ダイアログを出す', async () => {
+    const { container } = render(<AttendanceReport sessions={noZeroOverageSessions()} today="2026-06-12" />, { wrapper })
+    const sendBtn = container.querySelector('[data-tour="att-send"]') as HTMLElement
+    await screen.findByText('調整して送る')
+    fireEvent.click(sendBtn)
+    expect(attendanceRepository.send).not.toHaveBeenCalled()
+    expect(await screen.findByText('超過分を調整して送信します。よろしいですか？')).toBeInTheDocument()
+  })
+
   it('確認ダイアログをキャンセルすると送信しない', async () => {
-    const { container } = render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
+    const { container } = render(<AttendanceReport sessions={zeroTaskSessions()} today="2026-06-12" />, { wrapper })
     const sendBtn = container.querySelector('[data-tour="att-send"]') as HTMLElement
     await screen.findByText('調整して送る')
     fireEvent.click(sendBtn)

--- a/src/renderer/src/components/Popover/AttendanceReport.test.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.test.tsx
@@ -86,15 +86,15 @@ describe('AttendanceReport — 0分タスクの送信確認', () => {
     ]
   }
 
-  it('超過時の送るボタンに調整分が表示される', async () => {
+  it('超過時の送るボタンは「調整して送る」になる', async () => {
     render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
-    expect(await screen.findByText('30分を調整して送る')).toBeInTheDocument()
+    expect(await screen.findByText('調整して送る')).toBeInTheDocument()
   })
 
   it('0分タスクを含む送信は確認ダイアログを出し、確定で送信する', async () => {
     const { container } = render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
     const sendBtn = container.querySelector('[data-tour="att-send"]') as HTMLElement
-    await screen.findByText('30分を調整して送る')
+    await screen.findByText('調整して送る')
     fireEvent.click(sendBtn)
     // この時点ではまだ送信されない
     expect(attendanceRepository.send).not.toHaveBeenCalled()
@@ -108,7 +108,7 @@ describe('AttendanceReport — 0分タスクの送信確認', () => {
   it('確認ダイアログをキャンセルすると送信しない', async () => {
     const { container } = render(<AttendanceReport sessions={overageSessions()} today="2026-06-12" />, { wrapper })
     const sendBtn = container.querySelector('[data-tour="att-send"]') as HTMLElement
-    await screen.findByText('30分を調整して送る')
+    await screen.findByText('調整して送る')
     fireEvent.click(sendBtn)
     fireEvent.click(await screen.findByRole('button', { name: 'キャンセル' }))
     expect(attendanceRepository.send).not.toHaveBeenCalled()

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -159,7 +159,7 @@ export function AttendanceReport({ sessions, today }: Props) {
                 disabled={sending || !canSend}
               >
                 {overageMinutes !== null
-                  ? <><WarningTriangle width={14} height={14} /> {overageMinutes}分を調整して送る</>
+                  ? <><WarningTriangle width={14} height={14} /> 調整して送る</>
                   : sending
                     ? '送信中...'
                     : sendResult === 'success'

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -32,9 +32,9 @@ export function AttendanceReport({ sessions, today }: Props) {
   const [dialogValue, setDialogValue] = useState('')
   const [confirmingSend, setConfirmingSend] = useState(false)
 
-  // 0 分タスクを含む場合のみ確認を挟む。それ以外は即送信。
+  // 超過調整がある場合は確認を挟む。それ以外は即送信。
   function handleSendClick(): void {
-    if (hasZeroTask) setConfirmingSend(true)
+    if (overageMinutes !== null) setConfirmingSend(true)
     else void send()
   }
 
@@ -185,7 +185,10 @@ export function AttendanceReport({ sessions, today }: Props) {
       <Dialog open={confirmingSend} onOpenChange={open => { if (!open) setConfirmingSend(false) }}>
         <DialogContent className="max-w-[280px]" aria-describedby={undefined}>
           <DialogTitle>送信確認</DialogTitle>
-          <p className="text-sm text-muted-foreground">0分のタスクが含まれています。本当に送信しますか？</p>
+          <p className="text-sm text-muted-foreground">
+            <span>超過分を調整して送信します。よろしいですか？</span>
+            {hasZeroTask && <><br />0分になるタスクがあります。</>}
+          </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmingSend(false)}>キャンセル</Button>
             <Button onClick={() => { setConfirmingSend(false); void send() }}>送信</Button>

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -25,11 +25,18 @@ export function AttendanceReport({ sessions, today }: Props) {
     breakMinutes, setBreakMinutes,
     workStart, setWorkStart,
     workEnd, setWorkEnd,
-    text, overageMinutes, canSend, copied, sending, sendResult, copy, send,
+    text, overageMinutes, hasZeroTask, canSend, copied, sending, sendResult, copy, send,
   } = useAttendanceReport(sessions, today)
 
   const [editField, setEditField] = useState<EditField | null>(null)
   const [dialogValue, setDialogValue] = useState('')
+  const [confirmingSend, setConfirmingSend] = useState(false)
+
+  // 0 分タスクを含む場合のみ確認を挟む。それ以外は即送信。
+  function handleSendClick(): void {
+    if (hasZeroTask) setConfirmingSend(true)
+    else void send()
+  }
 
   function openDialog(field: EditField): void {
     setEditField(field)
@@ -147,12 +154,12 @@ export function AttendanceReport({ sessions, today }: Props) {
                         ? 'bg-[linear-gradient(135deg,#ef4444,#dc2626)]'
                         : 'bg-[linear-gradient(135deg,#3b82f6,#2563eb)] shadow-[0_4px_12px_rgba(59,130,246,0.3)] hover:shadow-[0_6px_16px_rgba(59,130,246,0.4)]'
                 }`}
-                onClick={send}
+                onClick={handleSendClick}
                 data-tour="att-send"
-                disabled={sending || !canSend || overageMinutes !== null}
+                disabled={sending || !canSend}
               >
                 {overageMinutes !== null
-                  ? <><WarningTriangle width={14} height={14} /> {overageMinutes}分超過</>
+                  ? <><WarningTriangle width={14} height={14} /> {overageMinutes}分を調整して送る</>
                   : sending
                     ? '送信中...'
                     : sendResult === 'success'
@@ -165,11 +172,22 @@ export function AttendanceReport({ sessions, today }: Props) {
               </button>
             </TooltipTrigger>
             {overageMinutes !== null && (
-              <TooltipContent>作業時間が実稼働時間を超過しています</TooltipContent>
+              <TooltipContent>タイマー合計が実労働時間を超過したため、超過分を自動調整しました（一部タスクが0分になります）</TooltipContent>
             )}
           </Tooltip>
         </TooltipProvider>
       </div>
+
+      <Dialog open={confirmingSend} onOpenChange={open => { if (!open) setConfirmingSend(false) }}>
+        <DialogContent className="max-w-[280px]" aria-describedby={undefined}>
+          <DialogTitle>送信確認</DialogTitle>
+          <p className="text-sm text-muted-foreground">0分のタスクが含まれています。本当に送信しますか？</p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmingSend(false)}>キャンセル</Button>
+            <Button onClick={() => { setConfirmingSend(false); void send() }}>送信</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   )
 }

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -174,7 +174,8 @@ export function AttendanceReport({ sessions, today }: Props) {
             {overageMinutes !== null && (
               <TooltipContent className="text-center">
                 タイマー合計が実労働時間を超過したため、<br />
-                超過分を自動調整しました（一部タスクが0分になります）
+                超過分を自動調整しました<br />
+                （一部タスクが0分になります）
               </TooltipContent>
             )}
           </Tooltip>

--- a/src/renderer/src/components/Popover/AttendanceReport.tsx
+++ b/src/renderer/src/components/Popover/AttendanceReport.tsx
@@ -172,7 +172,10 @@ export function AttendanceReport({ sessions, today }: Props) {
               </button>
             </TooltipTrigger>
             {overageMinutes !== null && (
-              <TooltipContent>タイマー合計が実労働時間を超過したため、超過分を自動調整しました（一部タスクが0分になります）</TooltipContent>
+              <TooltipContent className="text-center">
+                タイマー合計が実労働時間を超過したため、<br />
+                超過分を自動調整しました（一部タスクが0分になります）
+              </TooltipContent>
             )}
           </Tooltip>
         </TooltipProvider>

--- a/src/renderer/src/domain/attendance.test.ts
+++ b/src/renderer/src/domain/attendance.test.ts
@@ -52,25 +52,38 @@ describe('buildAttendanceText', () => {
     expect(overageMinutes).toBeNull()
   })
 
-  it('タイマー合計が実労働時間を超える場合は自動調整せず overageMinutes を返す', () => {
+  it('タイマー合計が実労働時間を超える場合は末尾タスクから超過分を減算する', () => {
     // 勤務: 09:00〜12:00 = 180分, 休憩0分 → 実労働180分
-    // タイマー合計: 200分, 超過: 20分
+    // タイマー合計: 200分, 超過: 20分 → 200-20=180
     const sessions = [makeSession({ totalTime: 200 })]
-    const { text, overageMinutes } = buildAttendanceText(sessions, '09:00', '12:00', 0)
-    expect(text).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 200')
+    const { text, overageMinutes, hasZeroTask } = buildAttendanceText(sessions, '09:00', '12:00', 0)
+    expect(text).toBe('勤怠\n09:00 12:00 0\nZZ テスト作業 設計 180')
     expect(overageMinutes).toBe(20)
+    expect(hasZeroTask).toBe(false)
   })
 
-  it('複数タスクで超過している場合もすべてのタスクがそのまま残る', () => {
+  it('複数タスクで超過する場合は末尾から繰り上げ減算し、0分タスクは残す', () => {
     // 勤務: 09:00〜12:00 = 180分, 休憩30分 → 実労働150分
-    // タイマー合計: 180+60=240分, 超過: 90分 → 全タスク維持
+    // タイマー合計: 180+60=240分, 超過: 90分
+    // → 1on1: 60-90 → 0（残30繰上げ）, 社内MTG: 180-30 → 150
     const sessions = [
       makeSession({ id: 'a', taskId: 't1', name: '社内MTG', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 180 }),
       makeSession({ id: 'b', taskId: 't2', name: '1on1', projectCode: 'ZZ', workCategory: '打合せ', totalTime: 60 }),
     ]
-    const { text, overageMinutes } = buildAttendanceText(sessions, '09:00', '12:00', 30)
-    expect(text).toBe('勤怠\n09:00 12:00 30\nZZ 社内MTG 打合せ 180\nZZ 1on1 打合せ 60')
+    const { text, overageMinutes, hasZeroTask } = buildAttendanceText(sessions, '09:00', '12:00', 30)
+    expect(text).toBe('勤怠\n09:00 12:00 30\nZZ 社内MTG 打合せ 150\nZZ 1on1 打合せ 0')
     expect(overageMinutes).toBe(90)
+    expect(hasZeroTask).toBe(true)
+  })
+
+  it('超過分が全タスク合計を超える異常時は全タスクを0にクランプする', () => {
+    // 勤務: 09:00〜09:00 = 0分, 休憩60分 → 実労働-60分
+    // タイマー合計: 30分, 超過: 90分 → タスク0、残60は破棄
+    const sessions = [makeSession({ totalTime: 30 })]
+    const { text, overageMinutes, hasZeroTask } = buildAttendanceText(sessions, '09:00', '09:00', 60)
+    expect(text).toBe('勤怠\n09:00 09:00 60\nZZ テスト作業 設計 0')
+    expect(overageMinutes).toBe(90)
+    expect(hasZeroTask).toBe(true)
   })
 
   it('totalTimeが0のセッションはスキップする', () => {

--- a/src/renderer/src/domain/attendance.ts
+++ b/src/renderer/src/domain/attendance.ts
@@ -27,9 +27,11 @@ export interface AttendanceTextResult {
   text: string
   /**
    * タイマー合計が実労働時間を超えた分数。超過がなければ null。
-   * 超過時は自動調整せずこの値を警告として UI に表示する。
+   * 超過時はこの分を末尾タスクから減算済み。値は UI の情報表示に使う。
    */
   overageMinutes: number | null
+  /** 超過調整の結果、0 分のタスクが出力に含まれるか */
+  hasZeroTask: boolean
 }
 
 /** 勤怠報告テキストを生成する */
@@ -63,7 +65,8 @@ export function buildAttendanceText(
 
   // 勤務時間から休憩を引いた実労働時間とタイマー合計を比較する。
   // - プラス差分（計測漏れ）: 最後のタスクに加算して合計を実労働時間に合わせる
-  // - マイナス差分（タイマー超過）: 自動調整せず overageMinutes として返す
+  // - マイナス差分（タイマー超過）: 超過分を末尾タスクから順に減算（繰り上げ）し、
+  //   合計を実労働時間に合わせる。0 分になったタスクは消さず残す。
   if (groups.length > 0 && workStart && workEnd) {
     const startMin = parseHHMM(workStart)
     const endMin = parseHHMM(workEnd)
@@ -75,9 +78,19 @@ export function buildAttendanceText(
         groups[groups.length - 1].totalMinutes += diff
       } else if (diff < 0) {
         overageMinutes = -diff
+        // 末尾から順に減算し、引ききれない分は手前のタスクへ繰り上げる。
+        // 各タスクは 0 でクランプ（合計が全タスク分を超える異常時は全タスク 0）。
+        let remaining = overageMinutes
+        for (let i = groups.length - 1; i >= 0 && remaining > 0; i--) {
+          const reduce = Math.min(groups[i].totalMinutes, remaining)
+          groups[i].totalMinutes -= reduce
+          remaining -= reduce
+        }
       }
     }
   }
+
+  const hasZeroTask = groups.some(g => g.totalMinutes === 0)
 
   const timeLine = `${workStart ?? ''} ${workEnd ?? ''} ${breakMinutes}`
   const taskLines = groups.map(g => `${g.projectCode} ${g.name} ${g.workCategory} ${g.totalMinutes}`)
@@ -85,5 +98,6 @@ export function buildAttendanceText(
   return {
     text: ['勤怠', timeLine, ...taskLines].join('\n'),
     overageMinutes,
+    hasZeroTask,
   }
 }

--- a/src/renderer/src/hooks/useAttendanceReport.ts
+++ b/src/renderer/src/hooks/useAttendanceReport.ts
@@ -15,6 +15,8 @@ export interface AttendanceReportState {
   text: string
   /** タイマー合計が実労働時間を超えた分数。超過なければ null */
   overageMinutes: number | null
+  /** 超過調整の結果、0 分のタスクが含まれるか */
+  hasZeroTask: boolean
   canSend: boolean
   copied: boolean
   sending: boolean
@@ -54,7 +56,7 @@ export function useAttendanceReport(sessions: Session[], today: string): Attenda
   const [sendResult, setSendResult] = useState<'success' | 'auth' | 'error' | null>(null)
 
   const orderedSessions = orderSessions(sessions, day?.sessionOrder ?? null)
-  const { text, overageMinutes } = buildAttendanceText(orderedSessions, workStart, workEnd, breakMinutes)
+  const { text, overageMinutes, hasZeroTask } = buildAttendanceText(orderedSessions, workStart, workEnd, breakMinutes)
 
   const canSend = isValidWorkTime(workStart) && isValidWorkTime(workEnd) && sessions.length > 0
 
@@ -86,5 +88,5 @@ export function useAttendanceReport(sessions: Session[], today: string): Attenda
     }
   }
 
-  return { breakMinutes, setBreakMinutes, workStart, setWorkStart, workEnd, setWorkEnd, text, overageMinutes, canSend, copied, sending, sendResult, copy, send }
+  return { breakMinutes, setBreakMinutes, workStart, setWorkStart, workEnd, setWorkEnd, text, overageMinutes, hasZeroTask, canSend, copied, sending, sendResult, copy, send }
 }


### PR DESCRIPTION
## やったこと
- タイマー合計が実労働時間を超えた場合、超過分を末尾タスクから繰り上げ減算
- 0分になったタスクは消さず一覧に残す
- 超過でも送信可能に（ボタン文言「{X}分を調整して送る」）
- 0分タスクを含む送信は確認ダイアログを表示

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)