### PR TITLE
fix: 設定「休憩」セクションの上余白を統一

### DIFF
--- a/src/renderer/src/components/Settings/SettingsView.tsx
+++ b/src/renderer/src/components/Settings/SettingsView.tsx
@@ -190,8 +190,7 @@ export function SettingsView() {
               </CardContent>
             </Card>
 
-            <Separator />
-            <h3 className={heading}>休憩</h3>
+            <h2 className={heading} style={{ marginTop: '1.5rem' }}>休憩</h2>
             <Card>
               <CardContent className="flex items-center justify-between gap-4 px-4 py-3">
                 <div>


### PR DESCRIPTION
「休憩」セクションだけ `Separator + h3(mt-0)` で上余白が他より狭かったため、他セクションと同じ `h2 + marginTop:1.5rem` に統一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)