### PR TITLE
feat: 更新確認に確認中表示と「最新です ✓」を追加

### DIFF
--- a/src/renderer/src/components/Popover/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/Popover/UpdateBanner.test.tsx
@@ -12,6 +12,7 @@ const info = {
 function state(over: Partial<UpdateState>): UpdateState {
   return {
     phase: 'idle', info: null, percent: 0, error: null, currentVersion: '',
+    checking: false, checkedUpToDate: false,
     check: vi.fn(), install: vi.fn(), dismiss: vi.fn(),
     ...over,
   }

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -294,7 +294,7 @@ export function SettingsView() {
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-[13px] text-foreground">状態</span>
-                  <span className="text-[13px] text-muted-foreground">
+                  <span className="inline-flex items-center gap-1 text-[13px] text-muted-foreground">
                     {update.phase === 'available'
                       ? `更新があります（v${update.info?.latestVersion}）`
                       : update.phase === 'downloading'
@@ -303,15 +303,34 @@ export function SettingsView() {
                           ? '更新を適用しています…'
                           : update.phase === 'error'
                             ? (update.error ?? '確認に失敗しました')
-                            : '最新です'}
+                            : update.checkedUpToDate
+                              ? (
+                                <span className="inline-flex items-center gap-1 animate-in fade-in zoom-in duration-300">
+                                  最新です
+                                  <svg
+                                    className="h-3.5 w-3.5 text-[var(--accent)]"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2.5"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    aria-hidden="true"
+                                  >
+                                    <path d="M20 6 9 17l-5-5" />
+                                  </svg>
+                                </span>
+                              )
+                              : '最新です'}
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
                   <button
-                    className="rounded-md border border-input px-3 py-1.5 text-[13px]"
+                    className="inline-flex items-center gap-1.5 rounded-md border border-input px-3 py-1.5 text-[13px] disabled:opacity-60"
+                    disabled={update.checking}
                     onClick={() => { update.check().catch(console.error) }}
                   >
-                    更新を確認
+                    {update.checking ? (<><RefreshSpinner />確認中…</>) : '更新を確認'}
                   </button>
                   {update.phase === 'available' && (
                     <button
@@ -336,5 +355,23 @@ export function SettingsView() {
         )}
       </div>
     </Tabs>
+  )
+}
+
+/** 確認中に表示する回転スピナー（インライン SVG、依存追加なし） */
+function RefreshSpinner() {
+  return (
+    <svg
+      className="h-3.5 w-3.5 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
   )
 }

--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -295,33 +295,36 @@ export function SettingsView() {
                 <div className="flex items-center justify-between">
                   <span className="text-[13px] text-foreground">状態</span>
                   <span className="inline-flex items-center gap-1 text-[13px] text-muted-foreground">
-                    {update.phase === 'available'
-                      ? `更新があります（v${update.info?.latestVersion}）`
-                      : update.phase === 'downloading'
-                        ? `ダウンロード中… ${update.percent}%`
-                        : update.phase === 'installing'
-                          ? '更新を適用しています…'
-                          : update.phase === 'error'
-                            ? (update.error ?? '確認に失敗しました')
-                            : update.checkedUpToDate
-                              ? (
-                                <span className="inline-flex items-center gap-1 animate-in fade-in zoom-in duration-300">
-                                  最新です
-                                  <svg
-                                    className="h-3.5 w-3.5 text-[var(--accent)]"
-                                    viewBox="0 0 24 24"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="2.5"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    aria-hidden="true"
-                                  >
-                                    <path d="M20 6 9 17l-5-5" />
-                                  </svg>
-                                </span>
-                              )
-                              : '最新です'}
+                    {/* 確認中はアニメが終わるまで状態文言を出さない */}
+                    {update.checking
+                      ? null
+                      : update.phase === 'available'
+                        ? `更新があります（v${update.info?.latestVersion}）`
+                        : update.phase === 'downloading'
+                          ? `ダウンロード中… ${update.percent}%`
+                          : update.phase === 'installing'
+                            ? '更新を適用しています…'
+                            : update.phase === 'error'
+                              ? (update.error ?? '確認に失敗しました')
+                              : update.checkedUpToDate
+                                ? (
+                                  <span className="inline-flex items-center gap-1 animate-in fade-in zoom-in duration-300">
+                                    最新です
+                                    <svg
+                                      className="h-3.5 w-3.5 text-[var(--accent)]"
+                                      viewBox="0 0 24 24"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      strokeWidth="2.5"
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      aria-hidden="true"
+                                    >
+                                      <path d="M20 6 9 17l-5-5" />
+                                    </svg>
+                                  </span>
+                                )
+                                : '最新です'}
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
@@ -332,7 +335,7 @@ export function SettingsView() {
                   >
                     {update.checking ? (<><RefreshSpinner />確認中…</>) : '更新を確認'}
                   </button>
-                  {update.phase === 'available' && (
+                  {update.phase === 'available' && !update.checking && (
                     <button
                       className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-[13px] text-white"
                       onClick={update.install}

--- a/src/renderer/src/hooks/useUpdate.test.ts
+++ b/src/renderer/src/hooks/useUpdate.test.ts
@@ -111,6 +111,48 @@ describe('useUpdate', () => {
     const { result } = renderHook(() => useUpdate())
     await waitFor(() => expect(result.current.currentVersion).toBe('2.0.0'))
   })
+
+  it('check 中は checking=true になり、完了後 false に戻る', async () => {
+    mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
+    const { result } = renderHook(() => useUpdate())
+    act(() => { void result.current.check() })
+    await waitFor(() => expect(result.current.checking).toBe(true))
+    await waitFor(() => expect(result.current.checking).toBe(false))
+  })
+
+  it('更新なしの確認後は checkedUpToDate=true', async () => {
+    mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { await result.current.check() })
+    await waitFor(() => expect(result.current.checkedUpToDate).toBe(true))
+    expect(result.current.phase).toBe('idle')
+  })
+
+  it('更新ありの確認後は checkedUpToDate=false', async () => {
+    mockCheck.mockResolvedValue(info)
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { await result.current.check() })
+    await waitFor(() => expect(result.current.phase).toBe('available'))
+    expect(result.current.checkedUpToDate).toBe(false)
+  })
+
+  it('確認失敗で checkedUpToDate=false・checking=false', async () => {
+    mockCheck.mockRejectedValue(new Error('network error'))
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { await result.current.check() })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.checkedUpToDate).toBe(false)
+    expect(result.current.checking).toBe(false)
+  })
+
+  it('install 開始で checkedUpToDate=false に戻す', async () => {
+    mockCheck.mockResolvedValue({ ...info, hasUpdate: false })
+    const { result } = renderHook(() => useUpdate())
+    await act(async () => { await result.current.check() })
+    await waitFor(() => expect(result.current.checkedUpToDate).toBe(true))
+    act(() => { result.current.install() })
+    await waitFor(() => expect(result.current.checkedUpToDate).toBe(false))
+  })
 })
 
 describe('useUpdate.install', () => {

--- a/src/renderer/src/hooks/useUpdate.ts
+++ b/src/renderer/src/hooks/useUpdate.ts
@@ -11,6 +11,8 @@ export interface UpdateState {
   percent: number
   error: string | null
   currentVersion: string
+  checking: boolean
+  checkedUpToDate: boolean
   check: () => Promise<void>
   install: () => void
   dismiss: () => void
@@ -23,6 +25,8 @@ export function useUpdate(): UpdateState {
   const [percent, setPercent] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const [currentVersion, setCurrentVersion] = useState('')
+  const [checking, setChecking] = useState(false)
+  const [checkedUpToDate, setCheckedUpToDate] = useState(false)
 
   useEffect(() => {
     // マウント時に現在のバージョンを取得する（ネットワーク不要）
@@ -51,13 +55,30 @@ export function useUpdate(): UpdateState {
   }, [])
 
   const check = async (): Promise<void> => {
+    setChecking(true)
+    setError(null)
+    const started = Date.now()
     try {
       const result = await updateRepository.check()
       setInfo(result)
-      setPhase(result.hasUpdate ? 'available' : 'idle')
+      if (result.hasUpdate) {
+        setPhase('available')
+        setCheckedUpToDate(false)
+      } else {
+        setPhase('idle')
+        setCheckedUpToDate(true)
+      }
     } catch {
       setError('確認に失敗しました')
       setPhase('error')
+      setCheckedUpToDate(false)
+    } finally {
+      // ネットワーク確認は一瞬で終わるため、最低 600ms は確認中表示を保持する
+      const elapsed = Date.now() - started
+      if (elapsed < 600) {
+        await new Promise(resolve => setTimeout(resolve, 600 - elapsed))
+      }
+      setChecking(false)
     }
   }
 
@@ -70,6 +91,7 @@ export function useUpdate(): UpdateState {
       setError(null)
       setPercent(0)
       setPhase('downloading')
+      setCheckedUpToDate(false)
       updateRepository.install().catch(() => {
         setError('更新に失敗しました')
         setPhase('error')
@@ -82,5 +104,5 @@ export function useUpdate(): UpdateState {
     setPhase('idle')
   }
 
-  return { phase, info, percent, error, currentVersion, check, install, dismiss }
+  return { phase, info, percent, error, currentVersion, checking, checkedUpToDate, check, install, dismiss }
 }


### PR DESCRIPTION
## 概要
設定「アップデート」の「更新を確認」に確認中フィードバックを追加。

## 変更点
- 押下中はボタンに回転スピナー＋「確認中…」（最低0.6秒保持）
- 確認中は状態文言・更新ボタンを隠し、アニメ完了後に結果を表示
- 更新なしは「最新です ✓」（フェードイン）、更新ありは「更新があります（vX）」＋更新ボタン
- 対象は設定タブのみ、新規依存なし

## 検証
- 774 tests green / typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)