### PR TITLE
chore: v1.2.0 リリース準備（version bump + CHANGELOG）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-29
+
+### ✨ 新機能
+
+- フレックス勤務対応: 1日の中で勤務場所（出社/テレワーク）を切り替えられるように
+  なりました。アカウントメニューから切替でき、テレワークの工数は勤怠に `tw` 付きで
+  出力され、テレワークへの切替時は在席ボードも追従します
+
+### 🐛 修正
+
+- ヘッダーの「juice」ロゴが中央からわずかに左へずれていたのを修正
+
 ## [1.1.0] - 2026-06-29
 
 ### ✨ 新機能
@@ -29,6 +41,7 @@
 - 初回リリース。作業セッションをタイマーで記録し、カレンダー・勤怠の確認、テーマや
   各種通知（アイドル / 経過時間 / ポモドーロ）に対応した macOS メニューバーアプリ
 
-[Unreleased]: https://github.com/ryota-kanayama/juice/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ryota-kanayama/juice/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ryota-kanayama/juice/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ryota-kanayama/juice/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ryota-kanayama/juice/releases/tag/v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juice",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juice",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juice",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "macOS menu bar timer app",
   "main": "out/main/index.js",
   "author": "kanayama",


### PR DESCRIPTION
## やったこと
- `package.json` を 1.2.0 に bump
- CHANGELOG に [1.2.0] を追記（✨ フレックス勤務対応 / 🐛 ヘッダーロゴ中央寄せ）

リリース手順の一部。マージ後に DMG ビルド → GitHub Release(v1.2.0) を作成。