### PR TITLE
chore: package-lock.json のバージョンを package.json に合わせる

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juice",
-  "version": "1.3.2",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juice",
-      "version": "1.3.2",
+      "version": "2.0.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
- `package.json` は 2.0.1 だが `package-lock.json` は 1.3.2 のままだった（v2.0.0 / v2.0.1 で更新漏れ）
- `npm install` のたびに書き換わり、常に差分として現れていたのを解消
- `npm install --package-lock-only` の結果。差分はバージョン2箇所のみで依存の解決は変わらない

🤖 Generated with [Claude Code](https://claude.com/claude-code)