### PR TITLE
feat: アプリ内アップデート通知機能 (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ npm test
 # DMG をビルド（無署名）
 CSC_IDENTITY_AUTO_DISCOVERY=false npm run package
 ```
+
+## リリース（アップデート配信）
+
+アプリは GitHub Releases の最新版を起動時・6時間ごとに確認し、新バージョンがあれば
+アプリ内で通知する。配信時は次の手順を踏む（**version を上げ忘れると検知されない**）。
+
+1. `package.json` の `version` を上げる（例 `1.0.0` → `1.1.0`）
+2. `CSC_IDENTITY_AUTO_DISCOVERY=false npm run package` で arm64 / x64 の DMG をビルド
+3. GitHub Release を `vX.Y.Z` タグで作成し、`Juice-X.Y.Z-arm64.dmg` と
+   `Juice-X.Y.Z.dmg`（および blockmap・latest-mac.yml）を添付する
+4. クライアントは6時間以内（または再起動・手動チェック）に更新を検知し、
+   ワンクリックで DMG を取得・オープンできる

--- a/README.md
+++ b/README.md
@@ -59,5 +59,8 @@ CSC_IDENTITY_AUTO_DISCOVERY=false npm run package
 2. `CSC_IDENTITY_AUTO_DISCOVERY=false npm run package` で arm64 / x64 の DMG をビルド
 3. GitHub Release を `vX.Y.Z` タグで作成し、`Juice-X.Y.Z-arm64.dmg` と
    `Juice-X.Y.Z.dmg`（および blockmap・latest-mac.yml）を添付する
+   - **必ず正式リリースで公開する（pre-release にしない）**。アプリは
+     `releases/latest` を参照するが、このエンドポイントは pre-release / draft を
+     除外するため、pre-release のままだと更新が検知されない
 4. クライアントは6時間以内（または再起動・手動チェック）に更新を検知し、
    ワンクリックで DMG を取得・オープンできる

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juice",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "macOS menu bar timer app",
   "main": "out/main/index.js",
   "author": "kanayama",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, nativeImage } from 'electron'
+import { app, nativeImage, shell } from 'electron'
 import { join } from 'path'
 import os from 'os'
 import { SessionStore } from './sessionStore'
@@ -12,6 +12,11 @@ import { startIdleCheck } from './notifications/idle'
 import { registerIpcHandlers } from './ipc/registerHandlers'
 import { startSessionRefresh } from './auth/refreshSession'
 import { logger } from './logger'
+import { createUpdateService } from './update/updateService'
+import { fetchLatestRelease } from './update/githubRelease'
+import { readInstalledVersion } from './update/installedVersion'
+import { downloadFile } from './update/downloadFile'
+import { broadcastToAll } from './windows/updateBroadcast'
 
 // dev とパッケージ版でプロファイルを分離する（起動ロック衝突・localStorage 混入の防止）。
 // requestSingleInstanceLock より前に設定する必要がある。
@@ -40,6 +45,24 @@ const sessionStore = new SessionStore(dataDir)
 const dailyStore = new DailyStore(dataDir)
 const settingsStore = new SettingsStore(dataDir)
 const authStore = new AuthStore(dataDir)
+
+const updateService = createUpdateService({
+  currentVersion: app.getVersion(),
+  arch: process.arch,
+  isPackaged: app.isPackaged,
+  execPath: process.execPath,
+  tmpDir: app.getPath('temp'),
+  getDismissedVersion: () => settingsStore.getDismissedUpdateVersion(),
+  setDismissedVersion: (v) => settingsStore.setDismissedUpdateVersion(v),
+  fetchRelease: () => fetchLatestRelease(),
+  readInstalledVersion,
+  downloadFile,
+  send: broadcastToAll,
+  openPath: (p) => shell.openPath(p),
+  openExternal: (u) => shell.openExternal(u),
+  relaunch: () => { app.relaunch(); app.quit() },
+  logError: (...args) => logger.error(...args),
+})
 
 // 開発時は汎用 Electron.app に紐づくため juice:// の E2E はパッケージ版で確認する
 // juice:// カスタムスキーム（Slack サインインのコールバック受信）
@@ -71,7 +94,7 @@ app.whenReady().then(async () => {
     app.dock?.setIcon(dockIcon)
   }
 
-  registerIpcHandlers(sessionStore, settingsStore, authStore, dailyStore)
+  registerIpcHandlers(sessionStore, settingsStore, authStore, dailyStore, updateService)
   startSessionRefresh(authStore)
 
   // 初回セットアップ判定
@@ -86,6 +109,7 @@ app.whenReady().then(async () => {
     app.dock?.hide()
     createTray(settingsStore)
     startIdleCheck(settingsStore)
+    updateService.startPeriodicCheck()
   }
 })
 

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -16,6 +16,7 @@ import { startIdleCheck } from '../notifications/idle'
 import { recordActivity } from '../notifications/activity'
 import { onTimerStarted, onTimerStopped, onTimerAdjustStartTime, reschedule } from '../notifications/elapsed'
 import * as pomodoro from '../notifications/pomodoro'
+import { setTimerRunning, isTimerRunning } from '../timerActivity'
 import { sendAttendance } from '../integrations/attendance'
 import { sendWhiteboardTeleworkStart } from '../integrations/whiteboard'
 import { getHolidays } from '../integrations/holidays'
@@ -95,13 +96,16 @@ export function registerIpcHandlers(
 
   // timer signals
   handle('timer:started', () => {
+    setTimerRunning(true)
     onTimerStarted(settingsStore)
     pomodoro.onTimerStarted(settingsStore)
   })
   handle('timer:stopped', () => {
+    setTimerRunning(false)
     onTimerStopped()
     pomodoro.onTimerStopped()
   })
+  handle('timer:isRunning', () => isTimerRunning())
   handle('timer:adjustStartTime', (_, newStartMs) => {
     onTimerAdjustStartTime(newStartMs, settingsStore)
     pomodoro.onTimerAdjustStartTime(newStartMs, settingsStore)
@@ -139,6 +143,7 @@ export function registerIpcHandlers(
   handle('update:dismiss', (_, version) => updateService.dismiss(version))
 
   // misc
+  handle('app:getVersion', () => app.getVersion())
   handle('holidays:get', () => getHolidays())
   handle('window:hide', () => hidePopover())
   handle('window:resize', (_, { width, height }) => resizePopover(width, height))

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -3,6 +3,7 @@ import type { SessionStore } from '../sessionStore'
 import type { SettingsStore } from '../settingsStore'
 import type { AuthStore } from '../auth/authStore'
 import type { DailyStore } from '../dailyStore'
+import type { UpdateService } from '../update/updateService'
 import { startSignIn } from '../auth/signIn'
 import { logger } from '../logger'
 import { handle } from './handle'
@@ -26,6 +27,7 @@ export function registerIpcHandlers(
   settingsStore: SettingsStore,
   authStore: AuthStore,
   dailyStore: DailyStore,
+  updateService: UpdateService,
 ): void {
   // sessions
   handle('sessions:get', (_, yearMonth) => sessionStore.getSessions(yearMonth))
@@ -129,6 +131,12 @@ export function registerIpcHandlers(
     const status = await authStore.getStatus()
     broadcastAuthToAll(status)
   })
+
+  // update
+  handle('update:check', () => updateService.checkForUpdate())
+  handle('update:download', () => updateService.download())
+  handle('update:restart', () => { updateService.restart() })
+  handle('update:dismiss', (_, version) => updateService.dismiss(version))
 
   // misc
   handle('holidays:get', () => getHolidays())

--- a/src/main/settingsStore.test.ts
+++ b/src/main/settingsStore.test.ts
@@ -152,6 +152,12 @@ describe('SettingsStore', () => {
     const result = await store.getBreakBehaviorSettings()
     expect(result.behavior).toBe('pause')
   })
+
+  it('dismissedUpdateVersion を保存・取得できる（既定は空文字）', async () => {
+    expect(await store.getDismissedUpdateVersion()).toBe('')
+    await store.setDismissedUpdateVersion('1.2.0')
+    expect(await store.getDismissedUpdateVersion()).toBe('1.2.0')
+  })
 })
 
 describe('mainProjectCode', () => {

--- a/src/main/settingsStore.ts
+++ b/src/main/settingsStore.ts
@@ -13,6 +13,7 @@ interface Settings {
   whiteboardEnabled: boolean
   breakBehavior: 'stop' | 'pause'
   mainProjectCode: string
+  dismissedUpdateVersion: string
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -26,6 +27,7 @@ const DEFAULT_SETTINGS: Settings = {
   whiteboardEnabled: false,
   breakBehavior: 'stop',
   mainProjectCode: '',
+  dismissedUpdateVersion: '',
 }
 
 export class SettingsStore {
@@ -101,6 +103,8 @@ export class SettingsStore {
         whiteboardEnabled: parsed.whiteboardEnabled ?? DEFAULT_SETTINGS.whiteboardEnabled,
         breakBehavior: (parsed.breakBehavior === 'pause' ? 'pause' : 'stop'),
         mainProjectCode: parsed.mainProjectCode ?? DEFAULT_SETTINGS.mainProjectCode,
+        dismissedUpdateVersion:
+          parsed.dismissedUpdateVersion ?? DEFAULT_SETTINGS.dismissedUpdateVersion,
       }
     }
     try {
@@ -201,5 +205,14 @@ export class SettingsStore {
 
   async setMainProjectCode(code: string): Promise<void> {
     await this.update(s => ({ ...s, mainProjectCode: code }))
+  }
+
+  async getDismissedUpdateVersion(): Promise<string> {
+    const s = await this.readAll()
+    return s.dismissedUpdateVersion
+  }
+
+  async setDismissedUpdateVersion(version: string): Promise<void> {
+    await this.update(s => ({ ...s, dismissedUpdateVersion: version }))
   }
 }

--- a/src/main/timerActivity.ts
+++ b/src/main/timerActivity.ts
@@ -1,0 +1,11 @@
+// タイマーの稼働状態を main 側で保持する。renderer（複数ウィンドウ）から
+// timer:isRunning で問い合わせ、再起動前の確認文言の切り替えに使う。
+let running = false
+
+export function setTimerRunning(value: boolean): void {
+  running = value
+}
+
+export function isTimerRunning(): boolean {
+  return running
+}

--- a/src/main/update/downloadFile.test.ts
+++ b/src/main/update/downloadFile.test.ts
@@ -1,0 +1,43 @@
+// src/main/update/downloadFile.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { readFile, rm, mkdtemp } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { downloadFile } from './downloadFile'
+
+async function tmpFile(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'juice-dl-'))
+  return join(dir, 'out.bin')
+}
+
+// content-length 付き・2チャンクを返す fake fetch
+function fakeFetch(chunks: Uint8Array[], total: number, ok = true): typeof fetch {
+  return vi.fn(async () => ({
+    ok,
+    status: ok ? 200 : 500,
+    headers: { get: (k: string) => (k.toLowerCase() === 'content-length' ? String(total) : null) },
+    body: (async function* () { for (const c of chunks) yield c })(),
+  })) as unknown as typeof fetch
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('downloadFile', () => {
+  it('body をファイルに書き、進捗を 100 まで通知する', async () => {
+    const dest = await tmpFile()
+    const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])]
+    const onProgress = vi.fn()
+    await downloadFile('https://x/file', dest, onProgress, fakeFetch(chunks, 4))
+    const written = await readFile(dest)
+    expect(Array.from(written)).toEqual([1, 2, 3, 4])
+    expect(onProgress).toHaveBeenLastCalledWith(100)
+    await rm(dest, { force: true })
+  })
+
+  it('レスポンスが ok でなければ例外', async () => {
+    const dest = await tmpFile()
+    await expect(
+      downloadFile('https://x/file', dest, () => {}, fakeFetch([], 0, false)),
+    ).rejects.toThrow()
+  })
+})

--- a/src/main/update/downloadFile.ts
+++ b/src/main/update/downloadFile.ts
@@ -1,0 +1,35 @@
+// src/main/update/downloadFile.ts
+import { createWriteStream } from 'fs'
+
+/**
+ * URL を destPath にストリーム保存する。content-length があれば進捗(0-100)を通知。
+ * Electron main は global fetch（undici）を持つ。body は async-iterable。
+ */
+export async function downloadFile(
+  url: string,
+  destPath: string,
+  onProgress: (percent: number) => void,
+  fetchFn: typeof fetch = fetch,
+): Promise<void> {
+  const res = await fetchFn(url)
+  if (!res.ok || !res.body) {
+    throw new Error(`download failed: ${res.status}`)
+  }
+  const total = Number(res.headers.get('content-length')) || 0
+  const out = createWriteStream(destPath)
+  let received = 0
+  try {
+    for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+      received += chunk.length
+      if (!out.write(chunk)) {
+        await new Promise<void>(resolve => out.once('drain', resolve))
+      }
+      if (total > 0) onProgress(Math.round((received / total) * 100))
+    }
+    onProgress(100)
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      out.end((err?: Error | null) => (err ? reject(err) : resolve())),
+    )
+  }
+}

--- a/src/main/update/githubRelease.test.ts
+++ b/src/main/update/githubRelease.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchLatestRelease } from './githubRelease'
+
+function fakeFetch(payload: unknown, ok = true): typeof fetch {
+  return vi.fn(async () => ({
+    ok,
+    status: ok ? 200 : 404,
+    json: async () => payload,
+  })) as unknown as typeof fetch
+}
+
+describe('fetchLatestRelease', () => {
+  it('GitHub API レスポンスを GithubRelease に変換する', async () => {
+    const fetchFn = fakeFetch({
+      tag_name: 'v1.1.0',
+      html_url: 'https://github.com/ryota-kanayama/juice/releases/tag/v1.1.0',
+      body: 'changelog',
+      assets: [
+        { name: 'Juice-1.1.0-arm64.dmg', browser_download_url: 'https://x/arm64.dmg' },
+        { name: 'Juice-1.1.0.dmg', browser_download_url: 'https://x/x64.dmg' },
+      ],
+    })
+    const release = await fetchLatestRelease(fetchFn)
+    expect(release.tagName).toBe('v1.1.0')
+    expect(release.htmlUrl).toContain('/releases/tag/v1.1.0')
+    expect(release.body).toBe('changelog')
+    expect(release.assets).toEqual([
+      { name: 'Juice-1.1.0-arm64.dmg', url: 'https://x/arm64.dmg' },
+      { name: 'Juice-1.1.0.dmg', url: 'https://x/x64.dmg' },
+    ])
+  })
+
+  it('レスポンスが ok でなければ例外を投げる', async () => {
+    const fetchFn = fakeFetch({}, false)
+    await expect(fetchLatestRelease(fetchFn)).rejects.toThrow()
+  })
+
+  it('assets / body が欠けても安全に既定値を返す', async () => {
+    const fetchFn = fakeFetch({ tag_name: 'v1.0.0', html_url: 'u' })
+    const release = await fetchLatestRelease(fetchFn)
+    expect(release.assets).toEqual([])
+    expect(release.body).toBe('')
+  })
+})

--- a/src/main/update/githubRelease.ts
+++ b/src/main/update/githubRelease.ts
@@ -1,0 +1,41 @@
+import type { ReleaseAsset } from './selectAsset'
+
+export const LATEST_RELEASE_URL =
+  'https://api.github.com/repos/ryota-kanayama/juice/releases/latest'
+
+export interface GithubRelease {
+  tagName: string
+  htmlUrl: string
+  body: string
+  assets: ReleaseAsset[]
+}
+
+interface RawAsset {
+  name?: string
+  browser_download_url?: string
+}
+interface RawRelease {
+  tag_name?: string
+  html_url?: string
+  body?: string
+  assets?: RawAsset[]
+}
+
+/** GitHub の latest release を取得して正規化する。未認証・公開リポ前提 */
+export async function fetchLatestRelease(fetchFn: typeof fetch = fetch): Promise<GithubRelease> {
+  const res = await fetchFn(LATEST_RELEASE_URL, {
+    headers: { Accept: 'application/vnd.github+json' },
+  })
+  if (!res.ok) {
+    throw new Error(`GitHub API responded ${res.status}`)
+  }
+  const raw = (await res.json()) as RawRelease
+  return {
+    tagName: raw.tag_name ?? '',
+    htmlUrl: raw.html_url ?? '',
+    body: raw.body ?? '',
+    assets: (raw.assets ?? [])
+      .filter((a): a is Required<RawAsset> => Boolean(a.name && a.browser_download_url))
+      .map(a => ({ name: a.name, url: a.browser_download_url })),
+  }
+}

--- a/src/main/update/installedVersion.test.ts
+++ b/src/main/update/installedVersion.test.ts
@@ -20,4 +20,8 @@ describe('parseShortVersionFromPlist', () => {
   it('キーが無ければ null', () => {
     expect(parseShortVersionFromPlist('<dict></dict>')).toBeNull()
   })
+  it('属性付き <string> タグでも値を取り出す', () => {
+    const xml = `<key>CFBundleShortVersionString</key><string foo="bar">1.2.0</string>`
+    expect(parseShortVersionFromPlist(xml)).toBe('1.2.0')
+  })
 })

--- a/src/main/update/installedVersion.test.ts
+++ b/src/main/update/installedVersion.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { bundleInfoPlistPath, parseShortVersionFromPlist } from './installedVersion'
+
+describe('bundleInfoPlistPath', () => {
+  it('実行ファイルパスから Info.plist のパスを導く', () => {
+    expect(bundleInfoPlistPath('/Applications/Juice.app/Contents/MacOS/Juice'))
+      .toBe('/Applications/Juice.app/Contents/Info.plist')
+  })
+})
+
+describe('parseShortVersionFromPlist', () => {
+  it('CFBundleShortVersionString を取り出す', () => {
+    const xml = `
+      <dict>
+        <key>CFBundleIdentifier</key><string>com.kanaami.juice</string>
+        <key>CFBundleShortVersionString</key><string>1.2.0</string>
+      </dict>`
+    expect(parseShortVersionFromPlist(xml)).toBe('1.2.0')
+  })
+  it('キーが無ければ null', () => {
+    expect(parseShortVersionFromPlist('<dict></dict>')).toBeNull()
+  })
+})

--- a/src/main/update/installedVersion.ts
+++ b/src/main/update/installedVersion.ts
@@ -11,7 +11,7 @@ export function bundleInfoPlistPath(execPath: string): string {
 /** plist XML から CFBundleShortVersionString の値を取り出す。無ければ null */
 export function parseShortVersionFromPlist(xml: string): string | null {
   const m = xml.match(
-    /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
+    /<key>CFBundleShortVersionString<\/key>\s*<string[^>]*>([^<]+)<\/string>/,
   )
   return m ? m[1].trim() : null
 }

--- a/src/main/update/installedVersion.ts
+++ b/src/main/update/installedVersion.ts
@@ -1,0 +1,27 @@
+import { readFile } from 'fs/promises'
+import { dirname, join } from 'path'
+
+/** 実行ファイル(.../Contents/MacOS/Juice) から .../Contents/Info.plist を導く */
+export function bundleInfoPlistPath(execPath: string): string {
+  // execPath = <App>.app/Contents/MacOS/Juice → 2つ上が Contents
+  const contentsDir = dirname(dirname(execPath))
+  return join(contentsDir, 'Info.plist')
+}
+
+/** plist XML から CFBundleShortVersionString の値を取り出す。無ければ null */
+export function parseShortVersionFromPlist(xml: string): string | null {
+  const m = xml.match(
+    /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
+  )
+  return m ? m[1].trim() : null
+}
+
+/** インストール済みアプリの表示バージョンを読む。失敗時は null */
+export async function readInstalledVersion(execPath: string): Promise<string | null> {
+  try {
+    const xml = await readFile(bundleInfoPlistPath(execPath), 'utf-8')
+    return parseShortVersionFromPlist(xml)
+  } catch {
+    return null
+  }
+}

--- a/src/main/update/selectAsset.test.ts
+++ b/src/main/update/selectAsset.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { selectDmgAsset, type ReleaseAsset } from './selectAsset'
+
+const assets: ReleaseAsset[] = [
+  { name: 'Juice-1.1.0-arm64.dmg', url: 'https://x/arm64.dmg' },
+  { name: 'Juice-1.1.0-arm64.dmg.blockmap', url: 'https://x/arm64.blockmap' },
+  { name: 'Juice-1.1.0.dmg', url: 'https://x/x64.dmg' },
+  { name: 'Juice-1.1.0.dmg.blockmap', url: 'https://x/x64.blockmap' },
+  { name: 'latest-mac.yml', url: 'https://x/yml' },
+]
+
+describe('selectDmgAsset', () => {
+  it('arm64 は -arm64.dmg を選ぶ', () => {
+    expect(selectDmgAsset(assets, 'arm64')?.name).toBe('Juice-1.1.0-arm64.dmg')
+  })
+  it('x64 は -arm64 を含まない .dmg を選ぶ', () => {
+    expect(selectDmgAsset(assets, 'x64')?.name).toBe('Juice-1.1.0.dmg')
+  })
+  it('blockmap や yml は選ばない', () => {
+    const arm = selectDmgAsset(assets, 'arm64')
+    expect(arm?.name.endsWith('.dmg')).toBe(true)
+  })
+  it('該当アセットがなければ null', () => {
+    expect(selectDmgAsset([{ name: 'foo.zip', url: 'u' }], 'arm64')).toBeNull()
+  })
+})

--- a/src/main/update/selectAsset.ts
+++ b/src/main/update/selectAsset.ts
@@ -1,0 +1,15 @@
+export interface ReleaseAsset {
+  name: string
+  url: string
+}
+
+/**
+ * 実行アーキテクチャに合う DMG アセットを選ぶ。
+ * arm64 → "-arm64.dmg" で終わるもの。x64 → ".dmg" で終わり "-arm64.dmg" でないもの。
+ */
+export function selectDmgAsset(assets: ReleaseAsset[], arch: string): ReleaseAsset | null {
+  if (arch === 'arm64') {
+    return assets.find(a => a.name.endsWith('-arm64.dmg')) ?? null
+  }
+  return assets.find(a => a.name.endsWith('.dmg') && !a.name.endsWith('-arm64.dmg')) ?? null
+}

--- a/src/main/update/updateService.test.ts
+++ b/src/main/update/updateService.test.ts
@@ -1,0 +1,119 @@
+// src/main/update/updateService.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { createUpdateService, type UpdateServiceDeps } from './updateService'
+import type { GithubRelease } from './githubRelease'
+
+function baseDeps(over: Partial<UpdateServiceDeps> = {}): UpdateServiceDeps {
+  const release: GithubRelease = {
+    tagName: 'v1.1.0',
+    htmlUrl: 'https://github.com/ryota-kanayama/juice/releases/tag/v1.1.0',
+    body: 'notes',
+    assets: [
+      { name: 'Juice-1.1.0-arm64.dmg', url: 'https://x/arm64.dmg' },
+      { name: 'Juice-1.1.0.dmg', url: 'https://x/x64.dmg' },
+    ],
+  }
+  return {
+    currentVersion: '1.0.0',
+    arch: 'arm64',
+    isPackaged: true,
+    execPath: '/Applications/Juice.app/Contents/MacOS/Juice',
+    tmpDir: '/tmp',
+    getDismissedVersion: vi.fn(async () => ''),
+    setDismissedVersion: vi.fn(async () => {}),
+    fetchRelease: vi.fn(async () => release),
+    readInstalledVersion: vi.fn(async () => '1.0.0'),
+    downloadFile: vi.fn(async () => {}),
+    send: vi.fn(),
+    openPath: vi.fn(async () => ''),
+    openExternal: vi.fn(async () => {}),
+    relaunch: vi.fn(),
+    logError: vi.fn(),
+    ...over,
+  }
+}
+
+describe('checkForUpdate', () => {
+  it('arch 一致 DMG を選び hasUpdate を判定する', async () => {
+    const svc = createUpdateService(baseDeps())
+    const info = await svc.checkForUpdate()
+    expect(info).toMatchObject({
+      currentVersion: '1.0.0',
+      latestVersion: '1.1.0',
+      hasUpdate: true,
+      downloadUrl: 'https://x/arm64.dmg',
+      assetName: 'Juice-1.1.0-arm64.dmg',
+    })
+  })
+})
+
+describe('checkAndNotify', () => {
+  it('更新あり・未 dismiss なら update-available を送る', async () => {
+    const deps = baseDeps()
+    await createUpdateService(deps).checkAndNotify()
+    expect(deps.send).toHaveBeenCalledWith('update-available', expect.objectContaining({ hasUpdate: true }))
+  })
+  it('dismiss 済みバージョンなら送らない', async () => {
+    const deps = baseDeps({ getDismissedVersion: vi.fn(async () => '1.1.0') })
+    await createUpdateService(deps).checkAndNotify()
+    expect(deps.send).not.toHaveBeenCalled()
+  })
+  it('取得失敗は無音（送らず logError）', async () => {
+    const deps = baseDeps({ fetchRelease: vi.fn(async () => { throw new Error('net') }) })
+    await createUpdateService(deps).checkAndNotify()
+    expect(deps.send).not.toHaveBeenCalled()
+    expect(deps.logError).toHaveBeenCalled()
+  })
+})
+
+describe('download', () => {
+  it('DMG を DL→openPath し、進捗 done を送る', async () => {
+    const deps = baseDeps()
+    await createUpdateService(deps).download()
+    expect(deps.downloadFile).toHaveBeenCalledWith('https://x/arm64.dmg', '/tmp/Juice-1.1.0-arm64.dmg', expect.any(Function))
+    expect(deps.openPath).toHaveBeenCalledWith('/tmp/Juice-1.1.0-arm64.dmg')
+    expect(deps.send).toHaveBeenCalledWith('update-download-progress', { percent: 100, done: true })
+  })
+  it('downloadUrl が無ければ releaseUrl を外部で開く', async () => {
+    const deps = baseDeps({
+      fetchRelease: vi.fn(async () => ({
+        tagName: 'v1.1.0', htmlUrl: 'https://rel', body: '', assets: [],
+      })),
+    })
+    await createUpdateService(deps).download()
+    expect(deps.openExternal).toHaveBeenCalledWith('https://rel')
+    expect(deps.downloadFile).not.toHaveBeenCalled()
+  })
+})
+
+describe('pollInstalledOnce', () => {
+  it('インストール版が起動版と違えば update-installed を送り true', async () => {
+    const deps = baseDeps({ readInstalledVersion: vi.fn(async () => '1.1.0') })
+    const done = await createUpdateService(deps).pollInstalledOnce()
+    expect(done).toBe(true)
+    expect(deps.send).toHaveBeenCalledWith('update-installed', { version: '1.1.0' })
+  })
+  it('同じなら送らず false', async () => {
+    const deps = baseDeps({ readInstalledVersion: vi.fn(async () => '1.0.0') })
+    expect(await createUpdateService(deps).pollInstalledOnce()).toBe(false)
+    expect(deps.send).not.toHaveBeenCalled()
+  })
+  it('未パッケージなら何もせず false', async () => {
+    const deps = baseDeps({ isPackaged: false, readInstalledVersion: vi.fn(async () => '1.1.0') })
+    expect(await createUpdateService(deps).pollInstalledOnce()).toBe(false)
+    expect(deps.send).not.toHaveBeenCalled()
+  })
+})
+
+describe('dismiss / restart', () => {
+  it('dismiss は setDismissedVersion を呼ぶ', async () => {
+    const deps = baseDeps()
+    await createUpdateService(deps).dismiss('1.1.0')
+    expect(deps.setDismissedVersion).toHaveBeenCalledWith('1.1.0')
+  })
+  it('restart は relaunch を呼ぶ', () => {
+    const deps = baseDeps()
+    createUpdateService(deps).restart()
+    expect(deps.relaunch).toHaveBeenCalled()
+  })
+})

--- a/src/main/update/updateService.ts
+++ b/src/main/update/updateService.ts
@@ -37,12 +37,7 @@ export interface UpdateService {
   pollInstalledOnce(): Promise<boolean>
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnySend = (event: any, payload: any) => void
-
 export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
-  // Task 8 でイベント名が IpcEventContract に追加されるまで、send を緩い型でラップする
-  const send = deps.send as AnySend
   let installTimer: ReturnType<typeof setInterval> | null = null
 
   async function checkForUpdate(): Promise<UpdateInfo> {
@@ -65,7 +60,7 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
       const info = await checkForUpdate()
       const dismissed = await deps.getDismissedVersion()
       if (info.hasUpdate && info.latestVersion !== dismissed) {
-        send('update-available', info)
+        deps.send('update-available', info)
       }
     } catch (e) {
       deps.logError('update check failed:', e)
@@ -81,7 +76,7 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
     if (!deps.isPackaged) return false
     const installed = await deps.readInstalledVersion(deps.execPath)
     if (installed && installed !== deps.currentVersion) {
-      send('update-installed', { version: installed })
+      deps.send('update-installed', { version: installed })
       return true
     }
     return false
@@ -105,7 +100,7 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
       info = await checkForUpdate()
     } catch (e) {
       deps.logError('update download: re-check failed:', e)
-      send('update-download-progress', { percent: 0, done: true, error: '更新情報の取得に失敗しました' })
+      deps.send('update-download-progress', { percent: 0, done: true, error: '更新情報の取得に失敗しました' })
       return
     }
     if (!info.downloadUrl || !info.assetName) {
@@ -115,14 +110,14 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
     const dest = join(deps.tmpDir, info.assetName)
     try {
       await deps.downloadFile(info.downloadUrl, dest, p =>
-        send('update-download-progress', { percent: p, done: false }),
+        deps.send('update-download-progress', { percent: p, done: false }),
       )
-      send('update-download-progress', { percent: 100, done: true })
+      deps.send('update-download-progress', { percent: 100, done: true })
       await deps.openPath(dest)
       startInstallWatch()
     } catch (e) {
       deps.logError('update download failed:', e)
-      send('update-download-progress', { percent: 0, done: true, error: 'ダウンロードに失敗しました' })
+      deps.send('update-download-progress', { percent: 0, done: true, error: 'ダウンロードに失敗しました' })
     }
   }
 

--- a/src/main/update/updateService.ts
+++ b/src/main/update/updateService.ts
@@ -1,0 +1,133 @@
+// src/main/update/updateService.ts
+import { join } from 'path'
+import { normalizeVersion, isNewerVersion } from '../../shared/version'
+import { selectDmgAsset } from './selectAsset'
+import type { UpdateInfo } from '../../shared/types'
+import type { GithubRelease } from './githubRelease'
+import type { IpcEventName, IpcEventPayload } from '../../shared/ipc'
+
+export const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+const INSTALL_POLL_MS = 3000
+
+export interface UpdateServiceDeps {
+  currentVersion: string
+  arch: string
+  isPackaged: boolean
+  execPath: string
+  tmpDir: string
+  getDismissedVersion: () => Promise<string>
+  setDismissedVersion: (version: string) => Promise<void>
+  fetchRelease: () => Promise<GithubRelease>
+  readInstalledVersion: (execPath: string) => Promise<string | null>
+  downloadFile: (url: string, dest: string, onProgress: (p: number) => void) => Promise<void>
+  send: <E extends IpcEventName>(event: E, payload: IpcEventPayload<E>) => void
+  openPath: (path: string) => Promise<string>
+  openExternal: (url: string) => Promise<void>
+  relaunch: () => void
+  logError: (...args: unknown[]) => void
+}
+
+export interface UpdateService {
+  checkForUpdate(): Promise<UpdateInfo>
+  checkAndNotify(): Promise<void>
+  startPeriodicCheck(): void
+  download(): Promise<void>
+  dismiss(version: string): Promise<void>
+  restart(): void
+  pollInstalledOnce(): Promise<boolean>
+}
+
+export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
+  let installTimer: ReturnType<typeof setInterval> | null = null
+
+  async function checkForUpdate(): Promise<UpdateInfo> {
+    const release = await deps.fetchRelease()
+    const latestVersion = normalizeVersion(release.tagName)
+    const asset = selectDmgAsset(release.assets, deps.arch)
+    return {
+      currentVersion: deps.currentVersion,
+      latestVersion,
+      hasUpdate: isNewerVersion(latestVersion, deps.currentVersion),
+      releaseUrl: release.htmlUrl,
+      downloadUrl: asset?.url ?? null,
+      assetName: asset?.name ?? null,
+      notes: release.body,
+    }
+  }
+
+  async function checkAndNotify(): Promise<void> {
+    try {
+      const info = await checkForUpdate()
+      const dismissed = await deps.getDismissedVersion()
+      if (info.hasUpdate && info.latestVersion !== dismissed) {
+        deps.send('update-available' as IpcEventName, info as IpcEventPayload<IpcEventName>)
+      }
+    } catch (e) {
+      deps.logError('update check failed:', e)
+    }
+  }
+
+  function startPeriodicCheck(): void {
+    void checkAndNotify()
+    setInterval(() => void checkAndNotify(), CHECK_INTERVAL_MS)
+  }
+
+  async function pollInstalledOnce(): Promise<boolean> {
+    if (!deps.isPackaged) return false
+    const installed = await deps.readInstalledVersion(deps.execPath)
+    if (installed && installed !== deps.currentVersion) {
+      deps.send('update-installed' as IpcEventName, { version: installed } as IpcEventPayload<IpcEventName>)
+      return true
+    }
+    return false
+  }
+
+  function startInstallWatch(): void {
+    if (!deps.isPackaged || installTimer) return
+    installTimer = setInterval(() => {
+      void pollInstalledOnce().then(done => {
+        if (done && installTimer) {
+          clearInterval(installTimer)
+          installTimer = null
+        }
+      })
+    }, INSTALL_POLL_MS)
+  }
+
+  async function download(): Promise<void> {
+    let info: UpdateInfo
+    try {
+      info = await checkForUpdate()
+    } catch (e) {
+      deps.logError('update download: re-check failed:', e)
+      deps.send('update-download-progress' as IpcEventName, { percent: 0, done: true, error: '更新情報の取得に失敗しました' } as IpcEventPayload<IpcEventName>)
+      return
+    }
+    if (!info.downloadUrl || !info.assetName) {
+      await deps.openExternal(info.releaseUrl)
+      return
+    }
+    const dest = join(deps.tmpDir, info.assetName)
+    try {
+      await deps.downloadFile(info.downloadUrl, dest, p =>
+        deps.send('update-download-progress' as IpcEventName, { percent: p, done: false } as IpcEventPayload<IpcEventName>),
+      )
+      deps.send('update-download-progress' as IpcEventName, { percent: 100, done: true } as IpcEventPayload<IpcEventName>)
+      await deps.openPath(dest)
+      startInstallWatch()
+    } catch (e) {
+      deps.logError('update download failed:', e)
+      deps.send('update-download-progress' as IpcEventName, { percent: 0, done: true, error: 'ダウンロードに失敗しました' } as IpcEventPayload<IpcEventName>)
+    }
+  }
+
+  async function dismiss(version: string): Promise<void> {
+    await deps.setDismissedVersion(version)
+  }
+
+  function restart(): void {
+    deps.relaunch()
+  }
+
+  return { checkForUpdate, checkAndNotify, startPeriodicCheck, download, dismiss, restart, pollInstalledOnce }
+}

--- a/src/main/update/updateService.ts
+++ b/src/main/update/updateService.ts
@@ -37,7 +37,12 @@ export interface UpdateService {
   pollInstalledOnce(): Promise<boolean>
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySend = (event: any, payload: any) => void
+
 export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
+  // Task 8 でイベント名が IpcEventContract に追加されるまで、send を緩い型でラップする
+  const send = deps.send as AnySend
   let installTimer: ReturnType<typeof setInterval> | null = null
 
   async function checkForUpdate(): Promise<UpdateInfo> {
@@ -60,7 +65,7 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
       const info = await checkForUpdate()
       const dismissed = await deps.getDismissedVersion()
       if (info.hasUpdate && info.latestVersion !== dismissed) {
-        deps.send('update-available' as IpcEventName, info as IpcEventPayload<IpcEventName>)
+        send('update-available', info)
       }
     } catch (e) {
       deps.logError('update check failed:', e)
@@ -76,7 +81,7 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
     if (!deps.isPackaged) return false
     const installed = await deps.readInstalledVersion(deps.execPath)
     if (installed && installed !== deps.currentVersion) {
-      deps.send('update-installed' as IpcEventName, { version: installed } as IpcEventPayload<IpcEventName>)
+      send('update-installed', { version: installed })
       return true
     }
     return false
@@ -100,7 +105,7 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
       info = await checkForUpdate()
     } catch (e) {
       deps.logError('update download: re-check failed:', e)
-      deps.send('update-download-progress' as IpcEventName, { percent: 0, done: true, error: '更新情報の取得に失敗しました' } as IpcEventPayload<IpcEventName>)
+      send('update-download-progress', { percent: 0, done: true, error: '更新情報の取得に失敗しました' })
       return
     }
     if (!info.downloadUrl || !info.assetName) {
@@ -110,14 +115,14 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
     const dest = join(deps.tmpDir, info.assetName)
     try {
       await deps.downloadFile(info.downloadUrl, dest, p =>
-        deps.send('update-download-progress' as IpcEventName, { percent: p, done: false } as IpcEventPayload<IpcEventName>),
+        send('update-download-progress', { percent: p, done: false }),
       )
-      deps.send('update-download-progress' as IpcEventName, { percent: 100, done: true } as IpcEventPayload<IpcEventName>)
+      send('update-download-progress', { percent: 100, done: true })
       await deps.openPath(dest)
       startInstallWatch()
     } catch (e) {
       deps.logError('update download failed:', e)
-      deps.send('update-download-progress' as IpcEventName, { percent: 0, done: true, error: 'ダウンロードに失敗しました' } as IpcEventPayload<IpcEventName>)
+      send('update-download-progress', { percent: 0, done: true, error: 'ダウンロードに失敗しました' })
     }
   }
 

--- a/src/main/windows/updateBroadcast.ts
+++ b/src/main/windows/updateBroadcast.ts
@@ -1,0 +1,9 @@
+import { BrowserWindow } from 'electron'
+import type { IpcEventName, IpcEventPayload } from '../../shared/ipc'
+
+/** 全ウィンドウへ main→renderer イベントを配信する汎用ヘルパ */
+export function broadcastToAll<E extends IpcEventName>(event: E, payload: IpcEventPayload<E>): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(event, payload)
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import type {
   IpcChannel, IpcArg, IpcReturn, IpcEventName, IpcEventPayload, AuthStatus,
 } from '../shared/ipc'
-import type { DayRecord } from '../shared/types'
+import type { DayRecord, UpdateInfo } from '../shared/types'
 
 // 型付き invoke ラッパー: IpcContract に登録のないチャンネル / 不一致な引数はコンパイルエラー
 function invoke<C extends IpcChannel>(channel: C, arg: IpcArg<C>): Promise<IpcReturn<C>> {
@@ -72,6 +72,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAuthStatus: () => invoke('auth:getStatus', undefined),
   signOutSlack: () => invoke('auth:signOut', undefined),
   onAuthChanged: (callback: (status: AuthStatus) => void) => on('auth-changed', callback),
+
+  // update
+  checkForUpdate: () => invoke('update:check', undefined),
+  downloadUpdate: () => invoke('update:download', undefined),
+  restartForUpdate: () => invoke('update:restart', undefined),
+  dismissUpdate: (version: string) => invoke('update:dismiss', version),
+  onUpdateAvailable: (callback: (info: UpdateInfo) => void) => on('update-available', callback),
+  onUpdateProgress: (callback: (p: { percent: number; done: boolean; error?: string }) => void) =>
+    on('update-download-progress', callback),
+  onUpdateInstalled: (callback: (p: { version: string }) => void) => on('update-installed', callback),
 
   // misc
   completeSetup: () => invoke('setup:complete', undefined),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -58,6 +58,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   timerStarted: () => invoke('timer:started', undefined),
   timerStopped: () => invoke('timer:stopped', undefined),
   timerAdjustStartTime: (newStartMs: number) => invoke('timer:adjustStartTime', newStartMs),
+  isTimerRunning: () => invoke('timer:isRunning', undefined),
 
   // attendance
   sendAttendance: (text: string) => invoke('attendance:send', text),
@@ -87,4 +88,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   completeSetup: () => invoke('setup:complete', undefined),
   getHolidays: () => invoke('holidays:get', undefined),
   openUrl: (url: string) => invoke('shell:openUrl', url),
+  getAppVersion: () => invoke('app:getVersion', undefined),
 })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -22,6 +22,8 @@ import { User, Timer, Calendar, Xmark, OpenNewWindow, SendDiagonal } from 'icono
 import { Button } from '@/components/ui/button'
 import { useAuthStatus } from './hooks/useAuthStatus'
 import { DailyDataProvider } from './daily/DailyDataContext'
+import { useUpdate } from './hooks/useUpdate'
+import { UpdateBanner } from './components/Popover/UpdateBanner'
 
 type Page = 'timer' | 'calendar' | 'attendance'
 
@@ -69,6 +71,7 @@ function PopoverView() {
   }, [tour.index, tour.step])
 
   const sessions = useSessions()
+  const update = useUpdate()
 
   useEffect(() => {
     if (!menuOpen) return
@@ -145,6 +148,8 @@ function PopoverView() {
           </div>
         </div>
       </header>
+
+      <UpdateBanner update={update} />
 
       {/* ページコンテンツ */}
       <main className={styles.content}>

--- a/src/renderer/src/components/Popover/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.test.tsx
@@ -11,7 +11,7 @@ const info = {
 
 function state(over: Partial<UpdateState>): UpdateState {
   return {
-    phase: 'idle', info: null, percent: 0, error: null,
+    phase: 'idle', info: null, percent: 0, error: null, currentVersion: '',
     check: vi.fn(), download: vi.fn(), restart: vi.fn(), dismiss: vi.fn(),
     ...over,
   }
@@ -50,19 +50,17 @@ describe('UpdateBanner', () => {
     expect(screen.getByText(/42%/)).toBeInTheDocument()
   })
 
-  it('installed で再起動を確認後 restart を呼ぶ', () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  it('opened で再起動ボタンを押すと注入された restart が呼ばれる', () => {
     const restart = vi.fn()
-    render(<UpdateBanner update={state({ phase: 'installed', info, restart })} />)
+    render(<UpdateBanner update={state({ phase: 'opened', info, restart })} />)
     fireEvent.click(screen.getByRole('button', { name: '再起動' }))
     expect(restart).toHaveBeenCalled()
   })
 
-  it('再起動確認でキャンセルすると restart を呼ばない', () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false)
+  it('installed で再起動ボタンを押すと注入された restart が呼ばれる', () => {
     const restart = vi.fn()
-    render(<UpdateBanner update={state({ phase: 'opened', info, restart })} />)
+    render(<UpdateBanner update={state({ phase: 'installed', info, restart })} />)
     fireEvent.click(screen.getByRole('button', { name: '再起動' }))
-    expect(restart).not.toHaveBeenCalled()
+    expect(restart).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/Popover/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.test.tsx
@@ -1,0 +1,68 @@
+// src/renderer/src/components/Popover/UpdateBanner.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { UpdateBanner } from './UpdateBanner'
+import type { UpdateState } from '../../hooks/useUpdate'
+
+const info = {
+  currentVersion: '1.0.0', latestVersion: '1.1.0', hasUpdate: true,
+  releaseUrl: 'u', downloadUrl: 'd', assetName: 'a.dmg', notes: '',
+}
+
+function state(over: Partial<UpdateState>): UpdateState {
+  return {
+    phase: 'idle', info: null, percent: 0, error: null,
+    check: vi.fn(), download: vi.fn(), restart: vi.fn(), dismiss: vi.fn(),
+    ...over,
+  }
+}
+
+beforeEach(() => vi.restoreAllMocks())
+
+describe('UpdateBanner', () => {
+  it('idle では何も描画しない', () => {
+    const { container } = render(<UpdateBanner update={state({ phase: 'idle' })} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('available でバージョンと更新ボタンを表示', () => {
+    render(<UpdateBanner update={state({ phase: 'available', info })} />)
+    expect(screen.getByText(/1\.1\.0/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '更新' })).toBeInTheDocument()
+  })
+
+  it('更新ボタンで download を呼ぶ', () => {
+    const download = vi.fn()
+    render(<UpdateBanner update={state({ phase: 'available', info, download })} />)
+    fireEvent.click(screen.getByRole('button', { name: '更新' }))
+    expect(download).toHaveBeenCalled()
+  })
+
+  it('✕ で dismiss を呼ぶ', () => {
+    const dismiss = vi.fn()
+    render(<UpdateBanner update={state({ phase: 'available', info, dismiss })} />)
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+    expect(dismiss).toHaveBeenCalled()
+  })
+
+  it('downloading では進捗を表示し更新ボタンは無効', () => {
+    render(<UpdateBanner update={state({ phase: 'downloading', info, percent: 42 })} />)
+    expect(screen.getByText(/42%/)).toBeInTheDocument()
+  })
+
+  it('installed で再起動を確認後 restart を呼ぶ', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const restart = vi.fn()
+    render(<UpdateBanner update={state({ phase: 'installed', info, restart })} />)
+    fireEvent.click(screen.getByRole('button', { name: '再起動' }))
+    expect(restart).toHaveBeenCalled()
+  })
+
+  it('再起動確認でキャンセルすると restart を呼ばない', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const restart = vi.fn()
+    render(<UpdateBanner update={state({ phase: 'opened', info, restart })} />)
+    fireEvent.click(screen.getByRole('button', { name: '再起動' }))
+    expect(restart).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/Popover/UpdateBanner.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.tsx
@@ -10,10 +10,6 @@ export function UpdateBanner({ update }: Props) {
   const { phase, info, percent, restart, download, dismiss } = update
   if (phase === 'idle' || phase === 'error' || !info) return null
 
-  const confirmRestart = (): void => {
-    if (window.confirm('Juice を再起動しますか？')) restart()
-  }
-
   const bar = 'flex items-center justify-between gap-2 px-3 py-2 text-[12px] [-webkit-app-region:no-drag]'
 
   if (phase === 'available') {
@@ -47,7 +43,7 @@ export function UpdateBanner({ update }: Props) {
       <span>{message}</span>
       <button
         className={phase === 'installed' ? 'font-bold underline' : 'font-semibold underline'}
-        onClick={confirmRestart}
+        onClick={restart}
       >
         再起動
       </button>

--- a/src/renderer/src/components/Popover/UpdateBanner.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.tsx
@@ -1,0 +1,56 @@
+// src/renderer/src/components/Popover/UpdateBanner.tsx
+import type { UpdateState } from '../../hooks/useUpdate'
+
+interface Props {
+  update: UpdateState
+}
+
+/** ポップオーバー上部のアップデート通知バナー。状態に応じて文言・操作が変わる */
+export function UpdateBanner({ update }: Props) {
+  const { phase, info, percent, restart, download, dismiss } = update
+  if (phase === 'idle' || phase === 'error' || !info) return null
+
+  const confirmRestart = (): void => {
+    if (window.confirm('Juice を再起動しますか？')) restart()
+  }
+
+  const bar = 'flex items-center justify-between gap-2 px-3 py-2 text-[12px] [-webkit-app-region:no-drag]'
+
+  if (phase === 'available') {
+    return (
+      <div className={`${bar} bg-[var(--accent-light)] text-[var(--accent)]`}>
+        <span>新しいバージョン v{info.latestVersion} があります</span>
+        <span className="flex items-center gap-2">
+          <button className="font-semibold underline" onClick={download}>更新</button>
+          <button aria-label="閉じる" onClick={dismiss}>✕</button>
+        </span>
+      </div>
+    )
+  }
+
+  if (phase === 'downloading') {
+    return (
+      <div className={`${bar} bg-[var(--accent-light)] text-[var(--accent)]`}>
+        <span>ダウンロード中… {percent}%</span>
+        <button className="opacity-50" disabled>更新</button>
+      </div>
+    )
+  }
+
+  // opened / installed: 再起動を促す
+  const message =
+    phase === 'installed'
+      ? '新バージョンがインストールされました'
+      : 'Applications にドラッグして置き換え、完了したら再起動してください'
+  return (
+    <div className={`${bar} bg-[var(--accent-light)] text-[var(--accent)]`}>
+      <span>{message}</span>
+      <button
+        className={phase === 'installed' ? 'font-bold underline' : 'font-semibold underline'}
+        onClick={confirmRestart}
+      >
+        再起動
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -289,7 +289,7 @@ export function SettingsView() {
                 <div className="flex items-center justify-between">
                   <span className="text-[13px] text-foreground">現在のバージョン</span>
                   <span className="text-[13px] text-muted-foreground">
-                    {update.info?.currentVersion ?? '—'}
+                    {update.currentVersion || update.info?.currentVersion || '—'}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
@@ -324,7 +324,7 @@ export function SettingsView() {
                   {(update.phase === 'opened' || update.phase === 'installed') && (
                     <button
                       className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-[13px] text-white"
-                      onClick={() => { if (window.confirm('Juice を再起動しますか？')) update.restart() }}
+                      onClick={update.restart}
                     >
                       再起動
                     </button>

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { THEMES, DARK_THEMES } from '../../themes'
 import { useSettings } from '../../hooks/useSettings'
+import { useUpdate } from '../../hooks/useUpdate'
 import { ThemeGrid } from '../ThemeGrid/ThemeGrid'
 import { Card, CardContent } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
@@ -15,7 +16,7 @@ import {
 } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-type Section = 'theme' | 'notification' | 'account' | 'analysis' | 'startup'
+type Section = 'theme' | 'notification' | 'account' | 'analysis' | 'startup' | 'update'
 
 const NAV_ITEMS: { id: Section; label: string }[] = [
   { id: 'theme', label: 'テーマ' },
@@ -23,6 +24,7 @@ const NAV_ITEMS: { id: Section; label: string }[] = [
   { id: 'account', label: '連携' },
   { id: 'analysis', label: '分析' },
   { id: 'startup', label: '起動' },
+  { id: 'update', label: 'アップデート' },
 ]
 
 const heading = 'mb-2 mt-0 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground'
@@ -44,6 +46,7 @@ export function SettingsView() {
     setTheme, setIdle, setElapsed, setPomodoro, setWhiteboard, setBreakBehavior, setMainProjectCode,
     setLaunchAtLogin,
   } = useSettings()
+  const update = useUpdate()
 
   return (
     <Tabs
@@ -272,6 +275,61 @@ export function SettingsView() {
                   </p>
                 </div>
                 <Switch checked={launchAtLogin} onCheckedChange={setLaunchAtLogin} />
+              </CardContent>
+            </Card>
+          </>
+        )}
+
+        {/* ─── アップデート ─── */}
+        {activeSection === 'update' && (
+          <>
+            <h2 className={heading}>アップデート</h2>
+            <Card>
+              <CardContent className="flex flex-col gap-3 p-3.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-[13px] text-foreground">現在のバージョン</span>
+                  <span className="text-[13px] text-muted-foreground">
+                    {update.info?.currentVersion ?? '—'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-[13px] text-foreground">状態</span>
+                  <span className="text-[13px] text-muted-foreground">
+                    {update.phase === 'available'
+                      ? `更新があります（v${update.info?.latestVersion}）`
+                      : update.phase === 'downloading'
+                        ? `ダウンロード中… ${update.percent}%`
+                        : update.phase === 'opened' || update.phase === 'installed'
+                          ? '再起動で更新を適用'
+                          : update.phase === 'error'
+                            ? (update.error ?? '確認に失敗しました')
+                            : '最新です'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    className="rounded-md border border-input px-3 py-1.5 text-[13px]"
+                    onClick={() => { update.check().catch(console.error) }}
+                  >
+                    更新を確認
+                  </button>
+                  {update.phase === 'available' && (
+                    <button
+                      className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-[13px] text-white"
+                      onClick={update.download}
+                    >
+                      ダウンロード
+                    </button>
+                  )}
+                  {(update.phase === 'opened' || update.phase === 'installed') && (
+                    <button
+                      className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-[13px] text-white"
+                      onClick={() => { if (window.confirm('Juice を再起動しますか？')) update.restart() }}
+                    >
+                      再起動
+                    </button>
+                  )}
+                </div>
               </CardContent>
             </Card>
           </>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import type { Session, DailyMonth, DayRecord } from '../../shared/types'
+import type { Session, DailyMonth, DayRecord, UpdateInfo } from '../../shared/types'
 import type {
   AttendanceSendResult, AuthStatus, BreakBehaviorSettings, PomodoroSettings, ToggleSettings, WhiteboardSettings,
 } from '../../shared/ipc'
@@ -59,6 +59,15 @@ interface ElectronAPI {
   getAuthStatus: () => Promise<AuthStatus>
   signOutSlack: () => Promise<void>
   onAuthChanged: (callback: (status: AuthStatus) => void) => () => void
+
+  // update
+  checkForUpdate: () => Promise<UpdateInfo>
+  downloadUpdate: () => Promise<void>
+  restartForUpdate: () => Promise<void>
+  dismissUpdate: (version: string) => Promise<void>
+  onUpdateAvailable: (callback: (info: UpdateInfo) => void) => () => void
+  onUpdateProgress: (callback: (p: { percent: number; done: boolean; error?: string }) => void) => () => void
+  onUpdateInstalled: (callback: (p: { version: string }) => void) => () => void
 
   // misc
   completeSetup: () => Promise<void>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -45,6 +45,7 @@ interface ElectronAPI {
   timerStarted: () => Promise<void>
   timerStopped: () => Promise<void>
   timerAdjustStartTime: (newStartMs: number) => Promise<void>
+  isTimerRunning: () => Promise<boolean>
 
   // attendance
   sendAttendance: (text: string) => Promise<AttendanceSendResult>
@@ -73,6 +74,7 @@ interface ElectronAPI {
   completeSetup: () => Promise<void>
   getHolidays: () => Promise<Record<string, string>>
   openUrl: (url: string) => Promise<void>
+  getAppVersion: () => Promise<string>
 }
 
 declare global {

--- a/src/renderer/src/hooks/useUpdate.test.ts
+++ b/src/renderer/src/hooks/useUpdate.test.ts
@@ -12,6 +12,7 @@ const mockCheck = vi.fn()
 const mockDownload = vi.fn()
 const mockRestart = vi.fn()
 const mockDismiss = vi.fn()
+const mockGetCurrentVersion = vi.fn()
 
 vi.mock('../repositories/updateRepository', () => ({
   updateRepository: {
@@ -19,9 +20,18 @@ vi.mock('../repositories/updateRepository', () => ({
     download: () => mockDownload(),
     restart: () => mockRestart(),
     dismiss: (v: string) => mockDismiss(v),
+    getCurrentVersion: () => mockGetCurrentVersion(),
     onAvailable: (cb: (i: UpdateInfo) => void) => { handlers.available = cb; return () => {} },
     onProgress: (cb: (p: { percent: number; done: boolean; error?: string }) => void) => { handlers.progress = cb; return () => {} },
     onInstalled: (cb: (p: { version: string }) => void) => { handlers.installed = cb; return () => {} },
+  },
+}))
+
+const mockIsRunning = vi.fn()
+
+vi.mock('../repositories/timerRepository', () => ({
+  timerRepository: {
+    isRunning: () => mockIsRunning(),
   },
 }))
 
@@ -37,6 +47,8 @@ beforeEach(() => {
   mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
   mockDismiss.mockResolvedValue(undefined)
   mockRestart.mockResolvedValue(undefined)
+  mockGetCurrentVersion.mockResolvedValue('1.0.0')
+  mockIsRunning.mockResolvedValue(false)
 })
 
 describe('useUpdate', () => {
@@ -83,5 +95,51 @@ describe('useUpdate', () => {
     const { result } = renderHook(() => useUpdate())
     await act(async () => { await result.current.check() })
     await waitFor(() => expect(result.current.phase).toBe('available'))
+  })
+
+  it('check 成功で hasUpdate=false なら phase=idle', async () => {
+    mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { await result.current.check() })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+  })
+
+  it('check 失敗時に phase=error・error メッセージを設定', async () => {
+    mockCheck.mockRejectedValue(new Error('network error'))
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { await result.current.check() })
+    await waitFor(() => {
+      expect(result.current.phase).toBe('error')
+      expect(result.current.error).toBe('確認に失敗しました')
+    })
+  })
+
+  it('restart: confirm=true のとき updateRepository.restart を呼ぶ', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { result.current.restart() })
+    await waitFor(() => expect(mockRestart).toHaveBeenCalled())
+  })
+
+  it('restart: confirm=false のとき updateRepository.restart を呼ばない', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { result.current.restart() })
+    expect(mockRestart).not.toHaveBeenCalled()
+  })
+
+  it('restart: タイマー稼働中のとき confirm 文言に「稼働中」を含む', async () => {
+    mockIsRunning.mockResolvedValue(true)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { result.current.restart() })
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalled())
+    expect(confirmSpy.mock.calls[0][0]).toContain('稼働中')
+  })
+
+  it('マウント時に currentVersion を取得する', async () => {
+    mockGetCurrentVersion.mockResolvedValue('2.0.0')
+    const { result } = renderHook(() => useUpdate())
+    await waitFor(() => expect(result.current.currentVersion).toBe('2.0.0'))
   })
 })

--- a/src/renderer/src/hooks/useUpdate.test.ts
+++ b/src/renderer/src/hooks/useUpdate.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { UpdateInfo } from '../../../shared/types'
+
+const handlers: {
+  available?: (i: UpdateInfo) => void
+  progress?: (p: { percent: number; done: boolean; error?: string }) => void
+  installed?: (p: { version: string }) => void
+} = {}
+
+const mockCheck = vi.fn()
+const mockDownload = vi.fn()
+const mockRestart = vi.fn()
+const mockDismiss = vi.fn()
+
+vi.mock('../repositories/updateRepository', () => ({
+  updateRepository: {
+    check: () => mockCheck(),
+    download: () => mockDownload(),
+    restart: () => mockRestart(),
+    dismiss: (v: string) => mockDismiss(v),
+    onAvailable: (cb: (i: UpdateInfo) => void) => { handlers.available = cb; return () => {} },
+    onProgress: (cb: (p: { percent: number; done: boolean; error?: string }) => void) => { handlers.progress = cb; return () => {} },
+    onInstalled: (cb: (p: { version: string }) => void) => { handlers.installed = cb; return () => {} },
+  },
+}))
+
+import { useUpdate } from './useUpdate'
+
+const info: UpdateInfo = {
+  currentVersion: '1.0.0', latestVersion: '1.1.0', hasUpdate: true,
+  releaseUrl: 'u', downloadUrl: 'd', assetName: 'Juice-1.1.0-arm64.dmg', notes: '',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
+})
+
+describe('useUpdate', () => {
+  it('update-available で phase=available・info を反映', async () => {
+    const { result } = renderHook(() => useUpdate())
+    act(() => handlers.available!(info))
+    expect(result.current.phase).toBe('available')
+    expect(result.current.info?.latestVersion).toBe('1.1.0')
+  })
+
+  it('進捗イベントで downloading→opened に進む', async () => {
+    const { result } = renderHook(() => useUpdate())
+    act(() => handlers.available!(info))
+    act(() => handlers.progress!({ percent: 40, done: false }))
+    expect(result.current.phase).toBe('downloading')
+    expect(result.current.percent).toBe(40)
+    act(() => handlers.progress!({ percent: 100, done: true }))
+    expect(result.current.phase).toBe('opened')
+  })
+
+  it('進捗 error で phase=error', () => {
+    const { result } = renderHook(() => useUpdate())
+    act(() => handlers.progress!({ percent: 0, done: true, error: '失敗' }))
+    expect(result.current.phase).toBe('error')
+    expect(result.current.error).toBe('失敗')
+  })
+
+  it('update-installed で phase=installed', () => {
+    const { result } = renderHook(() => useUpdate())
+    act(() => handlers.installed!({ version: '1.1.0' }))
+    expect(result.current.phase).toBe('installed')
+  })
+
+  it('dismiss は repo.dismiss を呼び phase=idle', () => {
+    const { result } = renderHook(() => useUpdate())
+    act(() => handlers.available!(info))
+    act(() => result.current.dismiss())
+    expect(mockDismiss).toHaveBeenCalledWith('1.1.0')
+    expect(result.current.phase).toBe('idle')
+  })
+
+  it('check は repo.check の結果が更新ありなら available', async () => {
+    mockCheck.mockResolvedValue(info)
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { await result.current.check() })
+    await waitFor(() => expect(result.current.phase).toBe('available'))
+  })
+})

--- a/src/renderer/src/hooks/useUpdate.test.ts
+++ b/src/renderer/src/hooks/useUpdate.test.ts
@@ -35,6 +35,8 @@ const info: UpdateInfo = {
 beforeEach(() => {
   vi.clearAllMocks()
   mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
+  mockDismiss.mockResolvedValue(undefined)
+  mockRestart.mockResolvedValue(undefined)
 })
 
 describe('useUpdate', () => {

--- a/src/renderer/src/hooks/useUpdate.ts
+++ b/src/renderer/src/hooks/useUpdate.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { updateRepository } from '../repositories/updateRepository'
+import { timerRepository } from '../repositories/timerRepository'
 import type { UpdateInfo } from '../../../shared/types'
 
 export type UpdatePhase = 'idle' | 'available' | 'downloading' | 'opened' | 'installed' | 'error'
@@ -9,6 +10,7 @@ export interface UpdateState {
   info: UpdateInfo | null
   percent: number
   error: string | null
+  currentVersion: string
   check: () => Promise<void>
   download: () => void
   restart: () => void
@@ -21,6 +23,16 @@ export function useUpdate(): UpdateState {
   const [info, setInfo] = useState<UpdateInfo | null>(null)
   const [percent, setPercent] = useState(0)
   const [error, setError] = useState<string | null>(null)
+  const [currentVersion, setCurrentVersion] = useState('')
+
+  useEffect(() => {
+    // マウント時に現在のバージョンを取得する（ネットワーク不要）
+    let alive = true
+    updateRepository.getCurrentVersion()
+      .then(v => { if (alive) setCurrentVersion(v) })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [])
 
   useEffect(() => {
     const offAvail = updateRepository.onAvailable((i) => {
@@ -41,9 +53,14 @@ export function useUpdate(): UpdateState {
   }, [])
 
   const check = async (): Promise<void> => {
-    const result = await updateRepository.check()
-    setInfo(result)
-    if (result.hasUpdate) setPhase('available')
+    try {
+      const result = await updateRepository.check()
+      setInfo(result)
+      setPhase(result.hasUpdate ? 'available' : 'idle')
+    } catch {
+      setError('確認に失敗しました')
+      setPhase('error')
+    }
   }
 
   const download = (): void => {
@@ -57,7 +74,15 @@ export function useUpdate(): UpdateState {
   }
 
   const restart = (): void => {
-    updateRepository.restart().catch(console.error)
+    void (async () => {
+      const running = await timerRepository.isRunning().catch(() => false)
+      const message = running
+        ? 'タイマーが稼働中です。進行中の記録は保存されません。再起動しますか？'
+        : 'Juice を再起動しますか？'
+      if (window.confirm(message)) {
+        updateRepository.restart().catch(console.error)
+      }
+    })()
   }
 
   const dismiss = (): void => {
@@ -65,5 +90,5 @@ export function useUpdate(): UpdateState {
     setPhase('idle')
   }
 
-  return { phase, info, percent, error, check, download, restart, dismiss }
+  return { phase, info, percent, error, currentVersion, check, download, restart, dismiss }
 }

--- a/src/renderer/src/hooks/useUpdate.ts
+++ b/src/renderer/src/hooks/useUpdate.ts
@@ -61,7 +61,7 @@ export function useUpdate(): UpdateState {
   }
 
   const dismiss = (): void => {
-    if (info) void Promise.resolve(updateRepository.dismiss(info.latestVersion)).catch(console.error)
+    if (info) updateRepository.dismiss(info.latestVersion).catch(console.error)
     setPhase('idle')
   }
 

--- a/src/renderer/src/hooks/useUpdate.ts
+++ b/src/renderer/src/hooks/useUpdate.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { updateRepository } from '../repositories/updateRepository'
+import type { UpdateInfo } from '../../../shared/types'
+
+export type UpdatePhase = 'idle' | 'available' | 'downloading' | 'opened' | 'installed' | 'error'
+
+export interface UpdateState {
+  phase: UpdatePhase
+  info: UpdateInfo | null
+  percent: number
+  error: string | null
+  check: () => Promise<void>
+  download: () => void
+  restart: () => void
+  dismiss: () => void
+}
+
+/** アップデート状態の購読と操作（ポップオーバー・設定で共有） */
+export function useUpdate(): UpdateState {
+  const [phase, setPhase] = useState<UpdatePhase>('idle')
+  const [info, setInfo] = useState<UpdateInfo | null>(null)
+  const [percent, setPercent] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const offAvail = updateRepository.onAvailable((i) => {
+      setInfo(i)
+      setPhase('available')
+    })
+    const offProg = updateRepository.onProgress((p) => {
+      if (p.error) {
+        setError(p.error)
+        setPhase('error')
+        return
+      }
+      setPercent(p.percent)
+      setPhase(p.done ? 'opened' : 'downloading')
+    })
+    const offInst = updateRepository.onInstalled(() => setPhase('installed'))
+    return () => { offAvail(); offProg(); offInst() }
+  }, [])
+
+  const check = async (): Promise<void> => {
+    const result = await updateRepository.check()
+    setInfo(result)
+    if (result.hasUpdate) setPhase('available')
+  }
+
+  const download = (): void => {
+    setError(null)
+    setPercent(0)
+    setPhase('downloading')
+    updateRepository.download().catch(() => {
+      setError('ダウンロードに失敗しました')
+      setPhase('error')
+    })
+  }
+
+  const restart = (): void => {
+    updateRepository.restart().catch(console.error)
+  }
+
+  const dismiss = (): void => {
+    if (info) void Promise.resolve(updateRepository.dismiss(info.latestVersion)).catch(console.error)
+    setPhase('idle')
+  }
+
+  return { phase, info, percent, error, check, download, restart, dismiss }
+}

--- a/src/renderer/src/repositories/timerRepository.ts
+++ b/src/renderer/src/repositories/timerRepository.ts
@@ -14,4 +14,8 @@ export const timerRepository = {
   adjustStartTime(newStartMs: number): Promise<void> {
     return window.electronAPI.timerAdjustStartTime(newStartMs)
   },
+  /** タイマーが稼働中かどうかをメインプロセスに問い合わせる */
+  isRunning(): Promise<boolean> {
+    return window.electronAPI.isTimerRunning()
+  },
 }

--- a/src/renderer/src/repositories/updateRepository.ts
+++ b/src/renderer/src/repositories/updateRepository.ts
@@ -1,0 +1,28 @@
+// アップデートのデータアクセス: window.electronAPI への依存をこの層に閉じ込める。
+import type { UpdateInfo } from '../../../shared/types'
+
+export interface UpdateProgress { percent: number; done: boolean; error?: string }
+
+export const updateRepository = {
+  check(): Promise<UpdateInfo> {
+    return window.electronAPI.checkForUpdate()
+  },
+  download(): Promise<void> {
+    return window.electronAPI.downloadUpdate()
+  },
+  restart(): Promise<void> {
+    return window.electronAPI.restartForUpdate()
+  },
+  dismiss(version: string): Promise<void> {
+    return window.electronAPI.dismissUpdate(version)
+  },
+  onAvailable(cb: (info: UpdateInfo) => void): () => void {
+    return window.electronAPI.onUpdateAvailable(cb)
+  },
+  onProgress(cb: (p: UpdateProgress) => void): () => void {
+    return window.electronAPI.onUpdateProgress(cb)
+  },
+  onInstalled(cb: (p: { version: string }) => void): () => void {
+    return window.electronAPI.onUpdateInstalled(cb)
+  },
+}

--- a/src/renderer/src/repositories/updateRepository.ts
+++ b/src/renderer/src/repositories/updateRepository.ts
@@ -25,4 +25,7 @@ export const updateRepository = {
   onInstalled(cb: (p: { version: string }) => void): () => void {
     return window.electronAPI.onUpdateInstalled(cb)
   },
+  getCurrentVersion(): Promise<string> {
+    return window.electronAPI.getAppVersion()
+  },
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -80,6 +80,7 @@ export interface IpcContract {
   'timer:started': [void, void]
   'timer:stopped': [void, void]
   'timer:adjustStartTime': [newStartMs: number, void]
+  'timer:isRunning': [void, boolean]
 
   // attendance
   'attendance:send': [text: string, AttendanceSendResult]
@@ -106,6 +107,7 @@ export interface IpcContract {
   'setup:complete': [void, void]
   'holidays:get': [void, Record<string, string>]
   'shell:openUrl': [url: string, void]
+  'app:getVersion': [void, string]
 }
 
 export type IpcChannel = keyof IpcContract

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,4 +1,4 @@
-import type { Session, DailyMonth, DayRecord } from './types'
+import type { Session, DailyMonth, DayRecord, UpdateInfo } from './types'
 
 // IPC コントラクト: メインプロセスとレンダラーで共有する契約。
 // チャンネル名のリテラル衝突、ハンドラ追加忘れ、引数/戻り値のドリフトを型で防ぐ。
@@ -96,6 +96,12 @@ export interface IpcContract {
   'auth:getStatus': [void, AuthStatus]
   'auth:signOut': [void, void]
 
+  // update
+  'update:check': [void, UpdateInfo]
+  'update:download': [void, void]
+  'update:restart': [void, void]
+  'update:dismiss': [version: string, void]
+
   // misc
   'setup:complete': [void, void]
   'holidays:get': [void, Record<string, string>]
@@ -113,6 +119,9 @@ export type IpcReturn<C extends IpcChannel> = IpcContract[C][1]
 export interface IpcEventContract {
   'theme-changed': string
   'auth-changed': AuthStatus
+  'update-available': UpdateInfo
+  'update-download-progress': { percent: number; done: boolean; error?: string }
+  'update-installed': { version: string }
 }
 
 export type IpcEventName = keyof IpcEventContract

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -37,3 +37,14 @@ export interface DailyMonth {
   version: number
   days: Record<string, DayRecord>
 }
+
+/** アプリ内アップデートの状態（main→renderer 共有） */
+export interface UpdateInfo {
+  currentVersion: string      // 例 "1.0.0"（app.getVersion()）
+  latestVersion: string       // 例 "1.1.0"（タグ vX.Y.Z を正規化）
+  hasUpdate: boolean          // latest が current より新しい
+  releaseUrl: string          // リリースページ（フォールバックで開く）
+  downloadUrl: string | null  // arch 一致 DMG の URL。無ければ null
+  assetName: string | null    // 例 "Juice-1.1.0-arm64.dmg"。無ければ null
+  notes: string               // リリースノート本文（未使用なら空）
+}

--- a/src/shared/version.test.ts
+++ b/src/shared/version.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeVersion, compareVersions, isNewerVersion } from './version'
+
+describe('normalizeVersion', () => {
+  it('先頭の v と空白を除去する', () => {
+    expect(normalizeVersion('v1.2.3')).toBe('1.2.3')
+    expect(normalizeVersion('  V1.0.0 ')).toBe('1.0.0')
+    expect(normalizeVersion('1.0.0')).toBe('1.0.0')
+  })
+})
+
+describe('compareVersions', () => {
+  it('大小を数値として比較する', () => {
+    expect(compareVersions('1.0.0', '1.1.0')).toBe(-1)
+    expect(compareVersions('1.1.0', '1.0.0')).toBe(1)
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0)
+  })
+  it('文字列順ではなく数値順（1.10.0 > 1.9.0）', () => {
+    expect(compareVersions('1.10.0', '1.9.0')).toBe(1)
+  })
+  it('v 接頭辞や桁数差を吸収する', () => {
+    expect(compareVersions('v1.2', '1.2.0')).toBe(0)
+    expect(compareVersions('2.0.0', 'v1.9.9')).toBe(1)
+  })
+})
+
+describe('isNewerVersion', () => {
+  it('candidate が新しいときだけ true', () => {
+    expect(isNewerVersion('1.1.0', '1.0.0')).toBe(true)
+    expect(isNewerVersion('1.0.0', '1.0.0')).toBe(false)
+    expect(isNewerVersion('0.9.0', '1.0.0')).toBe(false)
+  })
+})

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,23 @@
+/** 先頭の v/V と前後空白を除いた semver 文字列を返す */
+export function normalizeVersion(v: string): string {
+  return v.trim().replace(/^[vV]/, '')
+}
+
+/** major.minor.patch を数値で比較。a<b→-1, a==b→0, a>b→1。桁の欠落は 0 扱い */
+export function compareVersions(a: string, b: string): number {
+  const pa = normalizeVersion(a).split('.').map(n => parseInt(n, 10) || 0)
+  const pb = normalizeVersion(b).split('.').map(n => parseInt(n, 10) || 0)
+  const len = Math.max(pa.length, pb.length)
+  for (let i = 0; i < len; i++) {
+    const da = pa[i] ?? 0
+    const db = pb[i] ?? 0
+    if (da > db) return 1
+    if (da < db) return -1
+  }
+  return 0
+}
+
+/** candidate が current より新しければ true */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  return compareVersions(candidate, current) > 0
+}


### PR DESCRIPTION
## やったこと

- GitHub Releases を起動時・6時間ごと・手動でチェックし、新バージョンをアプリ内通知（署名なし方式B）
- ポップオーバー上部バナー＋設定「アップデート」タブ
- arch 別 DMG を一時ディレクトリに DL→自動オープン
- `/Applications` の上書きを検知して「再起動」ボタン提示（稼働中は警告文言）
- バージョンを 1.1.0 に更新、README にリリース手順（正式リリースで公開）を追記

Closes #92