### PR TITLE
fix: ポップオーバーを開いた時にフォーカスが残るのを抑制

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/button'
 import { useAuthStatus } from './hooks/useAuthStatus'
 import { DailyDataProvider } from './daily/DailyDataContext'
 import { useUpdate } from './hooks/useUpdate'
+import { useClearFocusOnShow } from './hooks/useClearFocusOnShow'
 import { UpdateBanner } from './components/Popover/UpdateBanner'
 import { WorkLocationSwitch } from './components/Popover/WorkLocationSwitch'
 import { updateRepository } from './repositories/updateRepository'
@@ -72,6 +73,9 @@ function PopoverView() {
   const menuRef = useRef<HTMLDivElement>(null)
   const { status, signIn, signOut } = useAuthStatus()
   const tour = useTour()
+
+  // 再表示のたびに復元されるフォーカス（閉じるボタン等）をクリアする
+  useClearFocusOnShow()
 
   // ツアーのシーンを適用（指定タブへ切替）。デモ表示は tourDemo で制御する。
   useEffect(() => {

--- a/src/renderer/src/hooks/useClearFocusOnShow.test.ts
+++ b/src/renderer/src/hooks/useClearFocusOnShow.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { useClearFocusOnShow } from './useClearFocusOnShow'
+
+function setVisibility(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('useClearFocusOnShow', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+    document.body.innerHTML = ''
+  })
+
+  it('表示状態（visible）になったらフォーカスをクリアする', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    button.focus()
+    expect(document.activeElement).toBe(button)
+
+    renderHook(() => useClearFocusOnShow())
+    setVisibility('visible')
+
+    expect(document.activeElement).not.toBe(button)
+  })
+
+  it('非表示（hidden）への遷移でも復元対象を消すためフォーカスをクリアする', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+    button.focus()
+
+    renderHook(() => useClearFocusOnShow())
+    setVisibility('hidden')
+
+    expect(document.activeElement).not.toBe(button)
+  })
+
+  it('visibilitychange の後に復元されたフォーカスも次フレームでクリアする', () => {
+    const raf: { cb: FrameRequestCallback | null } = { cb: null }
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      raf.cb = cb
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {
+      raf.cb = null
+    })
+
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+
+    renderHook(() => useClearFocusOnShow())
+    setVisibility('visible')
+
+    // visibilitychange の後に Chromium がフォーカスを復元するケースを再現
+    button.focus()
+    expect(document.activeElement).toBe(button)
+
+    raf.cb?.(0)
+    expect(document.activeElement).not.toBe(button)
+  })
+
+  it('アンマウント後はリスナーが解除される', () => {
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+
+    const { unmount } = renderHook(() => useClearFocusOnShow())
+    unmount()
+
+    button.focus()
+    setVisibility('visible')
+
+    expect(document.activeElement).toBe(button)
+  })
+})

--- a/src/renderer/src/hooks/useClearFocusOnShow.ts
+++ b/src/renderer/src/hooks/useClearFocusOnShow.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+
+/**
+ * ポップオーバーのウィンドウは初回に生成したあと hide/show で使い回される。
+ * 再表示時に Chromium が前回フォーカスしていた要素（× 閉じるボタンなど）へ
+ * フォーカスを復元するため、開いた瞬間にフォーカスリングが残ってしまう。
+ *
+ * 表示／非表示が切り替わるたびにフォーカスをクリアして、「開いた直後はどこにも
+ * フォーカスしない」状態にする。
+ * - 非表示時: 復元対象になるフォーカスを今のうちに外し、復元レースの根を断つ。
+ * - 表示時: 復元が visibilitychange より後に走るケースに備え、同フレームと
+ *   次フレームの両方でクリアする。
+ *
+ * 表示中に行う操作（タイマー開始やダイアログ表示）の autoFocus は visibilitychange を
+ * 発火させないため影響を受けない。
+ */
+export function useClearFocusOnShow(): void {
+  useEffect(() => {
+    let raf = 0
+    const blurActive = (): void => {
+      const active = document.activeElement
+      if (active instanceof HTMLElement) active.blur()
+    }
+    const clearFocus = (): void => {
+      blurActive()
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(blurActive)
+    }
+    document.addEventListener('visibilitychange', clearFocus)
+    return () => {
+      document.removeEventListener('visibilitychange', clearFocus)
+      cancelAnimationFrame(raf)
+    }
+  }, [])
+}


### PR DESCRIPTION
## 概要
ポップオーバーを開いた瞬間に閉じるボタン等にフォーカス（リング）が残る問題を修正。

## 原因
ウィンドウは初回生成後 hide/show で使い回されるため `autoFocus` は初回しか効かず、再表示時に Chromium が前回フォーカス要素（× ボタン）へフォーカスを復元していた。

## 対応
- `useClearFocusOnShow` を追加し、表示/非表示の切り替えでフォーカスをクリア
- 復元レース対策として、非表示時に先に外す＋表示時は同フレーム+次フレームでクリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)