### PR TITLE
feat: 退勤時にマグネットが既に退勤ならホワイトボード更新をスキップ (#70)

### DIFF
--- a/lambda/src/whiteboardPost.test.ts
+++ b/lambda/src/whiteboardPost.test.ts
@@ -7,11 +7,20 @@ afterEach(() => vi.unstubAllGlobals())
 const OPTS = { apiUrl: 'https://wb.test', apiKey: 'WBKEY' }
 const EMAIL = 'kanayama@jsl.co.jp'
 
-function mockFetchSequence(responses: Array<{ ok: boolean; status?: number }>): ReturnType<typeof vi.fn> {
+function mockFetchSequence(
+  responses: Array<{ ok: boolean; status?: number; json?: unknown }>
+): ReturnType<typeof vi.fn> {
   const fn = vi.fn()
-  for (const r of responses) fn.mockResolvedValueOnce(r)
+  for (const r of responses) {
+    fn.mockResolvedValueOnce({ ok: r.ok, status: r.status, json: async () => r.json })
+  }
   vi.stubGlobal('fetch', fn)
   return fn
+}
+
+/** /api/users の成功レスポンス body（指定マグネット名のユーザー1件）を作る */
+function usersBody(magnetName: string): unknown {
+  return { code: 'OK', results: [{ magnet: { name: magnetName } }] }
 }
 
 describe('postWhiteboard', () => {
@@ -31,13 +40,60 @@ describe('postWhiteboard', () => {
     expect(JSON.parse(magnetInit.body)).toEqual({ magnet_id: 2, email: EMAIL })
   })
 
-  it('leave は 出勤打刻=false → magnet=3 を送る', async () => {
-    const fetchMock = mockFetchSequence([{ ok: true }, { ok: true }])
-    await postWhiteboard('leave', EMAIL, OPTS)
+  it('leave は 現在値を確認後に 出勤打刻=false → magnet=3 を送る', async () => {
+    // 1回目: 現在値取得(GET /api/users) → 退勤以外, 2回目: 打刻, 3回目: magnet
+    const fetchMock = mockFetchSequence([
+      { ok: true, json: usersBody('出社') },
+      { ok: true },
+      { ok: true },
+    ])
+    const result = await postWhiteboard('leave', EMAIL, OPTS)
+    expect(result).toEqual({ ok: true })
+    // 1回目: 現在のマグネットを GET で取得
+    const [usersUrl, usersInit] = fetchMock.mock.calls[0]
+    expect(usersUrl).toBe(`https://wb.test/api/users?apiKey=WBKEY&id=${encodeURIComponent(EMAIL)}`)
+    expect(usersInit.method).toBe('GET')
+    // 2回目: 打刻=false
     expect(
-      new URLSearchParams(String(fetchMock.mock.calls[0][1].body)).get('come_to_the_office')
+      new URLSearchParams(String(fetchMock.mock.calls[1][1].body)).get('come_to_the_office')
     ).toBe('false')
-    expect(JSON.parse(fetchMock.mock.calls[1][1].body).magnet_id).toBe(3)
+    // 3回目: magnet=3
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body).magnet_id).toBe(3)
+  })
+
+  it('leave で既に退勤なら 打刻も magnet も送らず ok を返す', async () => {
+    const fetchMock = mockFetchSequence([{ ok: true, json: usersBody('退勤') }])
+    const result = await postWhiteboard('leave', EMAIL, OPTS)
+    expect(result).toEqual({ ok: true })
+    // GET のみ。打刻・magnet の POST はしない
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('leave で現在値取得が失敗しても 従来通り退勤を送る（フェイルセーフ）', async () => {
+    const fetchMock = mockFetchSequence([
+      { ok: false, status: 500 },
+      { ok: true },
+      { ok: true },
+    ])
+    expect(await postWhiteboard('leave', EMAIL, OPTS)).toEqual({ ok: true })
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body).magnet_id).toBe(3)
+  })
+
+  it('leave で対象ユーザーが見つからなくても 従来通り退勤を送る', async () => {
+    const fetchMock = mockFetchSequence([
+      { ok: true, json: { code: 'OK', results: [] } },
+      { ok: true },
+      { ok: true },
+    ])
+    expect(await postWhiteboard('leave', EMAIL, OPTS)).toEqual({ ok: true })
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body).magnet_id).toBe(3)
+  })
+
+  it('telework は現在値を確認せず（GET を呼ばず）打刻・magnet を送る', async () => {
+    const fetchMock = mockFetchSequence([{ ok: true }, { ok: true }])
+    await postWhiteboard('telework', EMAIL, OPTS)
+    // 1回目が GET ではなく打刻であること（GET をスキップ）
+    expect(fetchMock.mock.calls[0][0]).toBe('https://wb.test/api/attendance?apiKey=WBKEY')
   })
 
   it('打刻失敗時は magnet を呼ばず error を返す', async () => {

--- a/lambda/src/whiteboardPost.ts
+++ b/lambda/src/whiteboardPost.ts
@@ -4,7 +4,34 @@ import { FETCH_TIMEOUT_MS } from './http'
 const MAGNET_TELEWORK = 2
 const MAGNET_LEAVE = 3
 
+// ホワイトボード側 statusMagnetMap における magnet_id=3(退勤) のラベル。
+// /api/users は magnet_id ではなくこのラベルを返すため文字列で比較する。
+const LEAVE_LABEL = '退勤'
+
 export type WhiteboardKind = 'telework' | 'leave'
+
+/**
+ * /api/users から現在のマグネット名を取得する。
+ * 取得できない場合（ネットワークエラー・非2xx・ユーザー不在・想定外レスポンス）は null。
+ * null のときは呼び出し側でフェイルセーフとして通常の退勤送信を行う。
+ */
+async function fetchCurrentMagnetName(
+  email: string,
+  opts: { apiUrl: string; apiKey: string }
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${opts.apiUrl}/api/users?apiKey=${opts.apiKey}&id=${encodeURIComponent(email)}`,
+      { method: 'GET', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }
+    )
+    if (!res.ok) return null
+    const data = (await res.json()) as { results?: Array<{ magnet?: { name?: string } }> }
+    const first = data.results?.[0]
+    return first?.magnet?.name ?? null
+  } catch {
+    return null
+  }
+}
 
 /**
  * ホワイトボードの状態を更新する（attendance → magnet の2段呼び出し）。
@@ -22,6 +49,13 @@ export async function postWhiteboard(
   email: string,
   opts: { apiUrl: string; apiKey: string }
 ): Promise<{ ok: true } | { error: string }> {
+  // 退勤時にすでにマグネットが「退勤」なら、打刻も magnet も送らず no-op で成功扱いにする。
+  // （出社時にカードをかざさず退勤のまま残ったケースで、無駄な退勤打刻を増やさない / issue #70）
+  // 現在値が取得できないとき（null）は誤表示を避けるため通常どおり退勤を送る（フェイルセーフ）。
+  if (kind === 'leave') {
+    const current = await fetchCurrentMagnetName(email, opts)
+    if (current === LEAVE_LABEL) return { ok: true }
+  }
   const magnetId = kind === 'telework' ? MAGNET_TELEWORK : MAGNET_LEAVE
   const comeToOffice = kind === 'telework'
   try {


### PR DESCRIPTION
## やったこと
- 退勤(`leave`)送信前に whiteboard `/api/users` で現在のマグネット値を確認
- 既に退勤(3)なら打刻・magnet を送らずスキップ（出社時にカードをかざさず退勤のまま残ったケースで無駄な退勤打刻を増やさない / #70）
- 取得失敗・ユーザー不在時は誤表示回避のため従来どおり退勤を送信（フェイルセーフ）
- 変更は Lambda の `whiteboardPost.ts` のみ。アプリ本体は変更なし
- テスト5ケース追加、デプロイ済み

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)