### PR TITLE
feat: 全自動アップデート（自己差し替え）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,8 @@ import { fetchLatestRelease } from './update/githubRelease'
 import { readInstalledVersion } from './update/installedVersion'
 import { downloadFile } from './update/downloadFile'
 import { broadcastToAll } from './windows/updateBroadcast'
+import { runInstaller } from './update/runInstaller'
+import { prepareQuitForUpdate } from './update/prepareQuit'
 
 // dev とパッケージ版でプロファイルを分離する（起動ロック衝突・localStorage 混入の防止）。
 // requestSingleInstanceLock より前に設定する必要がある。
@@ -46,6 +48,12 @@ const dailyStore = new DailyStore(dataDir)
 const settingsStore = new SettingsStore(dataDir)
 const authStore = new AuthStore(dataDir)
 
+/** execPath から実際の .app パスを導出する（例 /Applications/Juice.app）。dev 等で不明なら null */
+function deriveAppPath(execPath: string): string | null {
+  const i = execPath.indexOf('.app/')
+  return i === -1 ? null : execPath.slice(0, i + 4)
+}
+
 const updateService = createUpdateService({
   currentVersion: app.getVersion(),
   arch: process.arch,
@@ -62,6 +70,11 @@ const updateService = createUpdateService({
   openExternal: (u) => shell.openExternal(u),
   relaunch: () => { app.relaunch(); app.quit() },
   logError: (...args) => logger.error(...args),
+  appPath: deriveAppPath(process.execPath),
+  runInstaller: ({ dmgPath, appPath }) =>
+    runInstaller({ dmgPath, appPath, tmpDir: app.getPath('temp'), pid: process.pid }),
+  quit: () => app.quit(),
+  waitForRenderer: () => prepareQuitForUpdate(),
 })
 
 // 開発時は汎用 Electron.app に紐づくため juice:// の E2E はパッケージ版で確認する

--- a/src/main/ipc/registerHandlers.test.ts
+++ b/src/main/ipc/registerHandlers.test.ts
@@ -33,6 +33,7 @@ const m = vi.hoisted(() => ({
   startSignIn: vi.fn(),
   loggerWarn: vi.fn(),
   loggerError: vi.fn(),
+  notifyRendererReady: vi.fn(),
 }))
 
 vi.mock('./handle', () => ({
@@ -71,6 +72,7 @@ vi.mock('../windows/popover', () => ({ hidePopover: m.hidePopover, resizePopover
 vi.mock('../windows/setup', () => ({ getSetupWindow: m.getSetupWindow }))
 vi.mock('../windows/tray', () => ({ createTray: m.createTray }))
 vi.mock('../auth/signIn', () => ({ startSignIn: m.startSignIn }))
+vi.mock('../update/prepareQuit', () => ({ notifyRendererReady: m.notifyRendererReady }))
 vi.mock('../logger', () => ({ logger: { warn: m.loggerWarn, error: m.loggerError, info: vi.fn() } }))
 
 import { registerIpcHandlers } from './registerHandlers'

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -5,6 +5,7 @@ import type { AuthStore } from '../auth/authStore'
 import type { DailyStore } from '../dailyStore'
 import type { UpdateService } from '../update/updateService'
 import { startSignIn } from '../auth/signIn'
+import { notifyRendererReady } from '../update/prepareQuit'
 import { logger } from '../logger'
 import { handle } from './handle'
 import { hidePopover, resizePopover } from '../windows/popover'
@@ -141,6 +142,8 @@ export function registerIpcHandlers(
   handle('update:download', () => updateService.download())
   handle('update:restart', () => { updateService.restart() })
   handle('update:dismiss', (_, version) => updateService.dismiss(version))
+  handle('update:install', () => updateService.install())
+  handle('update:ready-to-quit', () => { notifyRendererReady() })
 
   // misc
   handle('app:getVersion', () => app.getVersion())

--- a/src/main/update/installScript.test.ts
+++ b/src/main/update/installScript.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { buildInstallScript } from './installScript'
+
+const base = {
+  pid: 4242,
+  dmgPath: '/tmp/Juice-1.1.0-arm64.dmg',
+  appPath: '/Applications/Juice.app',
+  logPath: '/tmp/juice-update.log',
+}
+
+describe('buildInstallScript', () => {
+  it('PID・DMG・APP・LOG を埋め込む', () => {
+    const s = buildInstallScript(base)
+    expect(s).toContain('PID=4242')
+    expect(s).toContain(`DMG='/tmp/Juice-1.1.0-arm64.dmg'`)
+    expect(s).toContain(`APP='/Applications/Juice.app'`)
+    expect(s).toContain(`LOG='/tmp/juice-update.log'`)
+  })
+
+  it('終了待ち→マウント→退避→コピー→quarantine除去→open の順で構成する', () => {
+    const s = buildInstallScript(base)
+    const order = ['kill -0', 'hdiutil attach', 'mv "$APP"', 'cp -R', 'xattr -dr com.apple.quarantine', 'open "$APP"']
+    let last = -1
+    for (const token of order) {
+      const i = s.indexOf(token)
+      expect(i, `"${token}" が見つからない`).toBeGreaterThan(-1)
+      expect(i, `"${token}" の順序が不正`).toBeGreaterThan(last)
+      last = i
+    }
+  })
+
+  it('コピー失敗時にロールバックする', () => {
+    const s = buildInstallScript(base)
+    expect(s).toContain('mv "$BACKUP" "$APP"')
+  })
+
+  it("シングルクォートを含むパスを安全にエスケープする", () => {
+    const s = buildInstallScript({ ...base, appPath: `/Applications/My'App.app` })
+    expect(s).toContain(`APP='/Applications/My'\\''App.app'`)
+  })
+})

--- a/src/main/update/installScript.test.ts
+++ b/src/main/update/installScript.test.ts
@@ -19,7 +19,7 @@ describe('buildInstallScript', () => {
 
   it('終了待ち→マウント→退避→コピー→quarantine除去→open の順で構成する', () => {
     const s = buildInstallScript(base)
-    const order = ['kill -0', 'hdiutil attach', 'mv "$APP"', 'cp -R', 'xattr -dr com.apple.quarantine', 'open "$APP"']
+    const order = ['kill -0', 'hdiutil attach', 'mv "$APP"', 'cp -R', 'xattr -dr com.apple.quarantine']
     let last = -1
     for (const token of order) {
       const i = s.indexOf(token)
@@ -27,11 +27,22 @@ describe('buildInstallScript', () => {
       expect(i, `"${token}" の順序が不正`).toBeGreaterThan(last)
       last = i
     }
+    // 成功時の最終 open "$APP" は xattr より後に位置すること（lastIndexOf で検証）
+    const finalOpenIdx = s.lastIndexOf('open "$APP"')
+    const xattrIdx = s.indexOf('xattr -dr com.apple.quarantine')
+    expect(finalOpenIdx, '成功時の open "$APP" が xattr より後に位置する').toBeGreaterThan(xattrIdx)
   })
 
   it('コピー失敗時にロールバックする', () => {
     const s = buildInstallScript(base)
     expect(s).toContain('mv "$BACKUP" "$APP"')
+  })
+
+  it('ロールバック経路で旧版を再起動する', () => {
+    const s = buildInstallScript(base)
+    const rollbackIdx = s.indexOf('mv "$BACKUP" "$APP"')
+    const openInRollbackIdx = s.indexOf('open "$APP"', rollbackIdx)
+    expect(openInRollbackIdx, 'ロールバック経路に open "$APP" が含まれる').toBeGreaterThan(rollbackIdx)
   })
 
   it("シングルクォートを含むパスを安全にエスケープする", () => {

--- a/src/main/update/installScript.ts
+++ b/src/main/update/installScript.ts
@@ -1,0 +1,51 @@
+export interface InstallScriptParams {
+  pid: number
+  dmgPath: string
+  appPath: string
+  logPath: string
+}
+
+/** 文字列をシングルクォートで安全に囲む（bash 用） */
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+/**
+ * アプリ終了後に .app を差し替える bash スクリプトを生成する。
+ * アプリ本体とは別プロセス（detached）で実行される前提。
+ */
+export function buildInstallScript(p: InstallScriptParams): string {
+  return `#!/bin/bash
+LOG=${shq(p.logPath)}
+exec >>"$LOG" 2>&1
+PID=${p.pid}
+DMG=${shq(p.dmgPath)}
+APP=${shq(p.appPath)}
+APP_NAME="$(basename "$APP")"
+MOUNT="$(mktemp -d)"
+BACKUP="$APP.old"
+
+# 1) アプリの終了を待つ（最大 ~30s の保険ループ）
+for i in $(seq 1 100); do kill -0 "$PID" 2>/dev/null || break; sleep 0.3; done
+
+# 2) DMG を専用マウントポイントへ（ボリューム名に依存しない）
+hdiutil attach "$DMG" -nobrowse -mountpoint "$MOUNT" || exit 1
+
+# 3) 退避 → コピー → 失敗時ロールバック
+rm -rf "$BACKUP"
+mv "$APP" "$BACKUP" 2>/dev/null
+if ! cp -R "$MOUNT/$APP_NAME" "$APP"; then
+  rm -rf "$APP"
+  mv "$BACKUP" "$APP"
+  hdiutil detach "$MOUNT" -quiet
+  exit 1
+fi
+rm -rf "$BACKUP"
+
+# 4) Gatekeeper 対策 → アンマウント → 新バージョン起動
+xattr -dr com.apple.quarantine "$APP" 2>/dev/null
+hdiutil detach "$MOUNT" -quiet || true
+rmdir "$MOUNT" 2>/dev/null
+open "$APP"
+`
+}

--- a/src/main/update/installScript.ts
+++ b/src/main/update/installScript.ts
@@ -38,6 +38,7 @@ if ! cp -R "$MOUNT/$APP_NAME" "$APP"; then
   rm -rf "$APP"
   mv "$BACKUP" "$APP"
   hdiutil detach "$MOUNT" -quiet
+  open "$APP"
   exit 1
 fi
 rm -rf "$BACKUP"

--- a/src/main/update/prepareQuit.test.ts
+++ b/src/main/update/prepareQuit.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+import { prepareQuitForUpdate, notifyRendererReady } from './prepareQuit'
+
+describe('prepareQuitForUpdate', () => {
+  it('send を呼び、notifyRendererReady で解決する', async () => {
+    const send = vi.fn()
+    const p = prepareQuitForUpdate(send, 10_000)
+    expect(send).toHaveBeenCalledTimes(1)
+    notifyRendererReady()
+    await expect(p).resolves.toBeUndefined()
+  })
+
+  it('ack が来なくてもタイムアウトで解決する', async () => {
+    vi.useFakeTimers()
+    const send = vi.fn()
+    const p = prepareQuitForUpdate(send, 3000)
+    vi.advanceTimersByTime(3000)
+    await expect(p).resolves.toBeUndefined()
+    vi.useRealTimers()
+  })
+})

--- a/src/main/update/prepareQuit.ts
+++ b/src/main/update/prepareQuit.ts
@@ -1,0 +1,32 @@
+import { broadcastToAll } from '../windows/updateBroadcast'
+
+// ポップオーバーからの ack を待つためのペンディング関数
+let pending: (() => void) | null = null
+
+/**
+ * ポップオーバーが保存完了を ack したときに呼ぶ（registerHandlers から）
+ */
+export function notifyRendererReady(): void {
+  pending?.()
+  pending = null
+}
+
+/**
+ * 全ウィンドウへ update-prepare-quit を送り、ack かタイムアウトを待つ。
+ * ack が無くても更新をハングさせないため timeoutMs で必ず解決する。
+ */
+export function prepareQuitForUpdate(
+  send: () => void = () => broadcastToAll('update-prepare-quit', undefined),
+  timeoutMs = 3000,
+): Promise<void> {
+  return new Promise<void>(resolve => {
+    const finish = (): void => {
+      clearTimeout(timer)
+      pending = null
+      resolve()
+    }
+    pending = finish
+    const timer = setTimeout(finish, timeoutMs)
+    send()
+  })
+}

--- a/src/main/update/runInstaller.ts
+++ b/src/main/update/runInstaller.ts
@@ -1,0 +1,23 @@
+import { spawn } from 'child_process'
+import { writeFileSync } from 'fs'
+import { join } from 'path'
+import { buildInstallScript } from './installScript'
+
+/**
+ * 差し替えスクリプトを一時ファイルへ書き出し、アプリと切り離して起動する。
+ * detached + unref により、アプリ（親）が quit してもスクリプトは生き残る。
+ */
+export function runInstaller(opts: {
+  dmgPath: string
+  appPath: string
+  tmpDir: string
+  pid?: number
+}): void {
+  const pid = opts.pid ?? process.pid
+  const logPath = join(opts.tmpDir, 'juice-update.log')
+  const scriptPath = join(opts.tmpDir, 'juice-update.sh')
+  const script = buildInstallScript({ pid, dmgPath: opts.dmgPath, appPath: opts.appPath, logPath })
+  writeFileSync(scriptPath, script, { mode: 0o755 })
+  const child = spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' })
+  child.unref()
+}

--- a/src/main/update/updateService.test.ts
+++ b/src/main/update/updateService.test.ts
@@ -29,6 +29,10 @@ function baseDeps(over: Partial<UpdateServiceDeps> = {}): UpdateServiceDeps {
     openExternal: vi.fn(async () => {}),
     relaunch: vi.fn(),
     logError: vi.fn(),
+    appPath: '/Applications/Juice.app',
+    runInstaller: vi.fn(),
+    quit: vi.fn(),
+    waitForRenderer: vi.fn(async () => {}),
     ...over,
   }
 }
@@ -115,5 +119,46 @@ describe('dismiss / restart', () => {
     const deps = baseDeps()
     createUpdateService(deps).restart()
     expect(deps.relaunch).toHaveBeenCalled()
+  })
+})
+
+describe('install', () => {
+  it('DL→保存待ち→runInstaller→quit の順に進む（パッケージ版）', async () => {
+    const deps = baseDeps()
+    await createUpdateService(deps).install()
+    expect(deps.downloadFile).toHaveBeenCalledWith(
+      'https://x/arm64.dmg', '/tmp/Juice-1.1.0-arm64.dmg', expect.any(Function),
+    )
+    expect(deps.send).toHaveBeenCalledWith('update-download-progress', { percent: 100, done: true })
+    expect(deps.waitForRenderer).toHaveBeenCalled()
+    expect(deps.runInstaller).toHaveBeenCalledWith({
+      dmgPath: '/tmp/Juice-1.1.0-arm64.dmg', appPath: '/Applications/Juice.app',
+    })
+    expect(deps.quit).toHaveBeenCalled()
+  })
+
+  it('未パッケージなら自己差し替えせず openPath にフォールバック', async () => {
+    const deps = baseDeps({ isPackaged: false })
+    await createUpdateService(deps).install()
+    expect(deps.openPath).toHaveBeenCalledWith('/tmp/Juice-1.1.0-arm64.dmg')
+    expect(deps.runInstaller).not.toHaveBeenCalled()
+    expect(deps.quit).not.toHaveBeenCalled()
+  })
+
+  it('arch 一致 DMG が無ければ releaseUrl を外部で開き、差し替えしない', async () => {
+    const deps = baseDeps({
+      fetchRelease: vi.fn(async () => ({ tagName: 'v1.1.0', htmlUrl: 'https://rel', body: '', assets: [] })),
+    })
+    await createUpdateService(deps).install()
+    expect(deps.openExternal).toHaveBeenCalledWith('https://rel')
+    expect(deps.runInstaller).not.toHaveBeenCalled()
+    expect(deps.quit).not.toHaveBeenCalled()
+  })
+
+  it('DL 失敗時はエラー進捗を送り quit しない', async () => {
+    const deps = baseDeps({ downloadFile: vi.fn(async () => { throw new Error('net') }) })
+    await createUpdateService(deps).install()
+    expect(deps.send).toHaveBeenCalledWith('update-download-progress', { percent: 0, done: true, error: 'ダウンロードに失敗しました' })
+    expect(deps.quit).not.toHaveBeenCalled()
   })
 })

--- a/src/main/update/updateService.ts
+++ b/src/main/update/updateService.ts
@@ -25,6 +25,10 @@ export interface UpdateServiceDeps {
   openExternal: (url: string) => Promise<void>
   relaunch: () => void
   logError: (...args: unknown[]) => void
+  appPath: string | null
+  runInstaller: (opts: { dmgPath: string; appPath: string }) => void
+  quit: () => void
+  waitForRenderer: () => Promise<void>
 }
 
 export interface UpdateService {
@@ -32,6 +36,7 @@ export interface UpdateService {
   checkAndNotify(): Promise<void>
   startPeriodicCheck(): void
   download(): Promise<void>
+  install(): Promise<void>
   dismiss(version: string): Promise<void>
   restart(): void
   pollInstalledOnce(): Promise<boolean>
@@ -121,6 +126,40 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
     }
   }
 
+  async function install(): Promise<void> {
+    let info: UpdateInfo
+    try {
+      info = await checkForUpdate()
+    } catch (e) {
+      deps.logError('update install: re-check failed:', e)
+      deps.send('update-download-progress', { percent: 0, done: true, error: '更新情報の取得に失敗しました' })
+      return
+    }
+    if (!info.downloadUrl || !info.assetName) {
+      await deps.openExternal(info.releaseUrl)
+      return
+    }
+    const dest = join(deps.tmpDir, info.assetName)
+    try {
+      await deps.downloadFile(info.downloadUrl, dest, p =>
+        deps.send('update-download-progress', { percent: p, done: false }),
+      )
+      deps.send('update-download-progress', { percent: 100, done: true })
+    } catch (e) {
+      deps.logError('update install: download failed:', e)
+      deps.send('update-download-progress', { percent: 0, done: true, error: 'ダウンロードに失敗しました' })
+      return
+    }
+    // 開発時 / .app パス不明 は自己差し替え不可 → DMG を開く従来挙動
+    if (!deps.isPackaged || !deps.appPath) {
+      await deps.openPath(dest)
+      return
+    }
+    await deps.waitForRenderer()
+    deps.runInstaller({ dmgPath: dest, appPath: deps.appPath })
+    deps.quit()
+  }
+
   async function dismiss(version: string): Promise<void> {
     await deps.setDismissedVersion(version)
   }
@@ -129,5 +168,5 @@ export function createUpdateService(deps: UpdateServiceDeps): UpdateService {
     deps.relaunch()
   }
 
-  return { checkForUpdate, checkAndNotify, startPeriodicCheck, download, dismiss, restart, pollInstalledOnce }
+  return { checkForUpdate, checkAndNotify, startPeriodicCheck, download, install, dismiss, restart, pollInstalledOnce }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -79,10 +79,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   downloadUpdate: () => invoke('update:download', undefined),
   restartForUpdate: () => invoke('update:restart', undefined),
   dismissUpdate: (version: string) => invoke('update:dismiss', version),
+  installUpdate: () => invoke('update:install', undefined),
+  readyToQuit: () => invoke('update:ready-to-quit', undefined),
   onUpdateAvailable: (callback: (info: UpdateInfo) => void) => on('update-available', callback),
   onUpdateProgress: (callback: (p: { percent: number; done: boolean; error?: string }) => void) =>
     on('update-download-progress', callback),
   onUpdateInstalled: (callback: (p: { version: string }) => void) => on('update-installed', callback),
+  onUpdatePrepareQuit: (callback: () => void) => on('update-prepare-quit', callback),
 
   // misc
   completeSetup: () => invoke('setup:complete', undefined),

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -11,6 +11,9 @@ vi.stubGlobal('electronAPI', {
   getDailyMonth,
   setDailyDay: vi.fn().mockResolvedValue(undefined),
   getBreakBehaviorSettings: vi.fn().mockResolvedValue({ behavior: 'stop' }),
+  // updateRepository が呼ぶ IPC モック
+  onUpdatePrepareQuit: vi.fn().mockReturnValue(() => {}),
+  readyToQuit: vi.fn().mockResolvedValue(undefined),
 })
 
 function stubSessions(): SessionsState {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -25,6 +25,7 @@ import { DailyDataProvider } from './daily/DailyDataContext'
 import { useUpdate } from './hooks/useUpdate'
 import { UpdateBanner } from './components/Popover/UpdateBanner'
 import { WorkLocationSwitch } from './components/Popover/WorkLocationSwitch'
+import { updateRepository } from './repositories/updateRepository'
 
 type Page = 'timer' | 'calendar' | 'attendance'
 
@@ -214,6 +215,19 @@ function PopoverView() {
 
 export function TimerPage({ sessions, tourDemo = false }: { sessions: SessionsState; tourDemo?: boolean }) {
   const ts = useTimerSession(sessions)
+
+  // 更新適用直前：稼働中の区間を保存してから main へ ack を返す
+  useEffect(() => {
+    return updateRepository.onPrepareQuit(() => {
+      void (async () => {
+        if (ts.isRunning) {
+          await ts.stop(ts.activeTimerProjectCode, ts.activeTimerWorkCategory).catch(() => {})
+        }
+        await updateRepository.readyToQuit().catch(() => {})
+      })()
+    })
+  }, [ts])
+
   const workday = useWorkday(ts.today)
   const breakState = useBreak(ts, workday)
   const suggestions = useSuggestions(ts.todaySessions, ts.today)

--- a/src/renderer/src/components/Popover/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.test.tsx
@@ -63,4 +63,9 @@ describe('UpdateBanner', () => {
     fireEvent.click(screen.getByRole('button', { name: '再起動' }))
     expect(restart).toHaveBeenCalled()
   })
+
+  it('installing 中は適用中の文言を表示する', () => {
+    render(<UpdateBanner update={state({ phase: 'installing', info })} />)
+    expect(screen.getByText('更新を適用しています…')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/src/components/Popover/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.test.tsx
@@ -68,4 +68,12 @@ describe('UpdateBanner', () => {
     render(<UpdateBanner update={state({ phase: 'installing', info })} />)
     expect(screen.getByText('更新を適用しています…')).toBeInTheDocument()
   })
+
+  it('available で更新ボタンが install を呼ぶ', () => {
+    const install = vi.fn()
+    const update = state({ phase: 'available', info, install })
+    render(<UpdateBanner update={update} />)
+    fireEvent.click(screen.getByText('更新'))
+    expect(install).toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/Popover/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.test.tsx
@@ -12,7 +12,7 @@ const info = {
 function state(over: Partial<UpdateState>): UpdateState {
   return {
     phase: 'idle', info: null, percent: 0, error: null, currentVersion: '',
-    check: vi.fn(), download: vi.fn(), restart: vi.fn(), dismiss: vi.fn(),
+    check: vi.fn(), install: vi.fn(), restart: vi.fn(), dismiss: vi.fn(),
     ...over,
   }
 }
@@ -31,11 +31,11 @@ describe('UpdateBanner', () => {
     expect(screen.getByRole('button', { name: '更新' })).toBeInTheDocument()
   })
 
-  it('更新ボタンで download を呼ぶ', () => {
-    const download = vi.fn()
-    render(<UpdateBanner update={state({ phase: 'available', info, download })} />)
+  it('更新ボタンで install を呼ぶ', () => {
+    const install = vi.fn()
+    render(<UpdateBanner update={state({ phase: 'available', info, install })} />)
     fireEvent.click(screen.getByRole('button', { name: '更新' }))
-    expect(download).toHaveBeenCalled()
+    expect(install).toHaveBeenCalled()
   })
 
   it('✕ で dismiss を呼ぶ', () => {

--- a/src/renderer/src/components/Popover/UpdateBanner.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 /** ポップオーバー上部のアップデート通知バナー。状態に応じて文言・操作が変わる */
 export function UpdateBanner({ update }: Props) {
-  const { phase, info, percent, restart, download, dismiss } = update
+  const { phase, info, percent, restart, install, dismiss } = update
   if (phase === 'idle' || phase === 'error' || !info) return null
 
   const bar = 'flex items-center justify-between gap-2 px-3 py-2 text-[12px] [-webkit-app-region:no-drag]'
@@ -17,7 +17,7 @@ export function UpdateBanner({ update }: Props) {
       <div className={`${bar} bg-[var(--accent-light)] text-[var(--accent)]`}>
         <span>新しいバージョン v{info.latestVersion} があります</span>
         <span className="flex items-center gap-2">
-          <button className="font-semibold underline" onClick={download}>更新</button>
+          <button className="font-semibold underline" onClick={install}>更新</button>
           <button aria-label="閉じる" onClick={dismiss}>✕</button>
         </span>
       </div>
@@ -28,6 +28,15 @@ export function UpdateBanner({ update }: Props) {
     return (
       <div className={`${bar} bg-[var(--accent-light)] text-[var(--accent)]`}>
         <span>ダウンロード中… {percent}%</span>
+        <button className="opacity-50" disabled>更新</button>
+      </div>
+    )
+  }
+
+  if (phase === 'installing') {
+    return (
+      <div className={`${bar} bg-[var(--accent-light)] text-[var(--accent)]`}>
+        <span>更新を適用しています…</span>
         <button className="opacity-50" disabled>更新</button>
       </div>
     )

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -299,11 +299,13 @@ export function SettingsView() {
                       ? `更新があります（v${update.info?.latestVersion}）`
                       : update.phase === 'downloading'
                         ? `ダウンロード中… ${update.percent}%`
-                        : update.phase === 'opened' || update.phase === 'installed'
-                          ? '再起動で更新を適用'
-                          : update.phase === 'error'
-                            ? (update.error ?? '確認に失敗しました')
-                            : '最新です'}
+                        : update.phase === 'installing'
+                          ? '更新を適用しています…'
+                          : update.phase === 'opened' || update.phase === 'installed'
+                            ? '再起動で更新を適用'
+                            : update.phase === 'error'
+                              ? (update.error ?? '確認に失敗しました')
+                              : '最新です'}
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
@@ -316,9 +318,17 @@ export function SettingsView() {
                   {update.phase === 'available' && (
                     <button
                       className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-[13px] text-white"
-                      onClick={update.download}
+                      onClick={update.install}
                     >
-                      ダウンロード
+                      更新
+                    </button>
+                  )}
+                  {update.phase === 'installing' && (
+                    <button
+                      className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-[13px] text-white opacity-50"
+                      disabled
+                    >
+                      更新を適用しています…
                     </button>
                   )}
                   {(update.phase === 'opened' || update.phase === 'installed') && (

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -65,10 +65,13 @@ interface ElectronAPI {
   checkForUpdate: () => Promise<UpdateInfo>
   downloadUpdate: () => Promise<void>
   restartForUpdate: () => Promise<void>
+  installUpdate: () => Promise<void>
+  readyToQuit: () => Promise<void>
   dismissUpdate: (version: string) => Promise<void>
   onUpdateAvailable: (callback: (info: UpdateInfo) => void) => () => void
   onUpdateProgress: (callback: (p: { percent: number; done: boolean; error?: string }) => void) => () => void
   onUpdateInstalled: (callback: (p: { version: string }) => void) => () => void
+  onUpdatePrepareQuit: (callback: () => void) => () => void
 
   // misc
   completeSetup: () => Promise<void>

--- a/src/renderer/src/hooks/useUpdate.test.ts
+++ b/src/renderer/src/hooks/useUpdate.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import type { UpdateInfo } from '../../../shared/types'
+import { updateRepository } from '../repositories/updateRepository'
+import { timerRepository } from '../repositories/timerRepository'
 
 const handlers: {
   available?: (i: UpdateInfo) => void
@@ -10,6 +12,7 @@ const handlers: {
 
 const mockCheck = vi.fn()
 const mockDownload = vi.fn()
+const mockInstall = vi.fn()
 const mockRestart = vi.fn()
 const mockDismiss = vi.fn()
 const mockGetCurrentVersion = vi.fn()
@@ -18,6 +21,7 @@ vi.mock('../repositories/updateRepository', () => ({
   updateRepository: {
     check: () => mockCheck(),
     download: () => mockDownload(),
+    install: () => mockInstall(),
     restart: () => mockRestart(),
     dismiss: (v: string) => mockDismiss(v),
     getCurrentVersion: () => mockGetCurrentVersion(),
@@ -46,6 +50,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
   mockDismiss.mockResolvedValue(undefined)
+  mockInstall.mockResolvedValue(undefined)
   mockRestart.mockResolvedValue(undefined)
   mockGetCurrentVersion.mockResolvedValue('1.0.0')
   mockIsRunning.mockResolvedValue(false)
@@ -66,7 +71,7 @@ describe('useUpdate', () => {
     expect(result.current.phase).toBe('downloading')
     expect(result.current.percent).toBe(40)
     act(() => handlers.progress!({ percent: 100, done: true }))
-    expect(result.current.phase).toBe('opened')
+    expect(result.current.phase).toBe('installing')
   })
 
   it('進捗 error で phase=error', () => {
@@ -141,5 +146,28 @@ describe('useUpdate', () => {
     mockGetCurrentVersion.mockResolvedValue('2.0.0')
     const { result } = renderHook(() => useUpdate())
     await waitFor(() => expect(result.current.currentVersion).toBe('2.0.0'))
+  })
+})
+
+describe('useUpdate.install', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('タイマー非稼働ならそのまま install を呼ぶ', async () => {
+    vi.spyOn(timerRepository, 'isRunning').mockResolvedValue(false)
+    const spy = vi.spyOn(updateRepository, 'install').mockResolvedValue()
+    const { result } = renderHook(() => useUpdate())
+    act(() => { result.current.install() })
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    expect(result.current.phase).toBe('downloading')
+  })
+
+  it('稼働中に確認をキャンセルしたら install を呼ばない', async () => {
+    vi.spyOn(timerRepository, 'isRunning').mockResolvedValue(true)
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const spy = vi.spyOn(updateRepository, 'install').mockResolvedValue()
+    const { result } = renderHook(() => useUpdate())
+    act(() => { result.current.install() })
+    await waitFor(() => expect(timerRepository.isRunning).toHaveBeenCalled())
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/hooks/useUpdate.ts
+++ b/src/renderer/src/hooks/useUpdate.ts
@@ -3,7 +3,7 @@ import { updateRepository } from '../repositories/updateRepository'
 import { timerRepository } from '../repositories/timerRepository'
 import type { UpdateInfo } from '../../../shared/types'
 
-export type UpdatePhase = 'idle' | 'available' | 'downloading' | 'opened' | 'installed' | 'error'
+export type UpdatePhase = 'idle' | 'available' | 'downloading' | 'installing' | 'opened' | 'installed' | 'error'
 
 export interface UpdateState {
   phase: UpdatePhase
@@ -12,7 +12,7 @@ export interface UpdateState {
   error: string | null
   currentVersion: string
   check: () => Promise<void>
-  download: () => void
+  install: () => void
   restart: () => void
   dismiss: () => void
 }
@@ -46,7 +46,7 @@ export function useUpdate(): UpdateState {
         return
       }
       setPercent(p.percent)
-      setPhase(p.done ? 'opened' : 'downloading')
+      setPhase(p.done ? 'installing' : 'downloading')
     })
     const offInst = updateRepository.onInstalled(() => setPhase('installed'))
     return () => { offAvail(); offProg(); offInst() }
@@ -63,14 +63,20 @@ export function useUpdate(): UpdateState {
     }
   }
 
-  const download = (): void => {
-    setError(null)
-    setPercent(0)
-    setPhase('downloading')
-    updateRepository.download().catch(() => {
-      setError('ダウンロードに失敗しました')
-      setPhase('error')
-    })
+  const install = (): void => {
+    void (async () => {
+      const running = await timerRepository.isRunning().catch(() => false)
+      if (running && !window.confirm('作業を保存して更新します。アプリが再起動します。よろしいですか？')) {
+        return
+      }
+      setError(null)
+      setPercent(0)
+      setPhase('downloading')
+      updateRepository.install().catch(() => {
+        setError('更新に失敗しました')
+        setPhase('error')
+      })
+    })()
   }
 
   const restart = (): void => {
@@ -90,5 +96,5 @@ export function useUpdate(): UpdateState {
     setPhase('idle')
   }
 
-  return { phase, info, percent, error, currentVersion, check, download, restart, dismiss }
+  return { phase, info, percent, error, currentVersion, check, install, restart, dismiss }
 }

--- a/src/renderer/src/repositories/updateRepository.ts
+++ b/src/renderer/src/repositories/updateRepository.ts
@@ -10,6 +10,15 @@ export const updateRepository = {
   download(): Promise<void> {
     return window.electronAPI.downloadUpdate()
   },
+  install(): Promise<void> {
+    return window.electronAPI.installUpdate()
+  },
+  readyToQuit(): Promise<void> {
+    return window.electronAPI.readyToQuit()
+  },
+  onPrepareQuit(cb: () => void): () => void {
+    return window.electronAPI.onUpdatePrepareQuit(cb)
+  },
   restart(): Promise<void> {
     return window.electronAPI.restartForUpdate()
   },

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -102,6 +102,8 @@ export interface IpcContract {
   'update:download': [void, void]
   'update:restart': [void, void]
   'update:dismiss': [version: string, void]
+  'update:install': [void, void]
+  'update:ready-to-quit': [void, void]
 
   // misc
   'setup:complete': [void, void]

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -124,6 +124,7 @@ export interface IpcEventContract {
   'update-available': UpdateInfo
   'update-download-progress': { percent: number; done: boolean; error?: string }
   'update-installed': { version: string }
+  'update-prepare-quit': void
 }
 
 export type IpcEventName = keyof IpcEventContract


### PR DESCRIPTION
## 概要
実行中アプリは自分自身の .app をロックしており上書きできないため、ドラッグ置換が「起動中のため上書きできません」で失敗していた問題を解消。

## 変更点
- 「更新」ワンクリックで DL→アプリ終了→切り離しスクリプトで .app 差し替え→新版自動起動（全自動）
- 設定の「ダウンロード」ボタンを「更新」に変更、`installing` フェーズ表示を追加
- タイマー稼働中は確認の上、進行中区間を保存（main→ポップオーバーへ依頼し ack 後に quit）してから更新
- 差し替えスクリプトはロールバック・quarantine除去付き。dev/arch不一致はフォールバック

## 検証
- 785 tests green / typecheck clean / markdownlint clean
- パッケージ版での実機差し替えは別途要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)