### PR TITLE
feat: 週次分析で過去の勤怠未入力日を「休」表示に (#69)

### DIFF
--- a/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
+++ b/src/renderer/src/components/Calendar/WeeklyAnalysisModal.tsx
@@ -40,14 +40,16 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
               <tr>
                 <td className="py-[5px] text-muted-foreground whitespace-nowrap">所定(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums">{d.scheduledMinutes}</td>
+                  <td key={d.date} className={`py-[5px] text-center tabular-nums${d.isOff ? ' text-muted-foreground' : ''}`}>
+                    {d.isOff ? '休' : d.scheduledMinutes}
+                  </td>
                 ))}
                 <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
               <tr>
                 <td className="py-[5px] text-muted-foreground whitespace-nowrap">実稼働(分)</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center tabular-nums">{fmt(d.actualMinutes)}</td>
+                  <td key={d.date} className={`py-[5px] text-center tabular-nums${d.isOff ? ' text-muted-foreground' : ''}`}>{fmt(d.actualMinutes)}</td>
                 ))}
                 <td className="py-[5px] text-center text-muted-foreground">—</td>
               </tr>
@@ -68,7 +70,7 @@ export function WeeklyAnalysisModal({ date, onClose }: Props) {
               <tr className="font-semibold">
                 <td className="py-[5px] whitespace-nowrap">稼働率</td>
                 {analysis.days.map(d => (
-                  <td key={d.date} className="py-[5px] text-center text-[9px] tabular-nums text-[var(--accent)]">
+                  <td key={d.date} className={`py-[5px] text-center text-[9px] tabular-nums ${d.isOff ? 'text-muted-foreground' : 'text-[var(--accent)]'}`}>
                     {fmt(d.utilizationRate, '%')}
                   </td>
                 ))}

--- a/src/renderer/src/hooks/useWeeklyAnalysis.test.ts
+++ b/src/renderer/src/hooks/useWeeklyAnalysis.test.ts
@@ -70,9 +70,11 @@ describe('buildDayAnalysis', () => {
     },
   ]
 
+  const TODAY = '2026-06-28'
+
   it('各指標を正しく計算する', () => {
     const record: DayRecord = { workStart: '09:00', workEnd: '18:00', breakMinutes: 60 }
-    const result = buildDayAnalysis('2026-06-23', '火', record, sessions, 'MAIN')
+    const result = buildDayAnalysis('2026-06-23', '火', record, sessions, 'MAIN', TODAY)
     expect(result.scheduledMinutes).toBe(480)
     expect(result.actualMinutes).toBe(480)
     expect(result.nonProjectMinutes).toBe(90)   // projectCode !== 'MAIN'
@@ -82,13 +84,34 @@ describe('buildDayAnalysis', () => {
 
   it('mainProjectCode が空のとき nonProjectMinutes は 0', () => {
     const record: DayRecord = { workStart: '09:00', workEnd: '18:00', breakMinutes: 60 }
-    const result = buildDayAnalysis('2026-06-23', '火', record, sessions, '')
+    const result = buildDayAnalysis('2026-06-23', '火', record, sessions, '', TODAY)
     expect(result.nonProjectMinutes).toBe(0)
   })
 
   it('actualMinutes が null のとき utilizationRate も null', () => {
-    const result = buildDayAnalysis('2026-06-23', '火', null, sessions, 'MAIN')
+    const result = buildDayAnalysis('2026-06-23', '火', null, sessions, 'MAIN', TODAY)
     expect(result.actualMinutes).toBeNull()
     expect(result.utilizationRate).toBeNull()
+  })
+
+  it('今日より前で勤怠未入力なら isOff は true（休扱い）', () => {
+    const result = buildDayAnalysis('2026-06-23', '火', null, sessions, 'MAIN', TODAY)
+    expect(result.isOff).toBe(true)
+  })
+
+  it('今日より前でも勤怠入力があれば isOff は false', () => {
+    const record: DayRecord = { workStart: '09:00', workEnd: '18:00', breakMinutes: 60 }
+    const result = buildDayAnalysis('2026-06-23', '火', record, sessions, 'MAIN', TODAY)
+    expect(result.isOff).toBe(false)
+  })
+
+  it('今日の未入力日は isOff false（未確定なので 480 のまま）', () => {
+    const result = buildDayAnalysis(TODAY, '日', null, sessions, 'MAIN', TODAY)
+    expect(result.isOff).toBe(false)
+  })
+
+  it('未来の未入力日は isOff false', () => {
+    const result = buildDayAnalysis('2026-07-01', '水', null, sessions, 'MAIN', TODAY)
+    expect(result.isOff).toBe(false)
   })
 })

--- a/src/renderer/src/hooks/useWeeklyAnalysis.ts
+++ b/src/renderer/src/hooks/useWeeklyAnalysis.ts
@@ -14,6 +14,8 @@ export interface DayAnalysis {
   nonProjectMinutes: number
   unexpectedMinutes: number
   utilizationRate: number | null
+  /** 今日より前で勤怠未入力の日（集計対象外＝「休」扱い） */
+  isOff: boolean
 }
 
 export interface WeeklyAnalysis {
@@ -64,6 +66,7 @@ export function buildDayAnalysis(
   record: DayRecord | null,
   sessions: Session[],
   mainProjectCode: string,
+  today: string,
 ): DayAnalysis {
   const actualMinutes = calcActualMinutes(record)
   const nonProjectMinutes = mainProjectCode
@@ -75,7 +78,8 @@ export function buildDayAnalysis(
   const utilizationRate = actualMinutes !== null
     ? Math.round(actualMinutes / 480 * 100)
     : null
-  return { date, dayLabel, scheduledMinutes: 480, actualMinutes, nonProjectMinutes, unexpectedMinutes, utilizationRate }
+  const isOff = actualMinutes === null && date < today
+  return { date, dayLabel, scheduledMinutes: 480, actualMinutes, nonProjectMinutes, unexpectedMinutes, utilizationRate, isOff }
 }
 
 /** 選択日を含む週の稼働分析データを返すフック */
@@ -100,12 +104,15 @@ export function useWeeklyAnalysis(date: string | null): { analysis: WeeklyAnalys
       const allSessions = (results.slice(0, months.length) as Session[][]).flat()
       const mainProjectCode = results[months.length] as string
 
+      const now = new Date()
+      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+
       const days = weekdays.map(d => {
         const dow = new Date(`${d}T00:00:00`).getDay()
         const dayLabel = DAY_LABELS[dow]
         const record = daily.getDay(d)
         const daySessions = allSessions.filter(s => s.date === d)
-        return buildDayAnalysis(d, dayLabel, record, daySessions, mainProjectCode)
+        return buildDayAnalysis(d, dayLabel, record, daySessions, mainProjectCode, today)
       })
 
       const validRates = days.map(d => d.utilizationRate).filter((r): r is number => r !== null)


### PR DESCRIPTION
## 概要
週次分析モーダルで、過去の勤怠未入力日が稼働率の集計対象外であることを表示で分かるようにした。

## 変更点
- 今日より前の勤怠未入力日は所定欄に `480` ではなく `休` を表示し、所定/実稼働/稼働率の列をグレーアウト
- 今日・未来の未入力日は未確定のため `480` のまま
- 稼働率の週平均ロジックは変更なし（元々 `utilizationRate === null` の日は分母から除外）

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)