### PR TITLE
feat: フレックス勤務対応（勤務場所の切替・tw出力・whiteboard追従） (#68)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,7 +39,11 @@ function isSettingsRoute(): boolean {
 export default function App() {
   if (isSetupRoute()) return <SetupView />
   if (isSettingsRoute()) return <SettingsView />
-  return <PopoverView />
+  return (
+    <DailyDataProvider>
+      <PopoverView />
+    </DailyDataProvider>
+  )
 }
 
 /** トリガー用のアバター。画像があれば表示し、無い・読み込み失敗時は人型アイコンにフォールバック */
@@ -85,7 +89,6 @@ function PopoverView() {
   }, [menuOpen])
 
   return (
-    <DailyDataProvider>
     <div className={styles.app}>
       {/* ヘッダー */}
       <header className={styles.header}>
@@ -206,7 +209,6 @@ function PopoverView() {
 
       <TourOverlay tour={tour} />
     </div>
-    </DailyDataProvider>
   )
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -72,6 +72,7 @@ function PopoverView() {
   }, [tour.index, tour.step])
 
   const sessions = useSessions()
+  const workday = useWorkday(sessions.today)
   const update = useUpdate()
 
   useEffect(() => {
@@ -134,6 +135,16 @@ function PopoverView() {
                   </>
                 )}
               </div>
+              {workday.workStart && (
+                <>
+                  <div className={styles.menuDivider} />
+                  <WorkLocationSwitch
+                    location={workday.currentLocation}
+                    onSwitch={workday.switchLocation}
+                    className="flex w-full items-center justify-between gap-3 px-4 py-2.5 text-[13px] text-muted-foreground"
+                  />
+                </>
+              )}
               <div className={styles.menuDivider} />
               <button
                 className={styles.menuItem}
@@ -219,10 +230,6 @@ export function TimerPage({ sessions, tourDemo = false }: { sessions: SessionsSt
           <span>保存に失敗しました。タイマーは継続中です。もう一度停止してください</span>
           <button onClick={ts.dismissStopError}><Xmark width={14} height={14} /></button>
         </div>
-      )}
-
-      {!tourDemo && workday.workStart && (
-        <WorkLocationSwitch location={workday.currentLocation} onSwitch={workday.switchLocation} />
       )}
 
       {tourDemo ? (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -255,7 +255,7 @@ export function TimerPage({ sessions, tourDemo = false }: { sessions: SessionsSt
       ) : (
         /* 待機時: スクロール可能なコンテナ */
         <div className={styles.idleContent}>
-          <TimerForm onStart={ts.start} nameSuggestions={suggestions.names} />
+          <TimerForm onStart={(name, pc, wc) => ts.start(name, pc, wc, workday.currentLocation)} nameSuggestions={suggestions.names} />
           <SessionList
             sessions={ts.todaySessions}
             today={ts.today}
@@ -264,7 +264,7 @@ export function TimerPage({ sessions, tourDemo = false }: { sessions: SessionsSt
             onStartMore={ts.startMore}
             onDelete={ts.remove}
             onAdjustStartTime={ms => ts.adjustStartTime(new Date(ms))}
-            onAdd={ts.add}
+            onAdd={(params) => ts.add(params, workday.currentLocation)}
             workStart={workday.workStart}
             workEnd={workday.workEnd}
             onWorkEnd={workday.endWork}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import { useAuthStatus } from './hooks/useAuthStatus'
 import { DailyDataProvider } from './daily/DailyDataContext'
 import { useUpdate } from './hooks/useUpdate'
 import { UpdateBanner } from './components/Popover/UpdateBanner'
+import { WorkLocationSwitch } from './components/Popover/WorkLocationSwitch'
 
 type Page = 'timer' | 'calendar' | 'attendance'
 
@@ -218,6 +219,10 @@ export function TimerPage({ sessions, tourDemo = false }: { sessions: SessionsSt
           <span>保存に失敗しました。タイマーは継続中です。もう一度停止してください</span>
           <button onClick={ts.dismissStopError}><Xmark width={14} height={14} /></button>
         </div>
+      )}
+
+      {!tourDemo && workday.workStart && (
+        <WorkLocationSwitch location={workday.currentLocation} onSwitch={workday.switchLocation} />
       )}
 
       {tourDemo ? (

--- a/src/renderer/src/components/Popover/WorkLocationSwitch.test.tsx
+++ b/src/renderer/src/components/Popover/WorkLocationSwitch.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WorkLocationSwitch } from './WorkLocationSwitch'
+
+describe('WorkLocationSwitch', () => {
+  it('出社中はテレワークへ切替えるボタンを出す', () => {
+    const onSwitch = vi.fn()
+    render(<WorkLocationSwitch location="office" onSwitch={onSwitch} />)
+    expect(screen.getByText('出社')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'テレワークに切替' }))
+    expect(onSwitch).toHaveBeenCalledWith('telework')
+  })
+
+  it('テレワーク中は出社へ切替えるボタンを出す', () => {
+    const onSwitch = vi.fn()
+    render(<WorkLocationSwitch location="telework" onSwitch={onSwitch} />)
+    expect(screen.getByText('テレワーク')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '出社に切替' }))
+    expect(onSwitch).toHaveBeenCalledWith('office')
+  })
+})

--- a/src/renderer/src/components/Popover/WorkLocationSwitch.tsx
+++ b/src/renderer/src/components/Popover/WorkLocationSwitch.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components/ui/button'
+import type { WorkLocation } from '../../types/session'
+
+interface Props {
+  location: WorkLocation
+  onSwitch: (loc: WorkLocation) => void
+}
+
+const LABEL: Record<WorkLocation, string> = {
+  office: '出社',
+  telework: 'テレワーク',
+}
+
+/** 現在の勤務場所を表示し、反対の場所へ切り替えるボタンを出す。 */
+export function WorkLocationSwitch({ location, onSwitch }: Props) {
+  const next: WorkLocation = location === 'office' ? 'telework' : 'office'
+  return (
+    <div className="mx-4 mt-2 flex items-center justify-between text-xs text-muted-foreground">
+      <span>勤務場所: <span className="font-bold text-foreground">{LABEL[location]}</span></span>
+      <Button
+        variant="ghost"
+        className="h-6 px-2 text-xs"
+        onClick={() => onSwitch(next)}
+      >
+        {LABEL[next]}に切替
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Popover/WorkLocationSwitch.tsx
+++ b/src/renderer/src/components/Popover/WorkLocationSwitch.tsx
@@ -4,6 +4,8 @@ import type { WorkLocation } from '../../types/session'
 interface Props {
   location: WorkLocation
   onSwitch: (loc: WorkLocation) => void
+  /** コンテナの className を上書きする（配置先に合わせて調整するため） */
+  className?: string
 }
 
 const LABEL: Record<WorkLocation, string> = {
@@ -12,10 +14,10 @@ const LABEL: Record<WorkLocation, string> = {
 }
 
 /** 現在の勤務場所を表示し、反対の場所へ切り替えるボタンを出す。 */
-export function WorkLocationSwitch({ location, onSwitch }: Props) {
+export function WorkLocationSwitch({ location, onSwitch, className }: Props) {
   const next: WorkLocation = location === 'office' ? 'telework' : 'office'
   return (
-    <div className="mx-4 mt-2 flex items-center justify-between text-xs text-muted-foreground">
+    <div className={className ?? 'mx-4 mt-2 flex items-center justify-between text-xs text-muted-foreground'}>
       <span>勤務場所: <span className="font-bold text-foreground">{LABEL[location]}</span></span>
       <Button
         variant="ghost"

--- a/src/renderer/src/domain/attendance.test.ts
+++ b/src/renderer/src/domain/attendance.test.ts
@@ -103,6 +103,29 @@ describe('buildAttendanceText', () => {
   })
 })
 
+describe('buildAttendanceText: フレックス勤務場所(tw)', () => {
+  it('テレワークのセッションは行末に tw を付ける', () => {
+    const sessions = [makeSession({ totalTime: 180, workLocation: 'telework' })]
+    const { text } = buildAttendanceText(sessions, '10:00', '13:00', 0)
+    expect(text).toBe('勤怠\n10:00 13:00 0\nZZ テスト作業 設計 180 tw')
+  })
+
+  it('出社(workLocation 未指定)のセッションは tw を付けない', () => {
+    const sessions = [makeSession({ totalTime: 180 })]
+    const { text } = buildAttendanceText(sessions, '10:00', '13:00', 0)
+    expect(text).toBe('勤怠\n10:00 13:00 0\nZZ テスト作業 設計 180')
+  })
+
+  it('同一タスクを出社・テレワーク両方でやると2行に分かれる', () => {
+    const sessions = [
+      makeSession({ id: 'a', taskId: 't', totalTime: 120, workLocation: 'office' }),
+      makeSession({ id: 'b', taskId: 't', totalTime: 60, workLocation: 'telework' }),
+    ]
+    const { text } = buildAttendanceText(sessions, '10:00', '13:00', 0)
+    expect(text).toBe('勤怠\n10:00 13:00 0\nZZ テスト作業 設計 120\nZZ テスト作業 設計 60 tw')
+  })
+})
+
 describe('calcBreakMinutes', () => {
   it('12:00〜13:00 は 60', () => {
     expect(calcBreakMinutes('12:00', '13:00')).toBe(60)

--- a/src/renderer/src/domain/attendance.ts
+++ b/src/renderer/src/domain/attendance.ts
@@ -1,4 +1,4 @@
-import type { Session } from '../types/session'
+import type { Session, WorkLocation } from '../types/session'
 
 // 勤怠ドメイン: 勤怠報告に関する純粋なルール。React も IPC も知らない。
 
@@ -41,10 +41,11 @@ export function buildAttendanceText(
   workEnd: string | null,
   breakMinutes: number
 ): AttendanceTextResult {
-  const map = new Map<string, { name: string; projectCode: string; workCategory: string; totalMinutes: number }>()
+  const map = new Map<string, { name: string; projectCode: string; workCategory: string; workLocation: WorkLocation; totalMinutes: number }>()
 
   for (const s of sessions) {
-    const key = s.taskId ?? s.id
+    const location: WorkLocation = s.workLocation ?? 'office'
+    const key = `${s.taskId ?? s.id}:${location}`
     const minutes = s.totalTime
     const existing = map.get(key)
     if (existing) {
@@ -54,6 +55,7 @@ export function buildAttendanceText(
         name: s.name.replace(/\s/g, ''),
         projectCode: s.projectCode ?? '',
         workCategory: s.workCategory ?? '',
+        workLocation: location,
         totalMinutes: minutes,
       })
     }
@@ -93,7 +95,10 @@ export function buildAttendanceText(
   const hasZeroTask = groups.some(g => g.totalMinutes === 0)
 
   const timeLine = `${workStart ?? ''} ${workEnd ?? ''} ${breakMinutes}`
-  const taskLines = groups.map(g => `${g.projectCode} ${g.name} ${g.workCategory} ${g.totalMinutes}`)
+  const taskLines = groups.map(g => {
+    const base = `${g.projectCode} ${g.name} ${g.workCategory} ${g.totalMinutes}`
+    return g.workLocation === 'telework' ? `${base} tw` : base
+  })
 
   return {
     text: ['勤怠', timeLine, ...taskLines].join('\n'),

--- a/src/renderer/src/domain/session.test.ts
+++ b/src/renderer/src/domain/session.test.ts
@@ -152,6 +152,18 @@ describe('createManualSession', () => {
   })
 })
 
+describe('createManualSession: 勤務場所', () => {
+  it('workLocation=telework を渡すと保持する', () => {
+    const s = createManualSession({ name: 'a', projectCode: 'ZZ', workCategory: '開発', totalMinutes: 30, workLocation: 'telework' })
+    expect(s.workLocation).toBe('telework')
+  })
+
+  it('workLocation=office は保持しない（undefined）', () => {
+    const s = createManualSession({ name: 'a', projectCode: 'ZZ', workCategory: '開発', totalMinutes: 30, workLocation: 'office' })
+    expect(s.workLocation).toBeUndefined()
+  })
+})
+
 describe('appendRunningInterval', () => {
   it('endTime=null の区間を末尾に追加する', () => {
     const session = makeSession()

--- a/src/renderer/src/domain/session.ts
+++ b/src/renderer/src/domain/session.ts
@@ -1,4 +1,4 @@
-import type { Session } from '../types/session'
+import type { Session, WorkLocation } from '../types/session'
 import { formatLocalDate, formatLocalDateTime } from '../../../shared/sessionUtils'
 import { randomColor } from './colors'
 
@@ -52,6 +52,7 @@ export function createManualSession(params: {
   projectCode: string
   workCategory: string
   totalMinutes: number
+  workLocation?: WorkLocation
 }): Session {
   const id = crypto.randomUUID()
   return {
@@ -64,6 +65,7 @@ export function createManualSession(params: {
     date: formatLocalDate(Date.now()),
     color: randomColor(),
     totalTime: Math.max(1, params.totalMinutes),
+    ...(params.workLocation === 'telework' ? { workLocation: 'telework' as const } : {}),
   }
 }
 

--- a/src/renderer/src/hooks/useBreak.test.ts
+++ b/src/renderer/src/hooks/useBreak.test.ts
@@ -48,11 +48,13 @@ const makeMockWorkday = (overrides: Partial<WorkdayState> = {}): WorkdayState =>
   breakStart: null,
   breakEnd: null,
   telework: false,
+  currentLocation: 'office',
   startWork: vi.fn(),
   endWork: vi.fn(),
   startBreak: vi.fn(),
   endBreak: vi.fn(),
   setBreakMinutes: vi.fn(),
+  switchLocation: vi.fn(),
   ...overrides,
 })
 

--- a/src/renderer/src/hooks/useSessions.test.ts
+++ b/src/renderer/src/hooks/useSessions.test.ts
@@ -155,6 +155,14 @@ describe('useSessions', () => {
     expect(result.current.todaySessions[0].totalTime).toBe(45)
   })
 
+  it('add に workLocation=telework を渡すとセッションへ反映される', async () => {
+    const { result } = renderHook(() => useSessions())
+    await act(async () => {
+      await result.current.add({ name: 'a', projectCode: 'ZZ', workCategory: '開発', totalTime: '30' }, 'telework')
+    })
+    expect(updateSession).toHaveBeenCalledWith(expect.objectContaining({ workLocation: 'telework' }))
+  })
+
   it('remove は deleteSession を呼んで todaySessions から除去する', async () => {
     const session = makeSession()
     getSessions.mockResolvedValue([session])

--- a/src/renderer/src/hooks/useSessions.ts
+++ b/src/renderer/src/hooks/useSessions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import type { Session } from '../types/session'
+import type { Session, WorkLocation } from '../types/session'
 import { appendRunningInterval, createManualSession, hasRunningInterval } from '../domain/session'
 import { sessionRepository } from '../repositories/sessionRepository'
 import { attendanceRepository } from '../repositories/attendanceRepository'
@@ -15,7 +15,7 @@ export interface SessionsState {
   /** セッションを更新する（稼働中の場合はディスク書き込みをスキップ） */
   update: (session: Session) => Promise<void>
   /** 手動追加（区間なしの確定済みセッション） */
-  add: (params: { name: string; projectCode: string; workCategory: string; totalTime: string }) => Promise<void>
+  add: (params: { name: string; projectCode: string; workCategory: string; totalTime: string }, workLocation?: WorkLocation) => Promise<void>
   /** セッションを削除する */
   remove: (sessionId: string) => Promise<void>
   /** テレワーク開始をホワイトボード / Slack に通知する */
@@ -53,12 +53,13 @@ export function useSessions(): SessionsState {
     setTodaySessions(prev => prev.map(s => s.id === updated.id ? updated : s))
   }, [])
 
-  const add = useCallback(async (params: { name: string; projectCode: string; workCategory: string; totalTime: string }): Promise<void> => {
+  const add = useCallback(async (params: { name: string; projectCode: string; workCategory: string; totalTime: string }, workLocation?: WorkLocation): Promise<void> => {
     const session = createManualSession({
       name: params.name,
       projectCode: params.projectCode,
       workCategory: params.workCategory,
       totalMinutes: parseInt(params.totalTime, 10),
+      workLocation,
     })
     await sessionRepository.update(session)
     setTodaySessions(prev => [...prev, session])

--- a/src/renderer/src/hooks/useTimer.test.ts
+++ b/src/renderer/src/hooks/useTimer.test.ts
@@ -321,6 +321,27 @@ describe('useTimer', () => {
     })
   })
 
+  it('start に渡した workLocation=telework が stop で保存される', async () => {
+    const { result } = renderHook(() => useTimer())
+    act(() => { result.current.start('タスク', undefined, 'telework') })
+    await act(async () => { await Promise.resolve() })
+    act(() => { vi.advanceTimersByTime(60000) })
+    let saved: Session | null = null
+    await act(async () => { saved = await result.current.stop({ projectCode: 'ZZ', workCategory: '開発' }) })
+    expect((saved as Session | null)?.workLocation).toBe('telework')
+    expect(mockSaveSession).toHaveBeenCalledWith(expect.objectContaining({ workLocation: 'telework' }))
+  })
+
+  it('workLocation=office（既定）では workLocation を保存しない', async () => {
+    const { result } = renderHook(() => useTimer())
+    act(() => { result.current.start('タスク', undefined, 'office') })
+    await act(async () => { await Promise.resolve() })
+    act(() => { vi.advanceTimersByTime(60000) })
+    let saved: Session | null = null
+    await act(async () => { saved = await result.current.stop({ projectCode: 'ZZ', workCategory: '開発' }) })
+    expect((saved as Session | null)?.workLocation).toBeUndefined()
+  })
+
   describe('pause / resume', () => {
     it('pause を呼ぶと isPaused が true になり elapsed が止まる', () => {
       vi.useFakeTimers()

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback } from 'react'
-import type { Session } from '../types/session'
+import type { Session, WorkLocation } from '../types/session'
 import { formatLocalDateTime, formatLocalDate } from '../../../shared/sessionUtils'
 import { JUICE_COLOR_KEYS, randomColor } from '../domain/colors'
 import { timerRepository } from '../repositories/timerRepository'
@@ -28,7 +28,7 @@ export interface TimerState {
   fillSeconds: number
   activeColor: string
   activeSessionId: string | null
-  start: (name: string, color?: string) => void
+  start: (name: string, color?: string, workLocation?: WorkLocation) => void
   startMore: (existingSession: Session) => void
   stop: (opts?: { projectCode?: string; workCategory?: string }) => Promise<Session | null>
   cancel: () => void
@@ -54,15 +54,17 @@ export function useTimer(): TimerState {
   const activeColorRef = useRef<string>(JUICE_COLOR_KEYS[0])
   const isRunningRef = useRef<boolean>(false)
   const extendingSessionRef = useRef<Session | null>(null)
+  const workLocationRef = useRef<WorkLocation | undefined>(undefined)
   const isPausedRef = useRef<boolean>(false)
   const pausedSecondsRef = useRef<number>(0)
 
-  const start = useCallback((name: string, color?: string) => {
+  const start = useCallback((name: string, color?: string, workLocation?: WorkLocation) => {
     if (intervalRef.current) clearInterval(intervalRef.current)
     isPausedRef.current = false
     pausedSecondsRef.current = 0
     setIsPaused(false)
     extendingSessionRef.current = null
+    workLocationRef.current = workLocation
     const c = color ?? randomColor()
     startTimeRef.current = new Date()
     nameRef.current = name
@@ -153,6 +155,7 @@ export function useTimer(): TimerState {
         times: [newInterval],
         date: formatLocalDate(startTimeRef.current.getTime()),
         color: activeColorRef.current,
+        ...(workLocationRef.current === 'telework' ? { workLocation: 'telework' as const } : {}),
       }
     }
 
@@ -177,6 +180,7 @@ export function useTimer(): TimerState {
     nameRef.current = ''
     taskIdRef.current = ''
     extendingSessionRef.current = null
+    workLocationRef.current = undefined
     isRunningRef.current = false
     timerRepository.stopped()
     setIsRunning(false)

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -203,6 +203,7 @@ export function useTimer(): TimerState {
     nameRef.current = ''
     taskIdRef.current = ''
     extendingSessionRef.current = null
+    workLocationRef.current = undefined
     isRunningRef.current = false
     timerRepository.stopped()
     setIsRunning(false)

--- a/src/renderer/src/hooks/useTimerSession.test.ts
+++ b/src/renderer/src/hooks/useTimerSession.test.ts
@@ -82,7 +82,7 @@ describe('useTimerSession', () => {
     act(() => { result.current.start('テスト', 'PROJ', '開発') })
     expect(result.current.activeTimerName).toBe('テスト')
     expect(result.current.activeTimerProjectCode).toBe('PROJ')
-    expect(mockTimerStart).toHaveBeenCalledWith('テスト')
+    expect(mockTimerStart).toHaveBeenCalledWith('テスト', undefined, undefined)
   })
 
   it('startMore は activeTimerName を更新して applyStartMore と timerStartMore を呼ぶ', () => {

--- a/src/renderer/src/hooks/useTimerSession.ts
+++ b/src/renderer/src/hooks/useTimerSession.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import { useTimer } from './useTimer'
 import type { SessionsState } from './useSessions'
-import type { Session } from '../types/session'
+import type { Session, WorkLocation } from '../types/session'
 
 export interface TimerSessionState {
   isRunning: boolean
@@ -18,7 +18,7 @@ export interface TimerSessionState {
   todaySessions: Session[]
   midnightSession: Session | null
   stopError: boolean
-  start: (name: string, projectCode?: string, workCategory?: string) => void
+  start: (name: string, projectCode?: string, workCategory?: string, workLocation?: WorkLocation) => void
   startMore: (session: Session) => void
   stop: (projectCode: string, workCategory: string) => Promise<void>
   stopForBreak: (projectCode: string, workCategory: string) => Promise<Session | null>
@@ -27,7 +27,7 @@ export interface TimerSessionState {
   pause: () => void
   resume: () => void
   update: (session: Session) => Promise<void>
-  add: (params: { name: string; projectCode: string; workCategory: string; totalTime: string }) => Promise<void>
+  add: (params: { name: string; projectCode: string; workCategory: string; totalTime: string }, workLocation?: WorkLocation) => Promise<void>
   remove: (sessionId: string) => Promise<void>
   startTelework: () => Promise<void>
   dismissMidnightSession: () => void
@@ -42,11 +42,11 @@ export function useTimerSession(sessions: SessionsState): TimerSessionState {
   const [midnightSession, setMidnightSession] = useState<Session | null>(null)
   const [stopError, setStopError] = useState(false)
 
-  const start = useCallback((name: string, projectCode = '', workCategory = ''): void => {
+  const start = useCallback((name: string, projectCode = '', workCategory = '', workLocation?: WorkLocation): void => {
     setActiveTimerName(name)
     setActiveTimerProjectCode(projectCode)
     setActiveTimerWorkCategory(workCategory)
-    timer.start(name)
+    timer.start(name, undefined, workLocation)
   }, [timer])
 
   const startMore = useCallback((session: Session): void => {

--- a/src/renderer/src/hooks/useWorkday.test.ts
+++ b/src/renderer/src/hooks/useWorkday.test.ts
@@ -13,6 +13,11 @@ vi.mock('../daily/DailyDataContext', () => ({
   }),
 }))
 
+const mockStartTelework = vi.fn()
+vi.mock('../repositories/attendanceRepository', () => ({
+  attendanceRepository: { startTelework: () => mockStartTelework() },
+}))
+
 beforeEach(() => { vi.clearAllMocks() })
 
 describe('useWorkday', () => {
@@ -42,5 +47,40 @@ describe('useWorkday', () => {
     const { result } = renderHook(() => useWorkday('2026-06-18'))
     expect(result.current.breakStart).toBeNull()
     expect(result.current.breakEnd).toBeNull()
+  })
+
+  it('currentLocation は DayRecord の値を返す', () => {
+    mockGetDay.mockReturnValue({ workStart: '09:00', currentLocation: 'telework' })
+    const { result } = renderHook(() => useWorkday('2026-06-29'))
+    expect(result.current.currentLocation).toBe('telework')
+  })
+
+  it('currentLocation 未設定なら telework フラグからフォールバックする', () => {
+    mockGetDay.mockReturnValue({ workStart: '09:00', telework: true })
+    const { result } = renderHook(() => useWorkday('2026-06-29'))
+    expect(result.current.currentLocation).toBe('telework')
+  })
+
+  it('switchLocation(telework) は currentLocation を保存し whiteboard を更新する', () => {
+    mockGetDay.mockReturnValue({ workStart: '09:00' })
+    const { result } = renderHook(() => useWorkday('2026-06-29'))
+    act(() => { result.current.switchLocation('telework') })
+    expect(mockSetDay).toHaveBeenCalledWith('2026-06-29', { currentLocation: 'telework' })
+    expect(mockStartTelework).toHaveBeenCalledTimes(1)
+  })
+
+  it('switchLocation(office) は whiteboard を更新しない', () => {
+    mockGetDay.mockReturnValue({ workStart: '09:00', currentLocation: 'telework' })
+    const { result } = renderHook(() => useWorkday('2026-06-29'))
+    act(() => { result.current.switchLocation('office') })
+    expect(mockSetDay).toHaveBeenCalledWith('2026-06-29', { currentLocation: 'office' })
+    expect(mockStartTelework).not.toHaveBeenCalled()
+  })
+
+  it('startWork は currentLocation も初期化する', () => {
+    mockGetDay.mockReturnValue(undefined)
+    const { result } = renderHook(() => useWorkday('2026-06-29'))
+    act(() => { result.current.startWork('09:00', true) })
+    expect(mockSetDay).toHaveBeenCalledWith('2026-06-29', { workStart: '09:00', telework: true, currentLocation: 'telework' })
   })
 })

--- a/src/renderer/src/hooks/useWorkday.test.tsx
+++ b/src/renderer/src/hooks/useWorkday.test.tsx
@@ -22,7 +22,7 @@ describe('useWorkday', () => {
     await act(async () => { result.current.startWork('09:30', true) })
     await waitFor(() => expect(result.current.workStart).toBe('09:30'))
     expect(result.current.telework).toBe(true)
-    expect(setDailyDay).toHaveBeenCalledWith('2026-06-10', { workStart: '09:30', telework: true })
+    expect(setDailyDay).toHaveBeenCalledWith('2026-06-10', { workStart: '09:30', telework: true, currentLocation: 'telework' })
   })
 
   it('endWork は workEnd を保存する', async () => {

--- a/src/renderer/src/hooks/useWorkday.ts
+++ b/src/renderer/src/hooks/useWorkday.ts
@@ -1,5 +1,7 @@
 import { useEffect, useCallback } from 'react'
 import { useDailyData } from '../daily/DailyDataContext'
+import { attendanceRepository } from '../repositories/attendanceRepository'
+import type { WorkLocation } from '../types/session'
 
 export interface WorkdayState {
   workStart: string | null
@@ -7,6 +9,8 @@ export interface WorkdayState {
   breakStart: string | null
   breakEnd: string | null
   telework: boolean
+  /** 今の勤務場所（新規セッションに付与される） */
+  currentLocation: WorkLocation
   /** 業務開始時刻と在宅フラグを保存する */
   startWork: (time: string, telework: boolean) => void
   /** 業務終了時刻を保存する */
@@ -14,6 +18,8 @@ export interface WorkdayState {
   startBreak: (time: string) => void
   endBreak: (time: string) => void
   setBreakMinutes: (minutes: number) => void
+  /** 勤務場所を切り替える。telework になる時のみ whiteboard を更新する */
+  switchLocation: (loc: WorkLocation) => void
 }
 
 /** 日付（todayKey）ごとの勤怠時刻を日次ストアと同期する。 */
@@ -30,9 +36,10 @@ export function useWorkday(todayKey: string): WorkdayState {
   const breakStart = day?.breakStart ?? null
   const breakEnd = day?.breakEnd ?? null
   const telework = day?.telework ?? false
+  const currentLocation: WorkLocation = day?.currentLocation ?? (telework ? 'telework' : 'office')
 
   const startWork = useCallback((time: string, tw: boolean): void => {
-    void daily.setDay(todayKey, { workStart: time, telework: tw })
+    void daily.setDay(todayKey, { workStart: time, telework: tw, currentLocation: tw ? 'telework' : 'office' })
   }, [todayKey, daily])
 
   const endWork = useCallback((time: string): void => {
@@ -51,5 +58,10 @@ export function useWorkday(todayKey: string): WorkdayState {
     void daily.setDay(todayKey, { breakMinutes: minutes })
   }, [todayKey, daily])
 
-  return { workStart, workEnd, breakStart, breakEnd, telework, startWork, endWork, startBreak, endBreak, setBreakMinutes }
+  const switchLocation = useCallback((loc: WorkLocation): void => {
+    void daily.setDay(todayKey, { currentLocation: loc })
+    if (loc === 'telework') void attendanceRepository.startTelework()
+  }, [todayKey, daily])
+
+  return { workStart, workEnd, breakStart, breakEnd, telework, currentLocation, startWork, endWork, startBreak, endBreak, setBreakMinutes, switchLocation }
 }

--- a/src/renderer/src/types/session.ts
+++ b/src/renderer/src/types/session.ts
@@ -1,3 +1,3 @@
 // レンダラー側で Session 型を使う際の入り口。
 // 実体は src/shared/types.ts。再エクスポートして path の見た目を統一する。
-export type { Session } from '../../../shared/types'
+export type { Session, WorkLocation } from '../../../shared/types'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,8 @@ export interface TimeInterval {
   endTime: string | null
 }
 
+export type WorkLocation = 'office' | 'telework'
+
 export interface Session {
   id: string
   taskId: string
@@ -13,6 +15,8 @@ export interface Session {
   date: string
   color: string
   totalTime: number
+  /** そのセッションを行った勤務場所。undefined = 出社（tw 無し）扱い。telework のときのみ保存 */
+  workLocation?: WorkLocation
 }
 
 export interface SessionFile {
@@ -28,6 +32,8 @@ export interface DayRecord {
   breakMinutes?: number
   telework?: boolean
   sessionOrder?: string[]
+  /** 新規セッションに付ける「今の勤務場所」。切替ボタンで更新する */
+  currentLocation?: WorkLocation
   /** UTC ISO8601。setDay で main 側が打刻（将来の同期での last-write-wins 用） */
   updatedAt?: string
 }


### PR DESCRIPTION
## やったこと
- 勤務場所（出社/テレワーク）をセッション単位で保持し、業務中に切替可能に（切替UIはアカウントメニュー内）
- 勤怠テキストでテレワーク工数の行末に `tw` を出力（(taskId × 勤務場所)でグルーピング、同一タスクの混在は2行に分割）
- テレワーク切替時に whiteboard をテレワークマグネットに追従（出社はカードリーダー運用に委ねる）
- 後方互換: 追加は任意フィールドのみ、`workLocation` は telework のみ保存（既存出力は不変）

Closes #68
関連（将来対応）: #105 #106 #107