### PR TITLE
fix: ヘッダーの juice ロゴを中央に正確配置

### DIFF
--- a/src/renderer/src/App.module.css
+++ b/src/renderer/src/App.module.css
@@ -28,6 +28,10 @@
 }
 
 .logo {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
   font-size: 16px;
   font-weight: 800;
   background: var(--gradient-accent);


### PR DESCRIPTION
## やったこと
- 左右ボタンの幅差で space-between だとロゴが中央から少しずれていたのを、ヘッダー基準の絶対配置で真ん中に揃えた