### PR TITLE
docs: CHANGELOG.md を追加（手動テンプレート運用）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# 変更履歴
+
+このファイルは Juice の主な変更をまとめます。
+形式は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に準じ、
+バージョンは [セマンティック バージョニング](https://semver.org/lang/ja/) に従います。
+
+各リリース時は、このファイルに新しい節を追記し、その内容を GitHub Release の本文にも使います。
+カテゴリは必要なものだけ使い、内部的な変更（docs / chore / refactor など）はユーザー向けには載せません。
+
+- ✨ 新機能（Added）
+- 🔧 改善（Changed）
+- 🐛 修正（Fixed）
+- ⚠️ 重要な変更（互換性に影響する変更・注意）
+- 🔒 セキュリティ（Security）
+
+## [Unreleased]
+
+## [1.1.0] - 2026-06-29
+
+### ✨ 新機能
+
+- アプリ内アップデート通知: 新しいバージョンが出るとアプリ内で知らせ、ワンクリックで
+  DMG を取得・更新できるようになりました（起動時・6時間ごと・手動チェックに対応）
+
+## [1.0.0] - 2026-06-24
+
+### ✨ 新機能
+
+- 初回リリース。作業セッションをタイマーで記録し、カレンダー・勤怠の確認、テーマや
+  各種通知（アイドル / 経過時間 / ポモドーロ）に対応した macOS メニューバーアプリ
+
+[Unreleased]: https://github.com/ryota-kanayama/juice/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/ryota-kanayama/juice/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ryota-kanayama/juice/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ CSC_IDENTITY_AUTO_DISCOVERY=false npm run package
 アプリ内で通知する。配信時は次の手順を踏む（**version を上げ忘れると検知されない**）。
 
 1. `package.json` の `version` を上げる（例 `1.0.0` → `1.1.0`）
-2. `CSC_IDENTITY_AUTO_DISCOVERY=false npm run package` で arm64 / x64 の DMG をビルド
-3. GitHub Release を `vX.Y.Z` タグで作成し、`Juice-X.Y.Z-arm64.dmg` と
-   `Juice-X.Y.Z.dmg`（および blockmap・latest-mac.yml）を添付する
+2. [`CHANGELOG.md`](CHANGELOG.md) にこのバージョンの節を追記する
+   （形式はファイル冒頭のテンプレートに従う。リリース本文にも同じ内容を使う）
+3. `CSC_IDENTITY_AUTO_DISCOVERY=false npm run package` で arm64 / x64 の DMG をビルド
+4. GitHub Release を `vX.Y.Z` タグで作成し、本文に CHANGELOG の該当節を貼り、
+   `Juice-X.Y.Z-arm64.dmg` と `Juice-X.Y.Z.dmg`（および blockmap・latest-mac.yml）を添付する
    - **必ず正式リリースで公開する（pre-release にしない）**。アプリは
      `releases/latest` を参照するが、このエンドポイントは pre-release / draft を
      除外するため、pre-release のままだと更新が検知されない
-4. クライアントは6時間以内（または再起動・手動チェック）に更新を検知し、
+5. クライアントは6時間以内（または再起動・手動チェック）に更新を検知し、
    ワンクリックで DMG を取得・オープンできる


### PR DESCRIPTION
## やったこと

- Keep a Changelog 形式の `CHANGELOG.md` を追加（v1.1.0 / v1.0.0 を遡及記載）
- リリース手順（README）に CHANGELOG 追記ステップを追加
- markdownlint `MD024` を `siblings_only` に（バージョンごとの同名カテゴリ見出しを許可）

将来、運用が回ってきたら release-please 等で自動化予定。