### PR TITLE
refactor: SessionList を WorkTimeBar/SessionItem/SessionContextMenu に分解 (#85)

### DIFF
--- a/src/renderer/src/components/Popover/SessionContextMenu.tsx
+++ b/src/renderer/src/components/Popover/SessionContextMenu.tsx
@@ -1,0 +1,39 @@
+import type { RefObject } from 'react'
+import type { ContextMenuState } from '../../hooks/useContextMenu'
+import { EditPencil, Trash, Timer } from 'iconoir-react'
+
+interface Props {
+  menu: ContextMenuState
+  menuRef: RefObject<HTMLDivElement | null>
+  onAdd: () => void
+  onEdit: (sessionId: string) => void
+  onDelete: (sessionId: string) => void
+}
+
+const itemClass = 'flex w-full cursor-pointer items-center gap-1.5 rounded-[6px] border-0 bg-transparent px-3 py-2 text-left text-[13px] transition-colors duration-200 hover:bg-accent'
+
+/** セッション右クリック時のフローティングメニュー。位置補正は useContextMenu が行う。 */
+export function SessionContextMenu({ menu, menuRef, onAdd, onEdit, onDelete }: Props) {
+  return (
+    <div
+      ref={menuRef}
+      data-context-menu
+      className="fixed z-[1000] min-w-[120px] rounded-[8px] border border-border bg-card p-1 shadow-[var(--shadow-elevated)]"
+      style={{ left: menu.x, top: menu.y }}
+    >
+      <button className={`${itemClass} text-foreground`} onMouseDown={e => e.preventDefault()} onClick={onAdd}>
+        <Timer width={14} height={14} /> 追加
+      </button>
+      {menu.sessionId !== '' && (
+        <>
+          <button className={`${itemClass} text-foreground`} onMouseDown={e => e.preventDefault()} onClick={() => onEdit(menu.sessionId)}>
+            <EditPencil width={14} height={14} /> 編集
+          </button>
+          <button className={`${itemClass} text-[#e74c3c]`} onMouseDown={e => e.preventDefault()} onClick={() => onDelete(menu.sessionId)}>
+            <Trash width={14} height={14} /> 流す
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/Popover/SessionItem.tsx
+++ b/src/renderer/src/components/Popover/SessionItem.tsx
@@ -1,0 +1,75 @@
+import type { DragEvent, MouseEvent } from 'react'
+import type { Session } from '../../types/session'
+import { resolveJuiceColor } from '../../domain/colors'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
+import { Play } from 'iconoir-react'
+
+interface Props {
+  session: Session
+  isRunning?: boolean
+  expanded: boolean
+  dragOver: boolean
+  onStartMore?: (session: Session) => void
+  onToggleExpand: () => void
+  onEditStart: () => void
+  onContextMenu: (e: MouseEvent) => void
+  onDragStart: (e: DragEvent) => void
+  onDragOver: (e: DragEvent) => void
+  onDragLeave: () => void
+  onDragEnd: () => void
+}
+
+// クリック/ダブルクリックを行全体で拾うが、内部のボタン・入力・リストボックス上では無視する
+const isInteractiveTarget = (e: MouseEvent): boolean =>
+  Boolean((e.target as HTMLElement).closest('button, input, [role="listbox"]'))
+
+/** セッションリストの1行。展開状態・ドラッグ状態の見た目と、行ごとの操作を担う。 */
+export function SessionItem({
+  session, isRunning, expanded, dragOver, onStartMore,
+  onToggleExpand, onEditStart, onContextMenu,
+  onDragStart, onDragOver, onDragLeave, onDragEnd,
+}: Props) {
+  return (
+    <TooltipProvider delayDuration={450}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <li
+            data-session-item
+            draggable
+            className={`group flex cursor-grab items-start gap-2 rounded-[8px] border bg-card px-2.5 py-2 transition-all duration-200 hover:bg-accent active:cursor-grabbing ${expanded ? 'bg-accent' : ''} ${dragOver ? 'border-[var(--accent)] shadow-[0_0_0_2px_var(--accent-light)]' : 'border-border'}`}
+            onClick={e => { if (!isInteractiveTarget(e)) onToggleExpand() }}
+            onDoubleClick={e => { if (!isInteractiveTarget(e)) onEditStart() }}
+            onContextMenu={onContextMenu}
+            onDragStart={onDragStart}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            onDragEnd={onDragEnd}
+          >
+            <span className="mt-[3px] h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: resolveJuiceColor(session.color) }} aria-hidden="true" />
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-medium text-foreground transition-colors group-hover:text-[var(--accent)]">{session.name}</span>
+              {(session.projectCode || session.workCategory) && (
+                <div className="mt-px flex flex-wrap gap-1">
+                  {session.projectCode && <span className="rounded-[6px] border border-border bg-muted px-1.5 text-[11px] leading-[1.6] text-muted-foreground">{session.projectCode}</span>}
+                  {session.workCategory && <span className="rounded-[6px] border border-border bg-muted px-1.5 text-[11px] leading-[1.6] text-muted-foreground">{session.workCategory}</span>}
+                </div>
+              )}
+            </div>
+            <span className="shrink-0 text-[13px] font-semibold text-[var(--accent)]">{session.totalTime}分</span>
+            {!isRunning && onStartMore && (
+              <TooltipProvider delayDuration={450}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button className="shrink-0 cursor-pointer border-0 bg-transparent px-1 py-0.5 text-[13px] font-semibold text-[#26de81] opacity-0 transition-opacity focus:opacity-100 group-hover:opacity-100" onClick={() => onStartMore(session)} aria-label="追加で注ぐ"><Play width={14} height={14} /></button>
+                  </TooltipTrigger>
+                  <TooltipContent>追加で注ぐ</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </li>
+        </TooltipTrigger>
+        <TooltipContent>ダブルクリックで編集・右クリックで操作</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/renderer/src/components/Popover/SessionList.tsx
+++ b/src/renderer/src/components/Popover/SessionList.tsx
@@ -1,23 +1,19 @@
 import { useState, useEffect } from 'react'
 import type { Session } from '../../types/session'
-import { formatLocalDate, formatTimeFromDate, orderSessions } from '../../../../shared/sessionUtils'
+import { formatLocalDate, orderSessions } from '../../../../shared/sessionUtils'
 import { applySessionEdit } from '../../domain/session'
 import { useDailyData } from '../../daily/DailyDataContext'
 import { ConfirmDialog } from '../ConfirmDialog/ConfirmDialog'
 import { PageIndicator } from '../PageIndicator/PageIndicator'
 import { SessionFormDialog, type SessionFormValues } from './SessionFormDialog'
+import { SessionItem } from './SessionItem'
+import { SessionContextMenu } from './SessionContextMenu'
+import { WorkTimeBar } from './WorkTimeBar'
 import { useContextMenu } from '../../hooks/useContextMenu'
 import { useExpandedItem } from '../../hooks/useExpandedItem'
 import { usePagination } from '../../hooks/usePagination'
 import { useDragReorder } from '../../hooks/useDragReorder'
 import { EMPTY_SUGGESTIONS, type Suggestions } from '../../domain/suggestions'
-import { TimeField } from '@/components/ui/time-field'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
-import { resolveJuiceColor } from '../../domain/colors'
-import { Dialog, DialogContent, DialogTitle, DialogFooter } from '@/components/ui/dialog'
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
-import { Play, EditPencil, Trash, Timer } from 'iconoir-react'
 
 interface Props {
   sessions: Session[]
@@ -45,15 +41,13 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
   const daily = useDailyData()
   useEffect(() => { daily.ensureMonth(todayKey.slice(0, 7)) }, [todayKey, daily])
 
-  const [endPickerOpen, setEndPickerOpen] = useState(false)
-  const [timePickerValue, setTimePickerValue] = useState('')
   const [addDialogOpen, setAddDialogOpen] = useState(false)
   // 追加ダイアログは毎回空で開く（過去の入力は候補機能で呼び出せるため下書きは保持しない）
   const [addDraft, setAddDraft] = useState<SessionFormValues>(EMPTY_FORM)
   // 編集ダイアログ。開くたびに対象セッションの値で初期化する
   const [editTargetId, setEditTargetId] = useState<string | null>(null)
   const [editDraft, setEditDraft] = useState<SessionFormValues>(EMPTY_FORM)
-  // 時刻編集ダイアログ。区間を持つ完了済みセッションのみ対象
+  // 削除確認ダイアログの対象セッション
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
 
   const { contextMenu, setContextMenu, contextMenuRef } = useContextMenu()
@@ -96,16 +90,6 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
     if (!addDraft.name.trim() || !addDraft.totalTime) return
     onAdd?.({ ...addDraft, name: addDraft.name.trim() })
     setAddDialogOpen(false)
-  }
-
-  const handleWorkEnd = () => {
-    setTimePickerValue(formatTimeFromDate(new Date()))
-    setEndPickerOpen(true)
-  }
-
-  const handleTimePickerConfirm = () => {
-    onWorkEnd?.(timePickerValue)
-    setEndPickerOpen(false)
   }
 
   const handleEditStart = (session: Session) => {
@@ -151,26 +135,6 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
         setContextMenu({ sessionId: '', x: e.clientX, y: e.clientY })
       }}
     >
-      <Dialog open={endPickerOpen} onOpenChange={open => { if (!open) setEndPickerOpen(false) }}>
-        <DialogContent className="max-w-[220px]" aria-describedby={undefined}>
-          <DialogTitle>業務終了時刻</DialogTitle>
-          <div onKeyDown={e => { if (e.key === 'Enter') handleTimePickerConfirm() }}>
-            <TimeField
-              aria-label="業務終了時刻"
-              className="h-11 w-full justify-center text-xl"
-              value={timePickerValue}
-              onChange={setTimePickerValue}
-              autoFocus
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEndPickerOpen(false)}>キャンセル</Button>
-            <Button onClick={handleTimePickerConfirm}>確定</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-
       {sessions.length === 0 ? (
         <div className="m-0 flex-1 py-6 text-center text-[var(--text-muted)]">
           <p className="m-0 text-[13px]">まだジュースを注いでいません</p>
@@ -190,128 +154,58 @@ export function SessionList({ sessions, today, isRunning, onStartMore, onUpdate,
           }}
         >
           {pagedSessions.map(session => (
-            <TooltipProvider key={session.id} delayDuration={450}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-            <li
-              data-session-item
-              draggable
-              className={`group flex cursor-grab items-start gap-2 rounded-[8px] border bg-card px-2.5 py-2 transition-all duration-200 hover:bg-accent active:cursor-grabbing ${expandedId === session.id ? 'bg-accent' : ''} ${dragOverId === session.id ? 'border-[var(--accent)] shadow-[0_0_0_2px_var(--accent-light)]' : 'border-border'}`}
-              onClick={(e) => {
-                if ((e.target as HTMLElement).closest('button, input, [role="listbox"]')) return
-                setExpandedId(prev => prev === session.id ? null : session.id)
-              }}
-              onDoubleClick={(e) => {
-                if ((e.target as HTMLElement).closest('button, input, [role="listbox"]')) return
-                handleEditStart(session)
-              }}
+            <SessionItem
+              key={session.id}
+              session={session}
+              isRunning={isRunning}
+              expanded={expandedId === session.id}
+              dragOver={dragOverId === session.id}
+              onStartMore={onStartMore}
+              onToggleExpand={() => setExpandedId(prev => prev === session.id ? null : session.id)}
+              onEditStart={() => handleEditStart(session)}
               onContextMenu={e => {
                 e.preventDefault()
                 e.stopPropagation()
                 setContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY })
               }}
-              onDragStart={(e) => handleDragStart(e, session.id)}
-              onDragOver={(e) => handleDragOver(e, session.id)}
+              onDragStart={e => handleDragStart(e, session.id)}
+              onDragOver={e => handleDragOver(e, session.id)}
               onDragLeave={handleDragLeave}
               onDragEnd={handleDragEnd}
-            >
-              <span className="mt-[3px] h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: resolveJuiceColor(session.color) }} aria-hidden="true" />
-              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                <span className="overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-medium text-foreground transition-colors group-hover:text-[var(--accent)]">{session.name}</span>
-                {(session.projectCode || session.workCategory) && (
-                  <div className="mt-px flex flex-wrap gap-1">
-                    {session.projectCode && <span className="rounded-[6px] border border-border bg-muted px-1.5 text-[11px] leading-[1.6] text-muted-foreground">{session.projectCode}</span>}
-                    {session.workCategory && <span className="rounded-[6px] border border-border bg-muted px-1.5 text-[11px] leading-[1.6] text-muted-foreground">{session.workCategory}</span>}
-                  </div>
-                )}
-              </div>
-              <span className="shrink-0 text-[13px] font-semibold text-[var(--accent)]">{session.totalTime}分</span>
-              {!isRunning && onStartMore && (
-                <TooltipProvider delayDuration={450}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button className="shrink-0 cursor-pointer border-0 bg-transparent px-1 py-0.5 text-[13px] font-semibold text-[#26de81] opacity-0 transition-opacity focus:opacity-100 group-hover:opacity-100" onClick={() => onStartMore(session)} aria-label="追加で注ぐ"><Play width={14} height={14} /></button>
-                    </TooltipTrigger>
-                    <TooltipContent>追加で注ぐ</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-            </li>
-                </TooltipTrigger>
-                <TooltipContent>ダブルクリックで編集・右クリックで操作</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            />
           ))}
         </ul>
       )}
 
       <PageIndicator totalPages={totalPages} currentPage={page} onChangePage={changePage} />
 
-      <Card className="mb-2 mt-2" data-tour="demo-worktime">
-        <CardContent className="flex items-center justify-between px-3 py-2 text-[11px] text-muted-foreground">
-          <div className="flex items-center gap-1.5">
-            {workStart && !workEnd && (
-              breakStart === null ? (
-                <Button variant="outline" size="sm" className="h-7 border-amber-400 text-amber-500 hover:bg-amber-50 hover:text-amber-600 dark:hover:bg-amber-950" onClick={onBreakStart}>
-                  休憩
-                </Button>
-              ) : breakEnd === null ? (
-                <Button variant="outline" size="sm" className="h-7 border-amber-400 text-amber-500 hover:bg-amber-50 hover:text-amber-600 dark:hover:bg-amber-950" onClick={onBreakEnd}>
-                  休憩終了
-                </Button>
-              ) : (
-                <Button variant="destructive" size="sm" className="h-7" onClick={handleWorkEnd}>
-                  終了
-                </Button>
-              )
-            )}
-            <span className="min-w-[90px] text-[11px] text-[var(--text-muted)]">
-              {workStart ? `${workStart}${workEnd ? `〜${workEnd}` : '〜'}` : ''}
-            </span>
-          </div>
-          {sessions.length > 0 && (
-            <span>今日注いだ時間: <strong>{totalMinutes}分</strong></span>
-          )}
-        </CardContent>
-      </Card>
+      <WorkTimeBar
+        workStart={workStart}
+        workEnd={workEnd}
+        breakStart={breakStart}
+        breakEnd={breakEnd}
+        onBreakStart={onBreakStart}
+        onBreakEnd={onBreakEnd}
+        onWorkEnd={onWorkEnd}
+        totalMinutes={totalMinutes}
+        hasSessions={sessions.length > 0}
+      />
 
       {contextMenu && (
-        <div
-          ref={contextMenuRef}
-          data-context-menu
-          className="fixed z-[1000] min-w-[120px] rounded-[8px] border border-border bg-card p-1 shadow-[var(--shadow-elevated)]"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
-        >
-          <button className="flex w-full cursor-pointer items-center gap-1.5 rounded-[6px] border-0 bg-transparent px-3 py-2 text-left text-[13px] text-foreground transition-colors duration-200 hover:bg-accent" onMouseDown={e => e.preventDefault()} onClick={openAddDialog}>
-            <Timer width={14} height={14} /> 追加
-          </button>
-          {contextMenu.sessionId !== '' && (
-            <>
-              <button
-                className="flex w-full cursor-pointer items-center gap-1.5 rounded-[6px] border-0 bg-transparent px-3 py-2 text-left text-[13px] text-foreground transition-colors duration-200 hover:bg-accent"
-                onMouseDown={e => e.preventDefault()}
-                onClick={() => {
-                  const session = sessions.find(s => s.id === contextMenu.sessionId)
-                  setContextMenu(null)
-                  if (session) handleEditStart(session)
-                }}
-              >
-                <EditPencil width={14} height={14} /> 編集
-              </button>
-              <button
-                className="flex w-full cursor-pointer items-center gap-1.5 rounded-[6px] border-0 bg-transparent px-3 py-2 text-left text-[13px] text-[#e74c3c] transition-colors duration-200 hover:bg-accent"
-                onMouseDown={e => e.preventDefault()}
-                onClick={() => {
-                  const id = contextMenu.sessionId
-                  setContextMenu(null)
-                  setPendingDeleteId(id)
-                }}
-              >
-                <Trash width={14} height={14} /> 流す
-              </button>
-            </>
-          )}
-        </div>
+        <SessionContextMenu
+          menu={contextMenu}
+          menuRef={contextMenuRef}
+          onAdd={openAddDialog}
+          onEdit={sessionId => {
+            const session = sessions.find(s => s.id === sessionId)
+            setContextMenu(null)
+            if (session) handleEditStart(session)
+          }}
+          onDelete={sessionId => {
+            setContextMenu(null)
+            setPendingDeleteId(sessionId)
+          }}
+        />
       )}
 
       <SessionFormDialog

--- a/src/renderer/src/components/Popover/WorkTimeBar.tsx
+++ b/src/renderer/src/components/Popover/WorkTimeBar.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { formatTimeFromDate } from '../../../../shared/sessionUtils'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { TimeField } from '@/components/ui/time-field'
+import { Dialog, DialogContent, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+
+interface Props {
+  workStart?: string | null
+  workEnd?: string | null
+  breakStart?: string | null
+  breakEnd?: string | null
+  onBreakStart?: () => void
+  onBreakEnd?: () => void
+  onWorkEnd?: (time: string) => void
+  totalMinutes: number
+  hasSessions: boolean
+}
+
+/**
+ * 勤務時間バー。休憩/休憩終了/業務終了ボタンと、業務終了時刻の入力ダイアログ、
+ * 当日の合計作業時間を表示する。
+ */
+export function WorkTimeBar({
+  workStart = null, workEnd = null, breakStart = null, breakEnd = null,
+  onBreakStart, onBreakEnd, onWorkEnd, totalMinutes, hasSessions,
+}: Props) {
+  const [endPickerOpen, setEndPickerOpen] = useState(false)
+  const [timePickerValue, setTimePickerValue] = useState('')
+
+  const handleWorkEnd = (): void => {
+    setTimePickerValue(formatTimeFromDate(new Date()))
+    setEndPickerOpen(true)
+  }
+
+  const handleTimePickerConfirm = (): void => {
+    onWorkEnd?.(timePickerValue)
+    setEndPickerOpen(false)
+  }
+
+  return (
+    <>
+      <Dialog open={endPickerOpen} onOpenChange={open => { if (!open) setEndPickerOpen(false) }}>
+        <DialogContent className="max-w-[220px]" aria-describedby={undefined}>
+          <DialogTitle>業務終了時刻</DialogTitle>
+          <div onKeyDown={e => { if (e.key === 'Enter') handleTimePickerConfirm() }}>
+            <TimeField
+              aria-label="業務終了時刻"
+              className="h-11 w-full justify-center text-xl"
+              value={timePickerValue}
+              onChange={setTimePickerValue}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEndPickerOpen(false)}>キャンセル</Button>
+            <Button onClick={handleTimePickerConfirm}>確定</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Card className="mb-2 mt-2" data-tour="demo-worktime">
+        <CardContent className="flex items-center justify-between px-3 py-2 text-[11px] text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            {workStart && !workEnd && (
+              breakStart === null ? (
+                <Button variant="outline" size="sm" className="h-7 border-amber-400 text-amber-500 hover:bg-amber-50 hover:text-amber-600 dark:hover:bg-amber-950" onClick={onBreakStart}>
+                  休憩
+                </Button>
+              ) : breakEnd === null ? (
+                <Button variant="outline" size="sm" className="h-7 border-amber-400 text-amber-500 hover:bg-amber-50 hover:text-amber-600 dark:hover:bg-amber-950" onClick={onBreakEnd}>
+                  休憩終了
+                </Button>
+              ) : (
+                <Button variant="destructive" size="sm" className="h-7" onClick={handleWorkEnd}>
+                  終了
+                </Button>
+              )
+            )}
+            <span className="min-w-[90px] text-[11px] text-[var(--text-muted)]">
+              {workStart ? `${workStart}${workEnd ? `〜${workEnd}` : '〜'}` : ''}
+            </span>
+          </div>
+          {hasSessions && (
+            <span>今日注いだ時間: <strong>{totalMinutes}分</strong></span>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  )
+}

--- a/src/renderer/src/hooks/useContextMenu.ts
+++ b/src/renderer/src/hooks/useContextMenu.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 
-interface ContextMenuState {
+export interface ContextMenuState {
   sessionId: string
   x: number
   y: number

--- a/src/renderer/src/hooks/useDragReorder.test.ts
+++ b/src/renderer/src/hooks/useDragReorder.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { DragEvent } from 'react'
+import { useDragReorder } from './useDragReorder'
+
+const makeDragEvent = () =>
+  ({ preventDefault: vi.fn(), dataTransfer: { effectAllowed: '', dropEffect: '' } }) as unknown as DragEvent
+
+function setup(orderedIds: string[]) {
+  const onReorder = vi.fn()
+  const { result } = renderHook(() =>
+    useDragReorder({ orderedIds, onReorder, page: 0, totalPages: 1, changePage: vi.fn() })
+  )
+  return { result, onReorder }
+}
+
+// fromId を toId の位置へドラッグして確定する
+function drag(result: ReturnType<typeof setup>['result'], fromId: string, toId: string) {
+  act(() => { result.current.handleDragStart(makeDragEvent(), fromId) })
+  act(() => { result.current.handleDragOver(makeDragEvent(), toId) })
+  act(() => { result.current.handleDrop(makeDragEvent()) })
+}
+
+describe('useDragReorder', () => {
+  it('下方向ドラッグ: 対象の後ろに配置される', () => {
+    const { result, onReorder } = setup(['a', 'b', 'c', 'd', 'e'])
+    drag(result, 'b', 'd')
+    expect(onReorder).toHaveBeenCalledWith(['a', 'c', 'd', 'b', 'e'])
+  })
+
+  it('上方向ドラッグ: 対象の前に配置される', () => {
+    const { result, onReorder } = setup(['a', 'b', 'c', 'd', 'e'])
+    drag(result, 'e', 'b')
+    expect(onReorder).toHaveBeenCalledWith(['a', 'e', 'b', 'c', 'd'])
+  })
+
+  it('隣接する要素は入れ替わる（下方向）', () => {
+    const { result, onReorder } = setup(['a', 'b', 'c'])
+    drag(result, 'a', 'b')
+    expect(onReorder).toHaveBeenCalledWith(['b', 'a', 'c'])
+  })
+
+  it('同じ要素へのドロップでは onReorder を呼ばない', () => {
+    const { result, onReorder } = setup(['a', 'b', 'c'])
+    drag(result, 'b', 'b')
+    expect(onReorder).not.toHaveBeenCalled()
+  })
+
+  it('drop と dragend の両方が来ても一度しか確定しない', () => {
+    const { result, onReorder } = setup(['a', 'b', 'c'])
+    act(() => { result.current.handleDragStart(makeDragEvent(), 'a') })
+    act(() => { result.current.handleDragOver(makeDragEvent(), 'c') })
+    act(() => { result.current.handleDrop(makeDragEvent()) })
+    act(() => { result.current.handleDragEnd() })
+    expect(onReorder).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/hooks/useDragReorder.ts
+++ b/src/renderer/src/hooks/useDragReorder.ts
@@ -95,6 +95,9 @@ export function useDragReorder({ orderedIds, onReorder, page, totalPages, change
     const toIdx = currentOrder.indexOf(toId)
     if (fromIdx === -1 || toIdx === -1) return
 
+    // 削除後に元の toIdx へ挿入することで、方向依存の自然な配置になる:
+    // 下方向ドラッグ（fromIdx < toIdx）は削除でインデックスが1つ詰まり対象の後ろへ、
+    // 上方向ドラッグ（fromIdx > toIdx）は対象の前へ挿入される。
     currentOrder.splice(fromIdx, 1)
     currentOrder.splice(toIdx, 0, fromId)
 


### PR DESCRIPTION
## やったこと
- 勤務時間バー(休憩/終了ボタン+業務終了時刻ダイアログ)を `WorkTimeBar` へ抽出
- セッション行を `SessionItem`、右クリックメニューを `SessionContextMenu` へ抽出
- `SessionList` を state とフックの統括役に整理 (349→243行)
- 残骸コメント(削除済み時刻編集機能の説明)を削除
- `useDragReorder` に方向依存の並び替え挙動を記録する特性テストを追加

## 補足
- issue #85 の前提(540行 god component)は #36 等で既に大半解消済み。残っていた抽出を完了
- 調査で挙がったバグ候補は精査の結果すべて誤検知だった(D&D の上下非対称は正しい仕様)ため挙動変更なし
- typecheck / 全702テスト / eslint / knip / depcruise すべてパス

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)