### PR TITLE
feat: 使い方をヘッダー/フッターを残して本画面に表示

### DIFF
--- a/src/renderer/src/App.module.css
+++ b/src/renderer/src/App.module.css
@@ -135,6 +135,7 @@
 
 /* ====== コンテンツエリア ====== */
 .content {
+  position: relative;
   flex: 1;
   min-height: 0;
   display: flex;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import { SetupView } from './components/Setup/SetupView'
 import { CalendarPage } from './components/Calendar/CalendarPage'
 import { WorkStartOverlay } from './components/Popover/WorkStartOverlay'
 import { UsageGuideButton } from './components/UsageGuide/UsageGuideButton'
+import { UsageGuidePanel } from './components/UsageGuide/UsageGuidePanel'
 import { useTour } from './tour/useTour'
 import { TourOverlay } from './tour/TourOverlay'
 import { TourDemoTimer } from './tour/TourDemoTimer'
@@ -65,6 +66,8 @@ function AccountAvatar({ avatarUrl, name }: { avatarUrl?: string; name?: string 
 
 function PopoverView() {
   const [currentPage, setCurrentPage] = useState<Page>('timer')
+  // 使い方パネルの表示状態
+  const [helpOpen, setHelpOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const { status, signIn, signOut } = useAuthStatus()
@@ -98,7 +101,7 @@ function PopoverView() {
         </Button>
         <span className={styles.logo}>juice</span>
         <div className="flex items-center gap-0.5">
-          <UsageGuideButton onStartTour={tour.start} />
+          <UsageGuideButton onOpen={() => setHelpOpen(true)} />
           <div className={styles.menuWrapper} ref={menuRef}>
           <Button variant="ghost" size="icon" aria-label="アカウント" className="[-webkit-app-region:no-drag]" onClick={() => setMenuOpen(p => !p)}>
             <AccountAvatar avatarUrl={status.avatarUrl} name={status.name} />
@@ -178,13 +181,17 @@ function PopoverView() {
             <AttendanceReport sessions={sessions.todaySessions} today={sessions.today} />
           </div>
         )}
+        {/* 使い方パネル: main 内に絶対配置で重ねる */}
+        {helpOpen && (
+          <UsageGuidePanel onClose={() => setHelpOpen(false)} onStartTour={tour.start} />
+        )}
       </main>
 
       {/* ボトムナビゲーション */}
       <nav className="flex shrink-0 items-stretch gap-1 border-t border-border bg-card p-1">
         <button
           data-tour="tab-timer"
-          onClick={() => setCurrentPage('timer')}
+          onClick={() => { setHelpOpen(false); setCurrentPage('timer') }}
           className={`flex flex-1 flex-col items-center gap-0.5 rounded-md py-1.5 text-[11px] transition-colors ${currentPage === 'timer' ? 'bg-[var(--accent-light)] text-[var(--accent)]' : 'text-muted-foreground hover:bg-[var(--bg-hover)]'}`}
         >
           <Timer width={18} height={18} />
@@ -192,7 +199,7 @@ function PopoverView() {
         </button>
         <button
           data-tour="tab-calendar"
-          onClick={() => setCurrentPage('calendar')}
+          onClick={() => { setHelpOpen(false); setCurrentPage('calendar') }}
           className={`flex flex-1 flex-col items-center gap-0.5 rounded-md py-1.5 text-[11px] transition-colors ${currentPage === 'calendar' ? 'bg-[var(--accent-light)] text-[var(--accent)]' : 'text-muted-foreground hover:bg-[var(--bg-hover)]'}`}
         >
           <Calendar width={18} height={18} />
@@ -200,7 +207,7 @@ function PopoverView() {
         </button>
         <button
           data-tour="tab-attendance"
-          onClick={() => setCurrentPage('attendance')}
+          onClick={() => { setHelpOpen(false); setCurrentPage('attendance') }}
           className={`flex flex-1 flex-col items-center gap-0.5 rounded-md py-1.5 text-[11px] transition-colors ${currentPage === 'attendance' ? 'bg-[var(--accent-light)] text-[var(--accent)]' : 'text-muted-foreground hover:bg-[var(--bg-hover)]'}`}
         >
           <SendDiagonal width={18} height={18} />

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.test.tsx
@@ -1,37 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { UsageGuideButton } from './UsageGuideButton'
 
 describe('UsageGuideButton', () => {
-  it('初期状態ではガイドダイアログは閉じている', () => {
-    render(<UsageGuideButton />)
-    expect(screen.queryByText('使い方')).not.toBeInTheDocument()
-  })
-
-  it('「使い方」ボタンでガイドが開く', async () => {
+  it('「使い方」ボタン押下で onOpen を呼ぶ', async () => {
+    const onOpen = vi.fn()
     const user = userEvent.setup()
-    render(<UsageGuideButton />)
+    render(<UsageGuideButton onOpen={onOpen} />)
     await user.click(screen.getByRole('button', { name: '使い方' }))
-    expect(await screen.findByText('使い方')).toBeInTheDocument()
-    expect(screen.getByText('作業を始める')).toBeInTheDocument()
-  })
-
-  it('onStartTour 指定時、「ツアーを見る」で閉じてコールバックを呼ぶ', async () => {
-    const onStartTour = vi.fn()
-    const user = userEvent.setup()
-    render(<UsageGuideButton onStartTour={onStartTour} />)
-    await user.click(screen.getByRole('button', { name: '使い方' }))
-    await user.click(await screen.findByRole('button', { name: 'ツアーを見る' }))
-    expect(onStartTour).toHaveBeenCalled()
-  })
-
-  it('「戻る」でガイドを閉じる', async () => {
-    const user = userEvent.setup()
-    render(<UsageGuideButton />)
-    await user.click(screen.getByRole('button', { name: '使い方' }))
-    expect(await screen.findByText('使い方')).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: '戻る' }))
-    await waitFor(() => expect(screen.queryByText('使い方')).not.toBeInTheDocument())
+    expect(onOpen).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuideButton.tsx
@@ -1,59 +1,18 @@
-import { useState } from 'react'
-import { HelpCircle, NavArrowLeft } from 'iconoir-react'
+import { HelpCircle } from 'iconoir-react'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { UsageGuide } from './UsageGuide'
 
-export function UsageGuideButton({ onStartTour }: { onStartTour?: () => void }) {
-  const [open, setOpen] = useState(false)
+/** ヘッダーの「使い方」ボタン。押下で onOpen を呼ぶだけ（パネル本体は別） */
+export function UsageGuideButton({ onOpen }: { onOpen: () => void }) {
   return (
-    <>
-      <Button
-        variant="ghost"
-        size="icon"
-        aria-label="使い方"
-        data-tour="help"
-        className="[-webkit-app-region:no-drag]"
-        onClick={() => setOpen(true)}
-      >
-        <HelpCircle width={16} height={16} />
-      </Button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        {/* 不透明フルスクリーンの1画面として切り替える（背景を透けさせない） */}
-        <DialogContent
-          className="inset-0 z-[200] flex h-full w-full max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 bg-background p-0 [&>button]:hidden"
-          aria-describedby={undefined}
-        >
-          {/* ヘッダー: 戻る矢印（カレンダー詳細と同じ位置・操作感） */}
-          <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-2">
-            <Button variant="ghost" size="icon" aria-label="戻る" onClick={() => setOpen(false)}>
-              <NavArrowLeft width={18} height={18} />
-            </Button>
-            <DialogTitle className="text-[14px] font-semibold">使い方</DialogTitle>
-          </div>
-
-          {/* カルーセル（1項目ずつ） */}
-          <div className="flex flex-1 flex-col items-center justify-center px-6">
-            <UsageGuide />
-          </div>
-
-          {/* 下部: ツアー再生 */}
-          {onStartTour && (
-            <div className="shrink-0 border-t border-border p-3">
-              <Button
-                variant="outline"
-                className="w-full"
-                onClick={() => {
-                  setOpen(false)
-                  onStartTour()
-                }}
-              >
-                ツアーを見る
-              </Button>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-    </>
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="使い方"
+      data-tour="help"
+      className="[-webkit-app-region:no-drag]"
+      onClick={onOpen}
+    >
+      <HelpCircle width={16} height={16} />
+    </Button>
   )
 }

--- a/src/renderer/src/components/UsageGuide/UsageGuidePanel.test.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuidePanel.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { UsageGuidePanel } from './UsageGuidePanel'
+
+describe('UsageGuidePanel', () => {
+  it('使い方の見出しと最初の項目を表示する', () => {
+    render(<UsageGuidePanel onClose={() => {}} />)
+    expect(screen.getByText('使い方')).toBeInTheDocument()
+    expect(screen.getByText('作業を始める')).toBeInTheDocument()
+  })
+
+  it('「戻る」で onClose を呼ぶ', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(<UsageGuidePanel onClose={onClose} />)
+    await user.click(screen.getByRole('button', { name: '戻る' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('onStartTour 指定時、「ツアーを見る」で onClose→onStartTour を呼ぶ', async () => {
+    const onClose = vi.fn()
+    const onStartTour = vi.fn()
+    const user = userEvent.setup()
+    render(<UsageGuidePanel onClose={onClose} onStartTour={onStartTour} />)
+    await user.click(screen.getByRole('button', { name: 'ツアーを見る' }))
+    expect(onClose).toHaveBeenCalled()
+    expect(onStartTour).toHaveBeenCalled()
+  })
+
+  it('onStartTour 未指定なら「ツアーを見る」は表示しない', () => {
+    render(<UsageGuidePanel onClose={() => {}} />)
+    expect(screen.queryByRole('button', { name: 'ツアーを見る' })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/UsageGuide/UsageGuidePanel.tsx
+++ b/src/renderer/src/components/UsageGuide/UsageGuidePanel.tsx
@@ -1,0 +1,45 @@
+import { NavArrowLeft } from 'iconoir-react'
+import { Button } from '@/components/ui/button'
+import { UsageGuide } from './UsageGuide'
+
+/** 使い方を本画面領域（<main>）に重ねて表示するパネル */
+export function UsageGuidePanel({
+  onClose,
+  onStartTour,
+}: {
+  onClose: () => void
+  onStartTour?: () => void
+}) {
+  return (
+    <div className="absolute inset-0 z-10 flex flex-col bg-background">
+      {/* ヘッダー: 戻る矢印（カレンダー詳細と同じ位置・操作感） */}
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-2">
+        <Button variant="ghost" size="icon" aria-label="戻る" onClick={onClose}>
+          <NavArrowLeft width={18} height={18} />
+        </Button>
+        <span className="text-[14px] font-semibold">使い方</span>
+      </div>
+
+      {/* カルーセル（1項目ずつ） */}
+      <div className="flex flex-1 flex-col items-center justify-center px-6">
+        <UsageGuide />
+      </div>
+
+      {/* 下部: ツアー再生 */}
+      {onStartTour && (
+        <div className="shrink-0 border-t border-border p-3">
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+              onClose()
+              onStartTour()
+            }}
+          >
+            ツアーを見る
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要
使い方画面を全画面 Dialog から本画面領域（`<main>`）のパネルに変更。アプリのヘッダー（juice）と下部ナビは残したまま表示する。

## 変更点
- `UsageGuidePanel` を新設しヘッダーボタン（`UsageGuideButton`）と分離
- `helpOpen` を `PopoverView` に持ち、`<main>` を覆う `absolute inset-0` パネルとして描画（`.content` に `position: relative`）
- 戻る／タブ押下で閉じる。ツアーの `data-tour="help"` ターゲットはヘッダーボタンのまま

## 検証
- 775 tests green / typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)